### PR TITLE
Deployable to spot.curationexperts.com

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -10,6 +10,8 @@ install_plugin Capistrano::SCM::Git
 require 'capistrano/bundler'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
+require 'capistrano/sidekiq'
+require 'capistrano/passenger'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/**/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,10 @@ group :development do
   # Use Capistrano for deployment
   gem 'capistrano', '~> 3.10', require: false
   gem 'capistrano-rails', '~> 1.3', require: false
-
+  gem 'capistrano-bundler', '~> 1.3'
+  gem 'capistrano-ext'
+  gem 'capistrano-passenger'
+  gem 'capistrano-sidekiq', '~> 0.20.0'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,9 +145,16 @@ GEM
     capistrano-bundler (1.3.0)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
+    capistrano-ext (1.2.1)
+      capistrano (>= 1.0.0)
+    capistrano-passenger (0.2.0)
+      capistrano (~> 3.0)
     capistrano-rails (1.3.1)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
+    capistrano-sidekiq (0.20.0)
+      capistrano (>= 3.9.0)
+      sidekiq (>= 3.4)
     capybara (3.1.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -829,7 +836,11 @@ DEPENDENCIES
   bagit
   byebug
   capistrano (~> 3.10)
+  capistrano-bundler (~> 1.3)
+  capistrano-ext
+  capistrano-passenger
   capistrano-rails (~> 1.3)
+  capistrano-sidekiq (~> 0.20.0)
   capybara
   capybara-screenshot
   chromedriver-helper
@@ -873,4 +884,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -6,4 +6,4 @@ test: &test
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_TEST_PORT', 8985)}/solr/hydra-test" %>
 production:
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
+  url: <%= ENV['SOLR_URL'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,6 +5,7 @@ default: &default
   encoding: unicode
   username: "<%= ENV.fetch('PSQL_USER') %>"
   password: "<%= ENV.fetch('PSQL_PASSWORD') %>"
+  host: localhost
 
 development:
   <<: *default

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,36 +6,47 @@ set :repo_url, "https://github.com/LafayetteCollegeLibraries/spot.git"
 
 append :linked_dirs, 'log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system', 'public/uploads'
 
-# Default branch is :master
-# ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
+set :deploy_to, '/opt/spot'
 
-# Default deploy_to directory is /var/www/my_app_name
-# set :deploy_to, "/var/www/my_app_name"
+set :log_level, :debug
+set :bundle_flags, '--deployment'
+set :bundle_env_variables, nokogiri_use_system_libraries: 1
 
-# Default value for :format is :airbrussh.
-# set :format, :airbrussh
+set :keep_releases, 5
+set :assets_prefix, "#{shared_path}/public/assets"
 
-# You can configure the Airbrussh format using :format_options.
-# These are the defaults.
-# set :format_options, command_output: true, log_file: "log/capistrano.log", color: :auto, truncate: :auto
+SSHKit.config.command_map[:rake] = 'bundle exec rake'
 
-# Default value for :pty is false
-# set :pty, true
+set :branch, ENV['REVISION'] || ENV['BRANCH_NAME'] || 'master'
 
-# Default value for :linked_files is []
-# append :linked_files, "config/database.yml", "config/secrets.yml"
+append :linked_dirs, "log"
+append :linked_dirs, "public/assets"
 
-# Default value for linked_dirs is []
-# append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
+append :linked_files, ".env.production"
 
-# Default value for default_env is {}
-# set :default_env, { path: "/opt/ruby/bin:$PATH" }
+append :linked_files, "config/database.yml"
+append :linked_files, "config/secrets.yml"
 
-# Default value for local_user is ENV['USER']
-# set :local_user, -> { `git config user.name`.chomp }
-
-# Default value for keep_releases is 5
-# set :keep_releases, 5
-
-# Uncomment the following to require manually verifying the host key before first deploy.
-# set :ssh_options, verify_host_key: :secure
+# We have to re-define capistrano-sidekiq's tasks to work with
+# systemctl in production. Note that you must clear the previously-defined
+# tasks before re-defining them.
+Rake::Task["sidekiq:stop"].clear_actions
+Rake::Task["sidekiq:start"].clear_actions
+Rake::Task["sidekiq:restart"].clear_actions
+namespace :sidekiq do
+  task :stop do
+    on roles(:app) do
+      execute :sudo, :systemctl, :stop, :sidekiq
+    end
+  end
+  task :start do
+    on roles(:app) do
+      execute :sudo, :systemctl, :start, :sidekiq
+    end
+  end
+  task :restart do
+    on roles(:app) do
+      execute :sudo, :systemctl, :restart, :sidekiq
+    end
+  end
+end

--- a/config/deploy/localhost.rb
+++ b/config/deploy/localhost.rb
@@ -1,0 +1,3 @@
+set :stage, :localhost
+set :rails_env, 'production'
+server '127.0.0.1', user: 'deploy', roles: [:web, :app, :db]

--- a/config/deploy/sandbox.rb
+++ b/config/deploy/sandbox.rb
@@ -1,0 +1,3 @@
+set :stage, :sandbox
+set :rails_env, 'production'
+server 'spot.curationexperts.com', user: 'deploy', roles: [:web, :app, :db]

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -10,6 +10,6 @@ test:
   base_path: /test
 production:
   user: fedoraAdmin
-  password: fedoraAdmin
-  url: http://127.0.0.1:8983/fedora/rest
+  password: <%= ENV['FEDORA_PASSWORD'] %>
+  url: <%= ENV['FEDORA_URL'] %>
   base_path: /prod

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -4,4 +4,4 @@ development:
 test:
   url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8985 %>/solr/hydra-test
 production:
-  url: http://your.production.server:8080/bl_solr/core0
+  url: <%= ENV['SOLR_URL'] %>

--- a/lib/capistrano/tasks/spot/upload_dotenv_file.rake
+++ b/lib/capistrano/tasks/spot/upload_dotenv_file.rake
@@ -10,4 +10,4 @@ namespace :spot do
   end
 end
 
-before 'deploy:check:linked_files', 'spot:upload_dotenv_file'
+# before 'deploy:check:linked_files', 'spot:upload_dotenv_file'

--- a/spec/features/create_publication_spec.rb
+++ b/spec/features/create_publication_spec.rb
@@ -103,13 +103,16 @@ RSpec.feature 'Create a Publication', :clean, :js do
         choose 'publication_visibility_open'
 
         # check the submission agreement
-        check 'agreement'
+        # check 'agreement'
+        sleep(2)
+
+        page.find('#agreement').set(true)
+
 
         # give javascript a chance to catch up (otherwise the save button is hidden)
-        sleep(1)
+        sleep(2)
 
         page.find('#with_files_submit').click
-
         expect(page).to have_content attrs[:title].first
         expect(page).to have_content 'Your files are being processed by Spot in the background.'
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,8 +35,20 @@ Capybara.register_driver :selenium_chrome_headless_sandboxless do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 
+Capybara.register_driver :selenium do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
 Capybara.default_driver = :rack_test # This is a faster driver
 Capybara.javascript_driver = :selenium_chrome_headless_sandboxless # This is slower
+
+
+# Uncomment this block to watch feature tests run in a web browser
+# Capybara.javascript_driver = :selenium
+# Capybara.configure do |config|
+#   config.default_max_wait_time = 10 # seconds
+#   config.default_driver        = :selenium
+# end
 
 # since we've created a custsom driver (that is a wrapper around a Selenium
 # driver), we need to tell capybara-screenshot how to take a screenshot
@@ -122,8 +134,8 @@ RSpec.configure do |config|
 
   config.render_views = true
 
-  config.before(:suite) do
-    DatabaseCleaner.clean_with :truncation
+  config.before :suite do
+    DatabaseCleaner.clean_with(:truncation)
     ActiveFedora::Cleaner.clean!
   end
 
@@ -131,7 +143,13 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
   end
 
-  config.before(clean: true) do
+  config.before clean: true do
+    DatabaseCleaner.clean
+    ActiveFedora::Cleaner.clean!
+  end
+
+  config.after clean: true do
+    DatabaseCleaner.clean
     ActiveFedora::Cleaner.clean!
   end
 


### PR DESCRIPTION
    This capistrano setup follows the guide at
    https://github.com/curationexperts/ansible-samvera/blob/master/docs/capification.md
    It makes this application deployable to a server
    that has been set up via ansible-samvera:
    https://github.com/curationexperts/ansible-samvera

    * Set solr settings via dotenv
    * Set fedora settings via dotenv
    * Add host to database setup
    * Cap deploy for DCE sandbox
    * Add .env.production to cap deploy
    * Remove the copy dotenv file step from deploy (ansible-samvera put
    this in place already)
