### PR TITLE
[wip] update to hyrax 3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'jbuilder', '~> 2.5'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'hyrax', '2.4.1'
+gem 'hyrax', '3.0.0-beta1'
 
 gem 'almond-rails'
 gem 'bagit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,7 +377,7 @@ GEM
       hydra-file_characterization (~> 0.3, >= 0.3.3)
       hydra-pcdm (>= 0.9)
       om (~> 3.1)
-    hyrax (2.4.1)
+    hyrax (3.0.0.pre.beta1)
       active-fedora (~> 11.5, >= 11.5.2)
       almond-rails (~> 0.1)
       awesome_nested_set (~> 3.1)
@@ -910,7 +910,7 @@ DEPENDENCIES
   fcrepo_wrapper
   ffaker
   hydra-role-management (~> 1.0)
-  hyrax (= 2.4.1)
+  hyrax (= 3.0.0.pre.beta1)
   hyrax-spec
   iso-639
   jbuilder (~> 2.5)

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -3,38 +3,49 @@
 <%= render 'shared/citations' %>
 
 <div class="row work-type">
-  <div class="col-xs-12">&nbsp;</div>
   <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">
+    <%= render 'work_title', presenter: @presenter %>
+    <%= render 'show_actions', presenter: @presenter %>
     <div class="panel panel-default">
-      <div class="panel-heading">
-        <%= render 'work_title', presenter: @presenter %>
-      </div>
       <div class="panel-body">
         <div class="row">
-          <div class="col-sm-12">
-            <%= render 'show_actions', presenter: @presenter %>
-          </div>
           <%= render 'workflow_actions_widget', presenter: @presenter %>
-          <div class="col-sm-12 work-representative-media">
-            <%= render 'representative_media', presenter: @presenter, viewer: @presenter.universal_viewer? %>
-          </div>
-          <%# <div class="col-sm-3 text-center"> %>
-            <%# render 'citations', presenter: @presenter %>
-            <%# render 'social_media' %>
-          <%# </div> %>
           <div class="col-sm-12">
+            <%= render 'representative_media', presenter: @presenter,
+                                               viewer: @presenter.iiif_viewer? %>
+          </div>
+          <div class="col-sm-9">
             <%= render 'work_description', presenter: @presenter %>
             <%= render 'metadata', presenter: @presenter %>
           </div>
-          <div class="col-sm-12">
-            <%= render 'relationships', presenter: @presenter %>
-            <%= render 'items', presenter: @presenter %>
-            <%# TODO: we may consider adding these partials in the future %>
-            <%# = render 'sharing_with', presenter: @presenter %>
-            <%# = render 'user_activity', presenter: @presenter %>
+          <div class="col-sm-3 text-center">
+            <%= render 'citations', presenter: @presenter %>
           </div>
         </div>
       </div>
+    </div><!-- /panel -->
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Relationships</h3>
+      </div>
+      <div class="panel-body">
+        <%= render 'relationships', presenter: @presenter %>
+      </div>
     </div>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Items</h3>
+      </div>
+      <div class="panel-body">
+        <%= render 'items', presenter: @presenter %>
+      </div>
+    </div>
+
+    <%# TODO: we may consider adding these partials in the future %>
+    <%# = render 'sharing_with', presenter: @presenter %>
+    <%# = render 'user_activity', presenter: @presenter %>
+
   </div>
 </div>


### PR DESCRIPTION
the release of hyrax v3 is slated for late december, but the release notes don't seem to indicate much of a migration process for us. let's leave this pr open until 3.0 is _officially_ released and use it for spot updates to get v3 up and running.

## to-do list

- [x]  update `app/views/hyrax/base/show.html.erb` to new layout (which handles the reconfiguration of show_actions)