### PR TITLE
add controller for handle/hdl requests

### DIFF
--- a/app/controllers/handle_controller.rb
+++ b/app/controllers/handle_controller.rb
@@ -1,0 +1,16 @@
+class HandleController < ApplicationController
+  include Hydra::Catalog
+
+  def show
+    result, documents = search_results(q: "identifier_hdl_ssim:#{params[:id]}")
+
+    raise Blacklight::Exceptions::RecordNotFound if documents.empty?
+
+    # TODO: what happens if there are multiple responses?
+    doc = result.response['docs'].first
+    id = doc['id']
+    controller = doc['has_model_ssim'].first.downcase.pluralize
+
+    redirect_to controller: "hyrax/#{controller}", action: 'show', id: id
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,10 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
-  
+
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
   mount Blacklight::Engine => '/'
-  
+
     concern :searchable, Blacklight::Routes::Searchable.new
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
   end
 
   mount Sidekiq::Web => '/sidekiq'
+
+  get '/handle/*id', to: 'handle#show', as: 'handle'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/spot/handle_controller_spec.rb
+++ b/spec/controllers/spot/handle_controller_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe Spot::HandleController do
+  describe '#show' do
+    subject { get :show, params: { id: handle } }
+
+    context 'when a handle exists for an item' do
+      let(:handle) { '1234/5678' }
+      let(:work) { build(:publication, identifier: ["hdl:#{handle}"]) }
+
+      before { work.save }
+
+      it { is_expected.to redirect_to hyrax_publication_path(work.id) }
+    end
+
+    context 'when a handle does not exist for an item' do
+      let(:handle) { 'not/here' }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+  end
+end


### PR DESCRIPTION
adds a controller to redirect requests for `/handle/<identifier>` to their respective Publications, if exist.

closes #34 