### PR TITLE
[wip] index linked metadata fields

### DIFF
--- a/app/indexers/hyrax/deep_indexing_service.rb
+++ b/app/indexers/hyrax/deep_indexing_service.rb
@@ -1,0 +1,108 @@
+# This is a duplicate of hyrax:app/indexers/hyrax/deep_indexing_service.rb
+# but it replaces the parent class: from `Hyrax::BasicMetadataIndexer` to
+# the base `ActiveFedora::RDF::IndexingService`. This allows us to index
+# linked data without having to conform to the metadata schema of
+# `Hyrax::BasicMetadata`
+
+require 'linkeddata' # we need all the linked data types, because we don't know what types a service might return.
+module Hyrax
+  class DeepIndexingService < ActiveFedora::RDF::IndexingService
+    # We're overiding the default indexer in order to index the RDF labels. In order
+    # for this to be called, you must specify at least one default indexer on the property.
+    # @param [Hash] solr_doc
+    # @param [String] solr_field_key
+    # @param [Hash] field_info
+    # @param [ActiveTriples::Resource, String] val
+    def append_to_solr_doc(solr_doc, solr_field_key, field_info, val)
+      return super unless object.controlled_properties.include?(solr_field_key.to_sym)
+      case val
+      when ActiveTriples::Resource
+        append_label_and_uri(solr_doc, solr_field_key, field_info, val)
+      when String
+        append_label(solr_doc, solr_field_key, field_info, val)
+      else
+        raise ArgumentError, "Can't handle #{val.class}"
+      end
+    end
+
+    def add_assertions(*)
+      fetch_external
+      super
+    end
+
+    private
+
+      # Grab the labels for controlled properties from the remote sources
+      def fetch_external
+        object.controlled_properties.each do |property|
+          object[property].each do |value|
+            resource = value.respond_to?(:resource) ? value.resource : value
+            next unless resource.is_a?(ActiveTriples::Resource)
+            next if value.is_a?(ActiveFedora::Base)
+            fetch_with_persistence(resource)
+          end
+        end
+      end
+
+      def fetch_with_persistence(resource)
+        old_label = resource.rdf_label.first
+        return unless old_label == resource.rdf_subject.to_s || old_label.nil?
+        fetch_value(resource)
+        return if old_label == resource.rdf_label.first || resource.rdf_label.first == resource.rdf_subject.to_s
+        resource.persist! # Stores the fetched values into our marmotta triplestore
+      end
+
+      def fetch_value(value)
+        Rails.logger.info "Fetching #{value.rdf_subject} from the authorative source. (this is slow)"
+        value.fetch(headers: { 'Accept'.freeze => default_accept_header })
+      rescue IOError, SocketError => e
+        # IOError could result from a 500 error on the remote server
+        # SocketError results if there is no server to connect to
+        Rails.logger.error "Unable to fetch #{value.rdf_subject} from the authorative source.\n#{e.message}"
+      end
+
+      # Stripping off the */* to work around https://github.com/rails/rails/issues/9940
+      def default_accept_header
+        RDF::Util::File::HttpAdapter.default_accept_header.sub(/, \*\/\*;q=0\.1\Z/, '')
+      end
+
+      # Appends the uri to the default solr field and puts the label (if found) in the label solr field
+      # @param [Hash] solr_doc
+      # @param [String] solr_field_key
+      # @param [Hash] field_info
+      # @param [Array] val an array of two elements, first is a string (the uri) and the second is a hash with one key: `:label`
+      def append_label_and_uri(solr_doc, solr_field_key, field_info, val)
+        val = val.solrize
+        self.class.create_and_insert_terms(solr_field_key,
+                                           val.first,
+                                           field_info.behaviors, solr_doc)
+        return unless val.last.is_a? Hash
+        self.class.create_and_insert_terms("#{solr_field_key}_label",
+                                           label(val),
+                                           field_info.behaviors, solr_doc)
+      end
+
+      # Use this method to append a string value from a controlled vocabulary field
+      # to the solr document. It just puts a copy into the corresponding label field
+      # @param [Hash] solr_doc
+      # @param [String] solr_field_key
+      # @param [Hash] field_info
+      # @param [String] val
+      def append_label(solr_doc, solr_field_key, field_info, val)
+        self.class.create_and_insert_terms(solr_field_key,
+                                           val,
+                                           field_info.behaviors, solr_doc)
+        self.class.create_and_insert_terms("#{solr_field_key}_label",
+                                           val,
+                                           field_info.behaviors, solr_doc)
+      end
+
+      # Return a label for the solrized term:
+      # @example
+      #   label(["http://id.loc.gov/authorities/subjects/sh85062487", {:label=>"Hotels$http://id.loc.gov/authorities/subjects/sh85062487"}])
+      #   => 'Hotels'
+      def label(val)
+        val.last[:label].split('$').first
+      end
+  end
+end

