### PR TITLE
Spot approval workflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,7 @@ end
 group :test do
   gem 'simplecov', require: false
   gem 'coveralls', '~> 0.8', require: false
+  gem 'hyrax-spec'
 end
 
 gem 'riiif', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -398,6 +398,8 @@ GEM
       signet
       simple_form (~> 3.2, <= 3.5.0)
       tinymce-rails (~> 4.1)
+    hyrax-spec (0.3.2)
+      rspec (~> 3.6)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -674,6 +676,10 @@ GEM
     rsolr (2.2.1)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
     rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -856,6 +862,7 @@ DEPENDENCIES
   ffaker
   hydra-role-management (~> 1.0)
   hyrax (= 2.1.0)
+  hyrax-spec
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -13,6 +13,7 @@ Hyrax.config do |config|
   # The :default_active_workflow_name is the name of the workflow we will activate.
   # @see Hyrax::Configuration for additional details and defaults.
   # config.default_active_workflow_name = 'default'
+  Hyrax.config.default_active_workflow_name = 'spot_one_step_process'
 
   # Which RDF term should be used to relate objects to an admin set?
   # If this is a new repository, you may want to set a custom predicate term here to

--- a/config/workflows/spot_one_step_process.json
+++ b/config/workflows/spot_one_step_process.json
@@ -1,0 +1,37 @@
+{
+  "workflows": [
+    { "name": "spot_one_step_process",
+      "label": "One-step processing workflow",
+      "description": "A single-step workflow for adding items from special collections.",
+      "allows_access_grant": false,
+      "actions": [
+        {
+          "name": "deposit",
+          "from_states": [],
+          "transition_to": "processing",
+          "notifications": [],
+          "methods": [
+              "Hyrax::Workflow::DeactivateObject",
+              "Hyrax::Workflow::GrantReadToDepositor",
+              "Hyrax::Workflow::RevokeEditFromDepositor"
+          ]
+        },
+        {
+          "name": "approve",
+          "from_states": [{"names": ["processing"], "roles": ["approving"]}],
+          "transition_to": "processed",
+          "notifications": [],
+          "methods": [
+              "Hyrax::Workflow::GrantReadToDepositor",
+              "Hyrax::Workflow::RevokeEditFromDepositor",
+              "Hyrax::Workflow::ActivateObject"
+          ]
+        },
+        {
+          "name": "comment",
+          "from_states": []
+        }
+      ]
+    }
+  ]
+}

--- a/spec/features/spot_workflow_spec.rb
+++ b/spec/features/spot_workflow_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'SPOT one step workflow', :perform_jobs, :clean, :js do
+  let(:depositing_user) { FactoryBot.create(:user) }
+  let(:admin_user) { FactoryBot.create(:admin_user) }
+  let(:publication) { FactoryBot.actor_create(:publication, :public, user: depositing_user) }
+
+  context 'a logged in user' do
+    scenario "a user submits a publication and an admin approves it", js: true do
+      expect(publication.active_workflow.name).to eq "spot_one_step_process"
+      expect(publication.to_sipity_entity.reload.workflow_state_name).to eq "processing"
+
+      # Check workflow permissions for depositing user
+      available_workflow_actions = Hyrax::Workflow::PermissionQuery.scope_permitted_workflow_actions_available_for_current_state(user: depositing_user, entity: publication.to_sipity_entity).pluck(:name)
+      expect(available_workflow_actions).to be_empty
+
+      # Visit the work as a public user. It should not be visible.
+      logout
+      visit("/catalog?utf8=✓&search_field=all_fields&q=")
+      expect(page).not_to have_content publication.title.first
+
+      # Publication should be visible and downloadable by the depositor
+      login_as depositing_user
+      visit("/concern/publications/#{publication.id}")
+      expect(page).to have_content(publication.title.first)
+
+      # Check workflow permissions for admin user
+      available_workflow_actions = Hyrax::Workflow::PermissionQuery.scope_permitted_workflow_actions_available_for_current_state(user: admin_user, entity: publication.to_sipity_entity).pluck(:name)
+      expect(available_workflow_actions.include?("approve")).to eq true
+      expect(available_workflow_actions.include?("request_changes")).to eq false
+      expect(available_workflow_actions.include?("comment_only")).to eq false
+
+      # See works under review in the dashboard
+      login_as admin_user
+      visit '/admin/workflows?locale=en#under-review'
+      expect(page).to have_content(publication.title.first)
+
+      # The admin user marks the publication as approved
+      subject = Hyrax::WorkflowActionInfo.new(publication, admin_user)
+      sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
+      Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: nil)
+      expect(publication.to_sipity_entity.reload.workflow_state_name).to eq "processed"
+
+      # Visit the work as a public user. It should be visible.
+      logout
+      visit("/concern/publications/#{publication.id}")
+      expect(page).to have_content publication.title.first
+      expect(page).to have_content publication.description.first
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ require 'active_fedora/cleaner'
 require 'capybara/rspec'
 require 'capybara/rails'
 require 'capybara-screenshot/rspec'
+require 'hyrax/spec/factory_bot/build_strategies'
 
 # copied selenium chrome drive config from samvera/hyrax/spec/spec_helper.rb
 #


### PR DESCRIPTION
Add a workflow called spot_one_step_process that
puts a work in a "processing" state until it is approved,
at which point it is "processed".

The work is not publicly discoverable until it is processed.

Add feature test for workflow
Add hyrax actor_create method for factory objects