### PR TITLE
Seed existing collections

### DIFF
--- a/config/collections.yml
+++ b/config/collections.yml
@@ -1,0 +1,25 @@
+- title: Lafayette Magazine archive
+  visibility: public
+  metadata:
+    description: >
+      Digitized archive of Lafayette publications:
+      Lafayette Alumnus, Lafayette Alumni Quarterly,
+      Lafayette Magazine, as well as the Football
+      News Letter and Leopard Letter.
+- title: Lafayette Newspaper archive
+  visibility: public
+  metadata:
+    description: >
+      Digitized archive of The Lafayette, the oldest
+      college newspaper in Pennsylvania.
+- title: Shakespeare Bulletin Archive
+  visibility: public
+  metadata:
+    description: >
+      Digitized Shakespeare Bulletin Archive containing
+      complete runs of Shakespeare Bulletin (1983-2003),
+      the preceding Bulletin of the New York Shakespeare
+      Society (1982-1983), and the incorporated Shakespeare
+      on Film Newsletter (1976-1992).
+- title: Faculty Publications
+  visibility: public

--- a/lib/spot/collection_from_config.rb
+++ b/lib/spot/collection_from_config.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+# A (slightly) simpler way of creating classes with some
+# reasonable defaults.
+module Spot
+  class CollectionTypeDoesNotExistError < StandardError; end
+
+  class CollectionFromConfig
+    attr_reader :title, :metadata, :collection_type, :visibility
+
+    # Initialize from a parsed YAML configuration file
+    # (here to make our lives easier within a Rake task).
+    # A hash of metadata is processed so that keys are
+    # symbols and values are wrapped in arrays.
+    #
+    # @param config [Hash] A single parsed YAML block
+    # @option 'title' [String] Title of the collection
+    # @option 'metadata' [Hash] Collection metadata
+    # @option 'collection_type' [String] the +machine_id+ of a Hyrax::CollectionType
+    # @option 'visibility' [String] one of: 'public', 'authenticated', 'private'
+    # @raise [CollectionTypeDoesNotExistError] see {#parse_collection_type}
+    def self.from_yaml(config)
+      new(
+        title: config['title'],
+        metadata: wrap_metadata(config['metadata']),
+        collection_type: config['collection_type'],
+        visibility: config['visibility']
+      )
+    end
+
+    # @param :title [String] Title of the collection (required)
+    # @param :metadata [Hash] Collection metadata attributes
+    # @param :collection_type [String] the +machine_id+ of a Hyrax::CollectionType
+    # @param :visibility [String] one of: 'public', 'authenticated', 'private'
+    # @raise [CollectionTypeDoesNotExistError] see {#parse_collection_type}
+    def initialize(title:,
+                   metadata: {},
+                   collection_type: default_collection_type,
+                   visibility: default_visibility)
+      @title = title
+      @metadata = metadata
+      @collection_type = parse_collection_type(collection_type)
+      @visibility = parse_visibility(visibility)
+    end
+
+    # Our own homespun version of +ActiveRecord::Base.find_or_create_by_title+.
+    # We'll check to see if a Collection of the same name
+    # exists and return that if so. Otherwise, we'll create a new one.
+    #
+    # @return [Collection]
+    def create
+      # since ActiveFedora::Base doesn't have a '.find_or_create_by'
+      # method, we'll reproduce that behavior
+      existing = Collection.where(title: [title])&.first
+      return existing unless existing.nil?
+
+      Collection.create(title: [title]) do |col|
+        col.attributes = { title: [title] }.merge(metadata)
+        col.collection_type = collection_type
+        col.visibility = visibility
+      end
+    end
+
+    private
+
+    # Processes a raw hash from +YAML.safe_load+ to one having
+    # symbolized keys and Array-ified values.
+    #
+    # @param [Hash]
+    # @return [Hash<Symbol => Array>]
+    def self.wrap_metadata(metadata)
+      metadata.each_with_object({}) do |(key, val), obj|
+        obj[key.to_sym] = Array(val)
+      end
+    end
+
+    # If no collection_type is provided, we'll use +user_collection+
+    #
+    # @return [String]
+    def default_collection_type
+      Hyrax::CollectionType::USER_COLLECTION_MACHINE_ID
+    end
+
+    # Finds a CollectionType by a provided +machine_id+ String.
+    #
+    # @param value [String] A CollectionType's +machine_id+ property
+    # @return [Hyrax::CollectionType]
+    # @raise [CollectionTypeDoesNotExistError] if CollectionType machine_id does not exist
+    def parse_collection_type(value)
+      if value.blank?
+        value = default_collection_type
+      end
+
+      type = Hyrax::CollectionType.find_by(machine_id: value)
+      raise CollectionTypeDoesNotExistError, "CollectionType #{value} does not exist" if type.nil?
+
+      type
+    end
+
+    # Converts an easy-to-read value to its official
+    # Hydra::AccessControls value. Only 'authenticated'
+    # and 'public' will result in a different visibility,
+    # everything else defaults to 'private'
+    #
+    # @param value [String] one of 'authenticated', 'public'
+    # @return [String] the Hydra::AccessControls::AccessRight constant
+    def parse_visibility(value)
+      # safe navigating in case visibility is nil
+      case value&.downcase
+      when 'authenticated'
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      when 'public'
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      else
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      end
+    end
+  end
+end