--- a/app/indexers/publication_indexer.rb
+++ b/app/indexers/publication_indexer.rb
@@ -1,4 +1,14 @@
+# frozen_string_literal: true
+
 class PublicationIndexer < Hyrax::WorkIndexer
+
+  # replaces the work that including the `Hyrax::IndexesLinkedMetadata`
+  # mixin would do, without also bringing along metadata baggage from
+  # `Hyrax::BasicMetadataIndexer`.
+  def rdf_service
+    Hyrax::DeepIndexingService
+  end
+
   def generate_solr_document
     super.tap do |solr_doc|
       attach_individual_identifiers(solr_doc)

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -4,14 +4,9 @@ class Publication < ActiveFedora::Base
   # The `controlled_properties` attribute is used by the Hyrax::DeepIndexingService,
   # which is used to fetch RDF labels for indexing. This is used out-of-the-box
   # for :based_near (which, I believe, uses GeoNames), but could be used for,
-  # say, LCSH headings in other models, if not this one. This is implemented in
-  # Hyrax::BasicMetadata, but since we're implementing our basic metadata fields
-  # outside of that mixin, we'll need to define this manually.
-  #
-  # (You'll probably also need to switch on `accepts_nested_attributes` below)
-
-  # class_attribute :controlled_properties
-  # self.controlled_properties = []
+  # say, LCSH headings in other models, if not this one.
+  class_attribute :controlled_properties
+  self.controlled_properties = %i[based_near creator]
 
   self.indexer = PublicationIndexer
 
@@ -20,7 +15,10 @@ class Publication < ActiveFedora::Base
 
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  # title is included with ::ActiveFedora::Base
+  #
+  # note: title is included with ::ActiveFedora::Base
+  #
+
   property :subtitle, predicate: ::RDF::URI.new('http://purl.org/spar/doco/Subtitle') do |index|
     index.as :stored_searchable
   end
@@ -74,7 +72,10 @@ class Publication < ActiveFedora::Base
     index.as :symbol, :facetable
   end
 
-  property :creator, predicate: ::RDF::Vocab::DC11.creator do |index|
+  # Uses the `Spot::SolrizableActiveTriplesResource` to provide a `#solrize`
+  # method to the value.
+  property :creator, predicate: ::RDF::Vocab::DC11.creator,
+                     class_name: Spot::SolrizableActiveTriplesResource do |index|
     index.as :stored_searchable, :facetable
   end
 

--- a/lib/spot/solrizable_active_triples_resource.rb
+++ b/lib/spot/solrizable_active_triples_resource.rb
@@ -1,0 +1,11 @@
+# Essentially copying the work found in Hyrax::ControlledVocabularies::Location
+# but does not override the `rdf_label` configuration attribute.
+module Spot
+  class SolrizableActiveTriplesResource < ActiveTriples::Resource
+    # Return a tuple of url & label
+    def solrize
+      return [rdf_subject.to_s] if rdf_label.first.to_s.blank? || rdf_label.first.to_s == rdf_subject.to_s
+      [rdf_subject.to_s, { label: "#{rdf_label.first}$#{rdf_subject}" }]
+    end
+  end
+end


### PR DESCRIPTION
The current Hyrax-y way to add RDF fields that store label text is to include the `Hyrax::IndexesLinkedMetadata` mixin. However, this inherits from `Hyrax::IndexesBasicMetadata` which expects the model to also be including the `Hyrax::BasicMetadata` mixin. Since we've decided to _not_ include BasicMetadata, `Hyrax::IndexesBasicMetadata` complains that it can't find certain properties, defined in the `stored_and_faceted_fields`, `stored_fields`, and `symbol_fields` class attributes of `Hyrax::BasicMetadataIndexer`. This is the topic of an almost year-old pull request (https://github.com/samvera/hyrax/pull/1729). I'm not too stoked on the suggestion to override the class attributes w/ the fields we're using, so instead I've decided to replicate the PR as best as possible.

**Note:** I'm not exactly sure that this is the cure for what ails us, so let's not pull it in right away (it also needs testing!). But I went far enough down the rabbit hole of RDF indexing that I wanted to put some code together.