### PR TITLE
change Publication#editor predicate to bibo/editor

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -78,7 +78,7 @@ class Publication < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
-  property :editor, predicate: ::RDF::Vocab::DC11.contributor do |index|
+  property :editor, predicate: ::RDF::Vocab::BIBO.editor do |index|
     index.as :stored_searchable, :facetable
   end
 


### PR DESCRIPTION
we're already using `RDF::Vocab::DC11.contributor` for `Publication#contributor`, which causes a quiet warning:

![screen shot 2018-09-14 at 12 15 49 pm](https://user-images.githubusercontent.com/2744987/45566401-969cec00-b824-11e8-94db-87d8b0c657a4.png)

this updates to use `RDF::Vocab::BIBO.editor`, which might be what we're looking for anyway