--- a/lib/spot/collection_from_config.rb
+++ b/lib/spot/collection_from_config.rb
@@ -22,7 +22,7 @@ module Spot
     def self.from_yaml(config)
       new(
         title: config['title'],
-        metadata: wrap_metadata(config['metadata']),
+        metadata: wrap_metadata(config['metadata'] || {}),
         collection_type: config['collection_type'],
         visibility: config['visibility']
       )

--- a/lib/tasks/spot/collections.rake
+++ b/lib/tasks/spot/collections.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+namespace :spot do
+  namespace :collections do
+    desc 'Create Collections from a config file'
+    task create: [:environment] do
+      config_path = ENV.fetch('config') { Rails.root.join('config', 'collections.yml') }
+
+      YAML.safe_load(File.open(config_path)).each do |config|
+        Rails.logger.info "Creating collection: #{config['title']}"
+        Spot::CollectionFromConfig.from_yaml(config).create
+      end
+    end
+  end
+end

--- a/spec/lib/spot/collection_from_config_spec.rb
+++ b/spec/lib/spot/collection_from_config_spec.rb
@@ -62,16 +62,16 @@ RSpec.describe Spot::CollectionFromConfig do
       it { is_expected.to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
     end
 
-    context 'when "private"' do
-      let(:visibility) { 'private' }
-
-      it { is_expected.to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
-    end
-
-    context 'it defaults to "public"' do
-      let(:visibility) { 'i dunno?' }
+    context 'when "public"' do
+      let(:visibility) { 'public' }
 
       it { is_expected.to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    end
+
+    context 'it defaults to "private"' do
+      let(:visibility) { 'i dunno?' }
+
+      it { is_expected.to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
   end
 

--- a/spec/lib/spot/collection_from_config_spec.rb
+++ b/spec/lib/spot/collection_from_config_spec.rb
@@ -1,0 +1,122 @@
+RSpec.describe Spot::CollectionFromConfig do
+  subject(:collection) { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      title: title,
+      metadata: metadata,
+      collection_type: collection_type_id,
+      visibility: visibility
+    }
+  end
+
+  let(:title) { 'My cool collection' }
+  let(:metadata) { { description: ['Some good words'] } }
+  let(:collection_type_id) { 'user_collection' }
+  let(:visibility) { 'private' }
+
+  before do
+    Collection.destroy_all
+    Hyrax::CollectionTypes::CreateService.create_admin_set_type
+    Hyrax::CollectionTypes::CreateService.create_user_collection_type
+  end
+
+  after do
+    Collection.destroy_all
+  end
+
+  describe 'collection_type' do
+    subject(:type) { collection.collection_type }
+
+    context 'when a type exists' do
+      let(:collection_type_id) { Hyrax::CollectionType::ADMIN_SET_MACHINE_ID }
+
+      it 'adds a Hyrax::CollectionType object with that machine_id' do
+        expect(type.machine_id).to eq collection_type_id
+      end
+    end
+
+    context 'when a type does not exist' do
+      let(:collection_type_id) { 'no_not_here' }
+
+      it do
+        expect { type }.to raise_error(Spot::CollectionTypeDoesNotExistError)
+      end
+    end
+
+    context 'when none provided' do
+      let(:collection_type_id) { nil }
+
+      it 'adds a default type (user_collection)' do
+        expect(type.machine_id).to eq Hyrax::CollectionType::USER_COLLECTION_MACHINE_ID
+      end
+    end
+  end
+
+  describe 'visibility' do
+    subject(:visibility) { collection.visibility }
+
+    context 'when "authenticated"' do
+      let(:visibility) { 'authenticated' }
+
+      it { is_expected.to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+    end
+
+    context 'when "private"' do
+      let(:visibility) { 'private' }
+
+      it { is_expected.to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+    end
+
+    context 'it defaults to "public"' do
+      let(:visibility) { 'i dunno?' }
+
+      it { is_expected.to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    end
+  end
+
+  describe '#create' do
+    subject(:created) { collection.create }
+
+    it { is_expected.to be_a Collection }
+
+    context 'when metadata is provided' do
+      let(:title) { 'a new collection' }
+      let(:metadata) { { description: ['A very nice collction'] } }
+
+      it 'passes it to the Collection' do
+        expect(created.title).to eq [title]
+        expect(created.description).to eq metadata[:description]
+      end
+    end
+  end
+
+  describe '.from_yaml' do
+    subject(:created) { described_class.from_yaml(yaml) }
+
+    let(:description) { 'a nice description' }
+    let(:creator) { 'dss@lafayette.edu' }
+
+    let(:yaml) do
+      {
+        'title' => title,
+        'metadata' => {
+          'description' => description,
+          'creator' => creator
+        }
+      }
+    end
+
+    it 'wraps the metadata values in an array' do
+      expect(created.metadata[:description]).to be_an Array
+      expect(created.metadata[:creator]).to be_an Array
+    end
+
+    it 'converts metadata keys to symbols' do
+      expect(created.metadata).to include :description
+      expect(created.metadata).not_to include 'description'
+      expect(created.metadata).to include :creator
+      expect(created.metadata).not_to include 'creator'
+    end
+  end
+end


### PR DESCRIPTION
implements the ability to define some base Collection metadata in a YAML file and create those collections via a rake task