### PR TITLE
bump rubyzip to 1.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -701,7 +701,7 @@ GEM
       oauth2
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
     sass (3.5.6)
@@ -884,4 +884,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.2
+   1.16.4


### PR DESCRIPTION
fixes security issue raised with [CVE-2018-1000544]

[CVE-2018-1000544]: https://nvd.nist.gov/vuln/detail/CVE-2018-1000544