### PR TITLE
add language-tagged literals to work fields

### DIFF
--- a/app/assets/javascripts/language-tagged-autocomplete-setup.js
+++ b/app/assets/javascripts/language-tagged-autocomplete-setup.js
@@ -1,0 +1,29 @@
+var Autocomplete = require('hyrax/autocomplete')
+var autocomplete = new Autocomplete()
+
+$(document).ready(function () {
+  $('.form-group.language_tagged').manage_fields({
+    add: function (event, _element) {
+      // `add` is called after the element is cloned but before it's added
+      // to the DOM, so we need to quick pause for that to happen before
+      // initializing the next input
+      //
+      // note: this is on the roadmap for the 4.x series:
+      //       https://github.com/samvera/hydra-editor/issues/158
+      window.setTimeout(function () {
+        var $target = $(event.currentTarget)
+        var $elem = $target.find('[data-autocomplete]').last()
+
+        // cloning an input doesn't remove its value,
+        // so we need to do that manually
+        // (this causes a brief flash of the previous data
+        // but i don't think there's any way around that)
+        $elem.parent().parent().find('input').val('')
+
+        autocomplete.setup($elem,
+                           $elem.data('autocomplete'),
+                           $elem.data('autocompleteUrl'))
+      }, 0)
+    }
+  })
+})

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,3 +36,9 @@ ul.tabular {
   margin-bottom: .5rem;
   margin-top: .5rem;
 }
+
+// undoing `max-width: 40em` that hydra-editor sets;
+.multi_value .listing,
+.controlled_vocabulary .listing {
+  max-width: 100%;
+}

--- a/app/forms/concerns/identifier_form_fields.rb
+++ b/app/forms/concerns/identifier_form_fields.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+#
+# A concern for adding a custom identifier field to your hydra-editor form.
+# Adds the '_prefix' and '_value' fields to the form's permitted params
+# and transforms them back to the single field on submission. Allows
+# the customizing of the field name but defaults to +:identifier+.
+# To use it, simply include it in your form:
+#
+# @example
+#   class ImageForm < Hyrax::Forms::WorkForm
+#     include ::IdentifierFormFields
+#   end
+module IdentifierFormFields
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :identifier_field
+    self.identifier_field = :identifier
+  end
+
+  module ClassMethods
+    # Adds the _prefix and _value fields to the permitted params
+    # array. Will add either a pair of symbols or a hash, depending
+    # on how the field responds to +.multiple?+
+    #
+    # @return [Array<Symbol,Hash<Symbol => Array>>]
+    def build_permitted_params
+      super.tap do |params|
+        if multiple?(identifier_field.to_sym)
+          params << {
+            identifier_prefix_key => [],
+            identifier_value_key => []
+          }
+        else
+          params << identifier_prefix_key
+          params << identifier_value_key
+        end
+      end
+    end
+
+    # Calls our transformation method as part of the chain of
+    # {.model_attributes} calls.
+    #
+    # @return [Hash]
+    def model_attributes(form_params)
+      super.tap do |params|
+        transform_identifiers!(params)
+      end
+    end
+
+    private
+
+    # transforms arrays of identifier prefixes
+    # and values into a single array of identifier
+    # strings and appends it to +form_params['identifier']+
+    #
+    # @param [ActiveController::Parameters, Hash] params
+    # @return [void]
+    def transform_identifiers!(params)
+      prefixes = params.delete(identifier_prefix_key.to_s)
+      values = params.delete(identifier_value_key.to_s)
+
+      return unless prefixes && values
+
+      mapped = prefixes.zip(values).map do |(key, value)|
+        Spot::Identifier.new(key, value).to_s
+      end.reject(&:blank?)
+
+      params[identifier_field] = mapped if mapped
+    end
+
+    # @return [Symbol]
+    def identifier_prefix_key
+      :"#{identifier_field}_prefix"
+    end
+
+    # @return [Symbol]
+    def identifier_value_key
+      :"#{identifier_field}_value"
+    end
+  end
+end

--- a/app/forms/concerns/language_tagged_form_fields.rb
+++ b/app/forms/concerns/language_tagged_form_fields.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+#
+# A concern for adding language-tagged fields to your +hydra-editor+-based
+# form object. Abstracts away the addition of the defined fields to the
+# permitted parameters array as well as transforming the form values back
+# to something the object itself understands. To add support, include this
+# module into your form and call the {.transforms_language_tags_for} macro:
+#
+# @example
+#   class ImageForm < Hyrax::Forms::WorkForm
+#     include ::LanguageTaggedFormFields
+#
+#     transforms_language_tags_for :title, :description
+#   end
+module LanguageTaggedFormFields
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    # A macro for storing the fields we wish to transform. This needs to
+    # be called at the class level so that the fields can be stored in
+    # a singleton method to be called later.
+    #
+    # @todo is there a better way to do this? my meta-programming naïvity
+    #       might be showing?
+    # @param [Array<Symbol>] *fields The fields to transform
+    # @return [void]
+    def transforms_language_tags_for(*fields)
+      define_singleton_method(:_language_tagged_fields) { fields.flatten }
+    end
+
+    # Adds two fields to the form object's permitted parameters:
+    # +field_value+ and +field_language+, where one is expected to be
+    # property value and the other is the language tag (if present).
+    # Uses the form's +#multiple?# method to determine whether symbols
+    # or a hash goes into the object.
+    #
+    # @return [Array<Symbol,Hash<Symbol => Array>>]
+    def build_permitted_params
+      super.tap do |params|
+        _language_tagged_fields.each do |field|
+          if multiple?(field)
+            params << {
+              "#{field}_value": [],
+              "#{field}_language": []
+            }
+          else
+            params << :"#{field}_value"
+            params << :"#{field}_language"
+          end
+        end
+      end
+    end
+
+    # Calls our transformation method as part of the chain of
+    # {.model_attributes} calls.
+    #
+    # @param [ActiveController::Parameters, Hash<String => *>]
+    # @return [Hash]
+    def model_attributes(form_params)
+      super.tap do |params|
+        transform_language_tagged_fields!(params)
+      end
+    end
+
+    private
+
+    # transforms arrays of field values + languages into RDF::Literals
+    # tagged with said language
+    #
+    # @param [ActiveController::Parameters, Hash<String => Array<String>>] params
+    # @return [void]
+    def transform_language_tagged_fields!(params)
+      _language_tagged_fields.flatten.each do |field|
+        value_key = "#{field}_value"
+        lang_key = "#{field}_language"
+
+        next unless params.include?(value_key) && params.include?(lang_key)
+
+        values = Array(params.delete(value_key))
+        langs = Array(params.delete(lang_key))
+
+        mapped = values.zip(langs).map do |(value, lang)|
+          # need to skip blank entries here, otherwise we get a blank literal
+          # (""@"") which LDP doesn't like
+          next unless value.present?
+
+          # retain the value if no language tag is passed
+          lang.present? ? RDF::Literal(value, language: lang.to_sym) : value
+        end.reject(&:blank?)
+
+        params[field] = mapped if mapped
+        params[field] = params[field].first unless multiple?(field)
+      end
+    end
+  end
+end

--- a/app/forms/concerns/nested_form_fields.rb
+++ b/app/forms/concerns/nested_form_fields.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+#
+# A concern for adding support for fields that behave like ActiveFedora
+# nested properties, but aren't RDF related. A good use case is a property
+# that pulls a value from a controlled vocabulary via autocomplete, but
+# that vocabulary is controlled locally (ex. via a YAML file with the
+# Questioning Authority gem).
+#
+# Adding this support may also involve updating the
+# +app/assets/javascripts/hyrax/autocomplete.es6+ file to change the type
+# of Autocomplete function added to the field, as well as the field's edit
+# field rendering (at +app/views/records/edit_fields/_<property>.html.erb).
+#
+# To add support to your form, include this module and call the
+# {.transforms_nested_fields_for} macro:
+#
+# @example
+#   class ImageForm < Hyrax::Forms::WorkForm
+#     include ::NestedFormFields
+#
+#     transforms_nested_fields_for :academic_department, :keyword
+#   end
+module NestedFormFields
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    # A macro for storing the fields we'd like to transform. This
+    # is called at the class level, preferrably at the top, similar
+    # to ActiveRecord macros.
+    #
+    # @param [Array<Symbol>] *fields fields to transform
+    # @return [void]
+    def transforms_nested_fields_for(*fields)
+      define_singleton_method(:_nested_fields) { fields.flatten }
+    end
+
+    # Adds our nested fields to the form's permitted parameters.
+    #
+    # @return [Array<Symbol, Hash<Symbol => Array>]
+    def build_permitted_params
+      super.tap do |params|
+        _nested_fields.each do |field|
+          params << { "#{field}_attributes": [:id, :_destroy] }
+        end
+      end
+    end
+
+    # Tapping into the +.model_attributes+ chain to transform
+    # our nested fields.
+    #
+    # @param [ActiveController::Parameters, Hash<String => *>]
+    # @return [Hash]
+    def model_attributes(form_params)
+      super.tap do |params|
+        transform_nested_fields!(params)
+      end
+    end
+
+    private
+
+    # There may be a clearer name for this. Local controlled
+    # vocabulary fields are returned to the form looking like
+    # +WorkModel.accepts_nested_attributes_for+ properties.
+    # However, they're decidedly _not_ ActiveFedora nested
+    # attributes and they need to be transformed back.
+    #
+    # Essentially, we're receiving attributes that look like:
+    #
+    #   {'language_attributes' => {'0' => { 'id' => 'en' }}}
+    #
+    # and transforming them to look like:
+    #
+    #   {'language' => ['en']}
+    #
+    # Note that this step isn't necessary if we're
+    # just using the jquery-ui autocomplete field type.
+    #
+    # @param [ActionController::Parameters, Hash] params
+    # @return [void]
+    def transform_nested_fields!(params)
+      _nested_fields.each do |field|
+        attr_field_key = "#{field}_attributes"
+        next unless params.include?(attr_field_key)
+
+        values = transform_nested_attributes(params, attr_field_key)
+
+        params[field] = values || []
+      end
+    end
+
+    # flattens a nested_attribute hash into an array of
+    # ids. if the +_destroy+ key is present, the field
+    # is skipped, removing it from the record.
+    #
+    # @param [ActionController::Parameters,Hash] params
+    # @param [Symbol,String] field
+    # @return [Array<String>]
+    def transform_nested_attributes(params, field)
+      return if params[field].blank?
+
+      [].tap do |out|
+        params.delete(field.to_s).each do |_index, param|
+          next unless param['_destroy'].blank?
+          out << param['id'] if param['id']
+        end
+      end
+    end
+  end
+end

--- a/app/forms/hyrax/publication_form.rb
+++ b/app/forms/hyrax/publication_form.rb
@@ -135,6 +135,8 @@ module Hyrax
           # singular value/language fields
           params << :title_value
           params << :title_language
+          params << :abstract_value
+          params << :abstract_language
 
           params << {
             # identifier fields
@@ -144,6 +146,10 @@ module Hyrax
             # multiple value/language fields
             title_alternative_value: [],
             title_alternative_language: [],
+            subtitle_value: [],
+            subtitle_language: [],
+            description_value: [],
+            description_language: [],
 
             # locally controlled attibutes
             language_attributes: [:id, :_destroy],
@@ -169,7 +175,10 @@ module Hyrax
                                   :division)
           transform_language_tagged_fields!(params,
                                             :title,
-                                            :title_alternative)
+                                            :title_alternative,
+                                            :subtitle,
+                                            :abstract,
+                                            :description)
 
           singular_terms.each do |term|
             params[term] = Array(params[term]) if params[term]

--- a/app/inputs/concerns/language_tagging.rb
+++ b/app/inputs/concerns/language_tagging.rb
@@ -40,12 +40,14 @@
 # (see: #build_field_options, #autocomplete_name) and I have some
 # concerns about its fragility. But so far so good!
 module LanguageTagging
+
   # Overriding the default method to append a notice that this field can be
   # tagged with a language.
   #
   # @todo move this to a locale
+  # @param [Hash] _wrapper_options Not used
   # @return [String]
-  def hint
+  def hint(_wrapper_options = nil)
     default_hint = super
     return unless default_hint
 

--- a/app/inputs/concerns/language_tagging.rb
+++ b/app/inputs/concerns/language_tagging.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+#
+# A mixin to provide a single source for building out language-tagged
+# inputs on a form. If inheriting from MultiValueInput, it's as simple
+# as including this module and defining an :input_type method (so the
+# appropriate class is added to the html element).
+#
+# @example
+#   class SomeMultiTaggedInput < MultiValueInput
+#     include LanguageTagging
+#
+#     def input_type
+#       'multi_value language_tagged'
+#     end
+#   end
+#
+# Note: you need to include 'language_tagged' in the input type in order
+# for the javascript to work correctly.
+#
+# If extending a single-value item, you'll need to provide an :input
+# method (which +hydra-editor+ is expecting) and have it create a
+# +name+ option.
+#
+# @example
+#   class SingleTaggedInput < MultiValueInput
+#     include LanguageTagging
+#
+#     def input_type
+#       'text language_tagged'
+#     end
+#
+#     def input(wrapper_options = nil)
+#       input_html_options[:name] ||= "#{object_name}[#{attribute_name}]"
+#       value = object.send(attribute_name) || ''
+#       build_field(value, nil)
+#     end
+#   end
+#
+# This module relies on some ruby magic re: checking inheritance
+# (see: #build_field_options, #autocomplete_name) and I have some
+# concerns about its fragility. But so far so good!
+module LanguageTagging
+  private
+
+  # If inheriting from MultiValueInput, this method is called from
+  # the +#input+ method (which itself is called from within the
+  # hydra-form gem). Otherwise, you can use this from within your
+  # own +#input+ method.
+  #
+  # @param [RDF::Literal, String] raw_value
+  # @param [Integer] _index not used
+  # @return [String] HTML content for field row
+  def build_field(raw_value, _index = nil)
+    value, language = parse_value(raw_value)
+
+    <<-HTML
+    <div class="row">
+      <div class="form-group col-sm-10">
+        #{build_input(value, index)}
+      </div>
+      <div class="form-group col-sm-2">
+        #{build_language_autocomplete(language)}
+      </div>
+    </div>
+    HTML
+  end
+
+  # Responsible for building the input for the property value
+  # (not language tag). It'll produce a name similar to
+  # +work_type[field_value]+
+  #
+  # @param [String] value
+  # @param [Integer] index
+  # @return [String]
+  def build_input(value, index)
+    options = build_field_options(value, index)
+
+    # convert name from 'publication[title]' to 'publication[title_value]'
+    options[:name] = options[:name].gsub(/\[([^\]]+)\]/, '[\1_value]')
+
+    if options.delete(:type) == 'textarea'
+      @builder.text_area(attribute_name, options)
+    else
+      @builder.text_field(attribute_name, options)
+    end
+  end
+
+  # normally we'd just generate a <select>, but there are
+  # a _lot_ of options available, so we'll build a jquery-ui
+  # autocomplete + do some validation on the input afterwards.
+  #
+  # @param [String] val
+  # @return [String]
+  def build_language_autocomplete(val)
+    label = language_label(val)
+    options = {
+      value: val,
+      name: autocomplete_name,
+      class: 'form-control',
+      data: {
+        'autocomplete-url': '/authorities/search/language',
+        'autocomplete': 'language-label'
+      }
+    }
+
+    @builder.text_field("#{attribute_name}_language", options)
+  end
+
+  # a minimal implementation of MultiValueInput#build_field_options
+  # for input classes that _don't_ extend from MVI or have this
+  # method already defined
+  #
+  # @param [String] value
+  # @param [Integer] _index (not used here)
+  def build_field_options(value, _index)
+    return super if defined?(super)
+
+    dom_id = input_dom_id if self.respond_to?(:input_dom_id)
+    dom_id ||= "#{object_name}_#{attribute_name}"
+
+    input_html_options.dup.tap do |options|
+      options[:value] = value
+
+      options[:id] ||= dom_id
+      options[:class] ||= []
+      options[:class] += ["#{dom_id} form-control"]
+      options[:'aria-labelledby'] ||= "#{dom_id}_label"
+    end
+  end
+
+  # @param [String, Symbol] key
+  # @return [String] label for language key
+  def language_label(key)
+    Spot::ISO6391.label_for(key.to_s)
+  end
+
+  # Generates a name property for the autocomplete input.
+  #
+  # @return [String]
+  def autocomplete_name
+    base = "#{object_name}[#{attribute_name}_language]"
+
+    return base unless has_multiple_method? && multiple?
+
+    "#{base}[]"
+  end
+
+  # This has a pretty bad code-smell, but it's the best solution I could
+  # come up with. Does this Input have a +#multiple?+ method defined?
+  #
+  # @return [TrueClass, FalseClass]
+  def has_multiple_method?
+    self.private_methods.include?(:multiple?) || self.methods.include(:multiple?)
+  end
+
+  # extract the value + language from possible raw values: either an RDF::Literal
+  # or a String value (or neither).
+  #
+  # @return [Array<String>]
+  def parse_value(raw)
+    return [raw.value, raw.language] if raw.is_a? RDF::Literal
+    return [raw, nil] if raw.present?
+    return [nil, nil]
+  end
+end

--- a/app/inputs/concerns/language_tagging.rb
+++ b/app/inputs/concerns/language_tagging.rb
@@ -50,7 +50,7 @@ module LanguageTagging
   # @param [RDF::Literal, String] raw_value
   # @param [Integer] _index not used
   # @return [String] HTML content for field row
-  def build_field(raw_value, _index = nil)
+  def build_field(raw_value, index = nil)
     value, language = parse_value(raw_value)
 
     <<-HTML
@@ -150,7 +150,7 @@ module LanguageTagging
   #
   # @return [TrueClass, FalseClass]
   def has_multiple_method?
-    self.private_methods.include?(:multiple?) || self.methods.include(:multiple?)
+    self.private_methods.include?(:multiple?) || self.methods.include?(:multiple?)
   end
 
   # extract the value + language from possible raw values: either an RDF::Literal

--- a/app/inputs/concerns/language_tagging.rb
+++ b/app/inputs/concerns/language_tagging.rb
@@ -78,7 +78,7 @@ module LanguageTagging
     # convert name from 'publication[title]' to 'publication[title_value]'
     options[:name] = options[:name].gsub(/\[([^\]]+)\]/, '[\1_value]')
 
-    if options.delete(:type) == 'textarea'
+    if options.delete(:type).to_s == 'textarea'
       @builder.text_area(attribute_name, options)
     else
       @builder.text_field(attribute_name, options)

--- a/app/inputs/concerns/language_tagging.rb
+++ b/app/inputs/concerns/language_tagging.rb
@@ -40,6 +40,18 @@
 # (see: #build_field_options, #autocomplete_name) and I have some
 # concerns about its fragility. But so far so good!
 module LanguageTagging
+  # Overriding the default method to append a notice that this field can be
+  # tagged with a language.
+  #
+  # @todo move this to a locale
+  # @return [String]
+  def hint
+    default_hint = super
+    return unless default_hint
+
+    "#{default_hint} <strong>#{hint_text}</strong>".html_safe
+  end
+
   private
 
   # If inheriting from MultiValueInput, this method is called from
@@ -55,10 +67,10 @@ module LanguageTagging
 
     <<-HTML
     <div class="row">
-      <div class="form-group col-sm-10">
+      <div class="col-sm-10">
         #{build_input(value, index)}
       </div>
-      <div class="form-group col-sm-2">
+      <div class="col-sm-2">
         #{build_language_autocomplete(language)}
       </div>
     </div>
@@ -96,6 +108,7 @@ module LanguageTagging
     options = {
       value: val,
       name: autocomplete_name,
+      placeholder: autocomplete_placeholder,
       class: 'form-control',
       data: {
         'autocomplete-url': '/authorities/search/language',
@@ -112,6 +125,7 @@ module LanguageTagging
   #
   # @param [String] value
   # @param [Integer] _index (not used here)
+  # @return [Hash<Symbol => *>]
   def build_field_options(value, _index)
     return super if defined?(super)
 
@@ -126,6 +140,12 @@ module LanguageTagging
       options[:class] += ["#{dom_id} form-control"]
       options[:'aria-labelledby'] ||= "#{dom_id}_label"
     end
+  end
+
+  # @todo move this to a locale
+  # @return [String]
+  def hint_text
+    'This field may be tagged with a language'
   end
 
   # @param [String, Symbol] key
@@ -143,6 +163,12 @@ module LanguageTagging
     return base unless has_multiple_method? && multiple?
 
     "#{base}[]"
+  end
+
+  # @todo move this to a locale
+  # @return [String]
+  def autocomplete_placeholder
+    'Language'
   end
 
   # This has a pretty bad code-smell, but it's the best solution I could

--- a/app/inputs/identifier_input_group_input.rb
+++ b/app/inputs/identifier_input_group_input.rb
@@ -1,12 +1,33 @@
 # frozen_string_literal: true
-
+#
+# A +simple-form+ element that provides a drop-down select and text-input
+# for identifiers to allow prefixes to be appended. As stored, our identifiers
+# look like: `<prefix>:<value>` (see {Spot::Identifier}), but we would like
+# to remove the perils of conformance as much as possible and thus provide
+# a way to simplify the input process.
+#
+# @example
+#   <%# app/views/records/edit_fields/_identifier.html.erb %>
+#   <%= f.input :identifier, as: :identifier_input_group %>
+#
+# @todo abstract out the input 'name' field, so that a differently named
+#       property can perform similarly.
 class IdentifierInputGroupInput < MultiValueInput
+  # We want to preserve the look + feel of multi-value input, so we'll
+  # stuff this value (which is added as a class name to the wrapper element)
+  #
+  # @return [String]
   def input_type
     'multi_value'
   end
 
   private
 
+  # Called from {MultiValueInput#input} to build out the HTML of the input.
+  #
+  # @param [String] raw_value
+  # @param [Integer] index
+  # @return [String] HTML output
   def build_field(raw_value, index)
     identifier = Spot::Identifier.from_string(raw_value)
 
@@ -22,6 +43,12 @@ class IdentifierInputGroupInput < MultiValueInput
     HTML
   end
 
+  # Builds out the select dropdown with prefixes from {Spot::Identifier.prefixes}
+  #
+  # @todo could this be moved into a FormBuilder method call?
+  # @todo abstract out the +<select>+ element's +name+ attribute
+  # @param [String] the currently selected prefix
+  # @return [String] HTML for the dropdown
   def build_input_dropdown(selected = nil)
     button_text = selected ? label_for(selected) : 'Select type'
     <<-HTML
@@ -38,14 +65,26 @@ class IdentifierInputGroupInput < MultiValueInput
     HTML
   end
 
+  # Builds out the text input for the identifier
+  #
+  # @todo can we move this to a FormBuilder method call?
+  # @todo abstract out the +name+ attribute
+  # @param [String] value
+  # @param [Integer] index (not used)
+  # @return [String] HTML output for the +<input>+ element
   def build_input(value, index)
     %(<input type="text" name="#{object_name}[identifier_value][]" class="form-control" value="#{value}"/>)
   end
 
+  # @return [Array<String>] curated prefixes
   def prefixes
     Spot::Identifier.prefixes
   end
 
+  # Grabs the prefix label from {Spot::Identifier}
+  #
+  # @param [String] prefix
+  # @return [String]
   def label_for(prefix)
     Spot::Identifier.new(prefix, nil).prefix_label
   end

--- a/app/inputs/language_tagged_input_group_input.rb
+++ b/app/inputs/language_tagged_input_group_input.rb
@@ -1,8 +1,24 @@
 # frozen_string_literal: true
 #
+# A +simple-form+ element that appends an autocomplete input
+# to tag the value in a certain language. This relies heavily
+# on the {LanguageTagging} mixin for the rendering.
+#
+# This input is used for single-valued properties. For multiple
+# inputs, see {LanguageTaggedMultiInputGroupInput}.
+#
+# @example
+#   <%# app/views/records/edit_fields/_title.html.erb %>
+#   <%= f.input :title, as: :language_tagged_input_group %>
+#
 class LanguageTaggedInputGroupInput < SimpleForm::Inputs::Base
   include LanguageTagging
 
+  # Appends 'language_tagged' to a default value. This provides us
+  # with a target for the jQuery. NOTE: changing this value may
+  # upset the JS; please be careful!
+  #
+  # @return [String]
   def input_type
     'text language_tagged'
   end
@@ -18,5 +34,15 @@ class LanguageTaggedInputGroupInput < SimpleForm::Inputs::Base
     value = object.send(attribute_name) || ''
 
     build_field(value, nil)
+  end
+
+  private
+
+  # Explicitly state that this is a single property, rather than expecting
+  # this method to not be defined.
+  #
+  # @return [FalseClass]
+  def multiple?
+    false
   end
 end

--- a/app/inputs/language_tagged_input_group_input.rb
+++ b/app/inputs/language_tagged_input_group_input.rb
@@ -1,71 +1,22 @@
 # frozen_string_literal: true
 #
-# This input is used for fields that will become language-tagged
-# rdf literals. Instead of solely a text input, we're rendering
-# _two_ inputs: one for the value and one for the language. These
-# are then merged in the form into a single RDF::Literal with
-# the language tagged.
-class LanguageTaggedInputGroupInput < MultiValueInput
+class LanguageTaggedInputGroupInput < SimpleForm::Inputs::Base
+  include LanguageTagging
+
   def input_type
-    'multi_value'
+    'text language_tagged'
   end
 
-  private
+  # borrows a lot from hydra-editor's MultiValueInput but strips out
+  # the multi-input part
+  #
+  # @param [Hash] wrapper_options
+  # @return [] text input
+  def input(wrapper_options = nil)
+    input_html_classes.unshift('string')
+    input_html_options[:name] ||= "#{object_name}[#{attribute_name}]"
+    value = object.send(attribute_name) || ''
 
-  def build_field(raw_value, index)
-    value, language = parse_value(raw_value)
-
-    <<-HTML
-    <div class="row form-inline">
-      <div class="form-group col-sm-10">
-        #{build_input(value, index)}
-      </div>
-      <div class="form-group col-sm-2">
-        #{build_language_autocomplete(language)}
-      </div>
-    </div>
-    HTML
-  end
-
-  def build_input(value, index)
-    # this is coming from MultiValueInput
-    options = build_field_options(value, index)
-
-    # convert name from 'publication[title][]' to 'publication[title_value][]'
-    options[:name] = options[:name].gsub(/\[([^\]]+)\]/, '[\1_value]')
-
-    if options.delete(:type) == 'textarea'
-      @builder.text_area(attribute_name, options)
-    else
-      @builder.text_field(attribute_name, options)
-    end
-  end
-
-  # normally we'd just generate a <select>, but there are
-  # a _lot_ of options available, so we'll build a jquery-ui
-  # autocomplete + do some validation on the input afterwards.
-  def build_language_autocomplete(val)
-    label = language_label(val)
-    options = {
-      value: val,
-      name: "#{object_name}[#{attribute_name}_language][]",
-      class: 'form-control',
-      data: {
-        'autocomplete-url': '/authorities/search/language',
-        'autocomplete': 'language-label'
-      }
-    }
-
-    @builder.text_field("#{attribute_name}_language", options)
-  end
-
-  def language_label(key)
-    Spot::ISO6391.label_for(key.to_s)
-  end
-
-  def parse_value(raw)
-    return [raw.value, raw.language] if raw.is_a? RDF::Literal
-    return [raw, nil] if raw.present?
-    return [nil, nil]
+    build_field(value, nil)
   end
 end

--- a/app/inputs/language_tagged_input_group_input.rb
+++ b/app/inputs/language_tagged_input_group_input.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+#
+# This input is used for fields that will become language-tagged
+# rdf literals. Instead of solely a text input, we're rendering
+# _two_ inputs: one for the value and one for the language. These
+# are then merged in the form into a single RDF::Literal with
+# the language tagged.
+class LanguageTaggedInputGroupInput < MultiValueInput
+  def input_type
+    'multi_value'
+  end
+
+  private
+
+  def build_field(raw_value, index)
+    value, language = parse_value(raw_value)
+
+    <<-HTML
+    <div class="row form-inline">
+      <div class="form-group col-sm-10">
+        #{build_input(value, index)}
+      </div>
+      <div class="form-group col-sm-2">
+        #{build_language_autocomplete(language)}
+      </div>
+    </div>
+    HTML
+  end
+
+  def build_input(value, index)
+    # this is coming from MultiValueInput
+    options = build_field_options(value, index)
+
+    # convert name from 'publication[title][]' to 'publication[title_value][]'
+    options[:name] = options[:name].gsub(/\[([^\]]+)\]/, '[\1_value]')
+
+    if options.delete(:type) == 'textarea'
+      @builder.text_area(attribute_name, options)
+    else
+      @builder.text_field(attribute_name, options)
+    end
+  end
+
+  # normally we'd just generate a <select>, but there are
+  # a _lot_ of options available, so we'll build a jquery-ui
+  # autocomplete + do some validation on the input afterwards.
+  def build_language_autocomplete(val)
+    label = language_label(val)
+    options = {
+      value: val,
+      name: "#{object_name}[#{attribute_name}_language][]",
+      class: 'form-control',
+      data: {
+        'autocomplete-url': '/authorities/search/language',
+        'autocomplete': 'language-label'
+      }
+    }
+
+    @builder.text_field("#{attribute_name}_language", options)
+  end
+
+  def language_label(key)
+    Spot::ISO6391.label_for(key.to_s)
+  end
+
+  def parse_value(raw)
+    return [raw.value, raw.language] if raw.is_a? RDF::Literal
+    return [raw, nil] if raw.present?
+    return [nil, nil]
+  end
+end

--- a/app/inputs/language_tagged_multi_input_group_input.rb
+++ b/app/inputs/language_tagged_multi_input_group_input.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class LanguageTaggedMultiInputGroupInput < MultiValueInput
+  include LanguageTagging
+
+  def input_type
+    'multi_value language_tagged'
+  end
+end

--- a/app/inputs/language_tagged_multi_input_group_input.rb
+++ b/app/inputs/language_tagged_multi_input_group_input.rb
@@ -1,9 +1,34 @@
 # frozen_string_literal: true
-
+#
+# A +simple-form+ element that appends a autocomplete inputs
+# to tag the values in a certain language. This relies heavily
+# on the {LanguageTagging} mixin for the rendering.
+#
+# This input is used for multi-valued properties. For single inputs,
+# see {LanguageTaggedInputGroupInput}.
+#
+# @example
+#   <%# app/views/records/edit_fields/_subtitle.html.erb %>
+#   <%= f.input :subtitle, as: :language_tagged_multi_input_group %>
 class LanguageTaggedMultiInputGroupInput < MultiValueInput
   include LanguageTagging
 
+  # Appends 'language_tagged' to a default value. This provides us
+  # with a target for the jQuery. NOTE: changing this value may
+  # upset the JS; please be careful!
+  #
+  # @return [String]
   def input_type
     'multi_value language_tagged'
+  end
+
+  private
+
+  # Explicitly state that this is a multi-value property, rather than
+  # expecting this method to be defined in MultiValueInput
+  #
+  # @return [TrueClass]
+  def multiple?
+    true
   end
 end

--- a/app/inputs/local_controlled_vocabulary_input.rb
+++ b/app/inputs/local_controlled_vocabulary_input.rb
@@ -20,14 +20,27 @@
 #
 # Because this isn't a "traditional" nested_attributes case,
 # you'll have to add handling for this field within your
-# hydra-editor form.
+# hydra-editor form (see {NestedFormFields} concern).
 class LocalControlledVocabularyInput < ControlledVocabularyInput
+
+  # We want to piggy-back off the Hyrax ControlledVocabularyInput's
+  # Javascript goodness, so we stuff that value to give the js something
+  # to work with.
+  #
+  # @return [String]
   def input_type
     'controlled_vocabulary'
   end
 
   private
 
+  # Copied from {Hyrax::ControlledVocabularyInput}, but strips out
+  # any of the RDF-related work. This is called from
+  # {LocalControlledVocabularyInput#input}.
+  #
+  # @param [String] value
+  # @param [Integer] index
+  # @return [String] HTML of the input
   def build_field(value, index)
     options = input_html_options.dup
     build_options(value, index, options)
@@ -37,6 +50,13 @@ class LocalControlledVocabularyInput < ControlledVocabularyInput
     text_field(options) + hidden_id_field(value, index) + destroy_widget(attribute_name, index)
   end
 
+  # Builds out the options used to render the text field.
+  # Transforms the options object in place.
+  #
+  # @param [String] value
+  # @param [Integer] index
+  # @param [Hash] options dup'd from {LocalControlledVocabularyInput#input_html_options}
+  # @return [void]
   def build_options(value, index, options)
     options[:name] = name_for(attribute_name, index, 'hidden_label')
     options[:data] ||= {}
@@ -52,6 +72,12 @@ class LocalControlledVocabularyInput < ControlledVocabularyInput
     options[:'aria-labeledby'] = label_id
   end
 
+  # Builds the +<input type="hidden"/>+ element used to capture the
+  # ID from the js autocomplete widget.
+  #
+  # @param [String] value
+  # @param [Integer] index
+  # @return [String] HTML element
   def hidden_id_field(value, index)
     name = name_for(attribute_name, index, 'id')
     id = id_for(attribute_name, index, 'id')
@@ -63,6 +89,10 @@ class LocalControlledVocabularyInput < ControlledVocabularyInput
                           data: { id: 'remote' })
   end
 
+  # Builds out the values for our object and inserts an empty option at the end
+  #
+  # @todo why is this here? :sweat_smile:
+  # @return [Array<String>]
   def collection
     @collection ||= begin
                       val = object[attribute_name]

--- a/app/services/spot/mappers/newspaper_mapper.rb
+++ b/app/services/spot/mappers/newspaper_mapper.rb
@@ -5,21 +5,21 @@ module Spot::Mappers
     include NestedAttributes
 
     self.fields_map = {
-      description: 'dc:description',
       identifier: 'dc:identifier',
       keyword: 'dc:subject',
       physical_medium: 'dc:source',
       publisher: 'dc:publisher',
       resource_type: 'dc:type',
       rights_statement: 'dc:rights',
-      title: 'dc:title'
     }.freeze
 
     def fields
       super + %i[
         based_near_attributes
         date_issued
+        description
         rights_statement
+        title
       ]
     end
 
@@ -43,6 +43,13 @@ module Spot::Mappers
       end
     end
 
+    # @return [Array<RDF::Literal>]
+    def description
+      metadata['dc:description'].reject(&:blank?).map do |desc|
+        RDF::Literal(desc, language: :en)
+      end
+    end
+
     # @return [Array<String>]
     def rights_statement
       metadata['dc:rights'].map do |rights|
@@ -53,6 +60,11 @@ module Spot::Mappers
           rights
         end
       end
+    end
+
+    # @return [Array<RDF::Literal>]
+    def title
+      metadata['dc:title'].map { |title| RDF::Literal(title, language: :en) }
     end
   end
 end

--- a/app/services/spot/mappers/shakespeare_bulletin_mapper.rb
+++ b/app/services/spot/mappers/shakespeare_bulletin_mapper.rb
@@ -6,7 +6,6 @@ module Spot::Mappers
     self.fields_map = {
       publisher: 'originInfo_Publisher',
       source: 'relatedItem_typeHost_titleInfo_title',
-      subtitle: 'titleInfo_subTitle'
     }.freeze
 
     def fields
@@ -16,6 +15,7 @@ module Spot::Mappers
         date_issued
         editor
         identifier
+        subtitle
         title
       ]
     end
@@ -68,6 +68,13 @@ module Spot::Mappers
       end
     end
 
+    # @return [Array<RDF::Literal>]
+    def subtitle
+      metadata['titleInfo_subTitle'].reject(&:blank?).map do |subtitle|
+        RDF::Literal(subtitle, language: :en)
+      end
+    end
+
     # From our remediation notes:
     #
     #   Append <relatedItem_part1_date_qualifierApproximate>
@@ -77,7 +84,7 @@ module Spot::Mappers
     #     AND <relatedItem_part1_detail1_typeIssue_number>
     #     properties to title for Shakespeare Bulletin Collection.
     #
-    # @return [Array<String>]
+    # @return [Array<RDF::Literal>]
     def title
       base_title = metadata['titleInfo_Title'].first
       date_qualifier = metadata['relatedItem_part1_date_qualifierApproximate']
@@ -98,7 +105,9 @@ module Spot::Mappers
       parenthetical = "(#{date_qualifier.first})" unless date_qualifier.blank?
       volume_issue = "[#{volume_issue_block}]" unless volume_issue_block.blank?
 
-      [[base_title, parenthetical, volume_issue].reject(&:blank?).join(' ')]
+      joined = [base_title, parenthetical, volume_issue].reject(&:blank?).join(' ')
+
+      [RDF::Literal(joined, language: :en)]
     end
 
     private

--- a/app/views/records/edit_fields/_description.html.erb
+++ b/app/views/records/edit_fields/_description.html.erb
@@ -1,6 +1,6 @@
 <%=
-  f.input :abstract,
-          as: :language_tagged_input_group,
+  f.input :description,
+          as: :language_tagged_multi_input_group,
           input_html: {
             rows: '10',
             type: :textarea,

--- a/app/views/records/edit_fields/_subtitle.html.erb
+++ b/app/views/records/edit_fields/_subtitle.html.erb
@@ -1,0 +1,4 @@
+<%=
+  f.input :subtitle,
+          as: :language_tagged_multi_input_group
+%>

--- a/app/views/records/edit_fields/_title.html.erb
+++ b/app/views/records/edit_fields/_title.html.erb
@@ -1,0 +1,4 @@
+<%=
+  f.input :title,
+          as: :language_tagged_input_group
+%>

--- a/app/views/records/edit_fields/_title_alternative.html.erb
+++ b/app/views/records/edit_fields/_title_alternative.html.erb
@@ -1,0 +1,4 @@
+<%=
+  f.input :title_alternative,
+          as: :language_tagged_multi_input_group
+%>

--- a/spec/features/create_publication_spec.rb
+++ b/spec/features/create_publication_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'Create a Publication', :clean, :js do
         expect(page).to have_content "Add New #{i18n_term}"
 
         fill_in 'publication_title', with: attrs[:title].first
-        expect(page).to have_css '.publication_title .controls-add-text'
+        expect(page).not_to have_css '.publication_title .controls-add-text'
 
         fill_in 'Subtitle', with: attrs[:subtitle].first
         expect(page).to have_css '.publication_subtitle .controls-add-text'

--- a/spec/forms/hyrax/publication_form_spec.rb
+++ b/spec/forms/hyrax/publication_form_spec.rb
@@ -128,37 +128,20 @@ RSpec.describe Hyrax::PublicationForm do
     end
 
     context 'parses *_value and *_language into tagged RDF::Literals' do
-      context 'title' do
-        subject { attributes['title'] }
+      %w(title abstract).each do |field_name|
+        context field_name do
+          let(:field) { field_name }
 
-        let(:params) do
-          {
-            'title_value' => 'the Exorcist',
-            'title_language' => 'en'
-          }
+          it_behaves_like 'a parsed language-tagged literal (single)'
         end
-
-        it { is_expected.to eq [RDF::Literal('the Exorcist', language: :en)] }
       end
 
-      context 'title_alternative' do
-        subject { attributes['title_alternative'] }
+      %w(title_alternative subtitle description).each do |field_name|
+        context field_name do
+          let(:field) { field_name }
 
-        let(:params) do
-          {
-            'title_alternative_value' => ['Exorcist, the', 'L\'exorciste', ''],
-            'title_alternative_language' => ['', 'fr', '']
-          }
+          it_behaves_like 'a parsed language-tagged literal (multiple)'
         end
-
-        let(:tagged_literals) do
-          [
-            'Exorcist, the',
-            RDF::Literal("L'exorciste", language: :fr)
-          ]
-        end
-
-        it { is_expected.to eq tagged_literals }
       end
     end
   end

--- a/spec/forms/hyrax/publication_form_spec.rb
+++ b/spec/forms/hyrax/publication_form_spec.rb
@@ -72,8 +72,7 @@ RSpec.describe Hyrax::PublicationForm do
   describe '.build_permitted_params' do
     subject { described_class.build_permitted_params }
 
-    it { is_expected.to include({ identifier_prefix: [] }) }
-    it { is_expected.to include({ identifier_value: [] }) }
+    it { is_expected.to be_an Array }
   end
 
   describe '.model_attributes' do
@@ -125,6 +124,26 @@ RSpec.describe Hyrax::PublicationForm do
 
         it_behaves_like 'it transforms a local vocabulary attribute'
       end
+    end
+
+    context 'parses *_value and *_language into tagged RDF::Literals' do
+      subject { attributes['title'] }
+
+      let(:params) do
+        {
+          'title_value' => ["the Exorcist", 'L\'exorciste', ''],
+          'title_language' => ['', 'fr', '']
+        }
+      end
+
+      let(:tagged_literals) do
+        [
+          'the Exorcist',
+          RDF::Literal("L'exorciste", language: :fr),
+        ]
+      end
+
+      it { is_expected.to eq tagged_literals }
     end
   end
 end

--- a/spec/forms/hyrax/publication_form_spec.rb
+++ b/spec/forms/hyrax/publication_form_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe Hyrax::PublicationForm do
 
     let(:raw_params) { ActionController::Parameters.new(params) }
 
+
     context 'when passed identifier_prefix and identifier_value' do
       let(:params) do
         {

--- a/spec/forms/hyrax/publication_form_spec.rb
+++ b/spec/forms/hyrax/publication_form_spec.rb
@@ -128,23 +128,38 @@ RSpec.describe Hyrax::PublicationForm do
     end
 
     context 'parses *_value and *_language into tagged RDF::Literals' do
-      subject { attributes['title'] }
+      context 'title' do
+        subject { attributes['title'] }
 
-      let(:params) do
-        {
-          'title_value' => ["the Exorcist", 'L\'exorciste', ''],
-          'title_language' => ['', 'fr', '']
-        }
+        let(:params) do
+          {
+            'title_value' => 'the Exorcist',
+            'title_language' => 'en'
+          }
+        end
+
+        it { is_expected.to eq [RDF::Literal('the Exorcist', language: :en)] }
       end
 
-      let(:tagged_literals) do
-        [
-          'the Exorcist',
-          RDF::Literal("L'exorciste", language: :fr)
-        ]
-      end
+      context 'title_alternative' do
+        subject { attributes['title_alternative'] }
 
-      it { is_expected.to eq tagged_literals }
+        let(:params) do
+          {
+            'title_alternative_value' => ['Exorcist, the', 'L\'exorciste', ''],
+            'title_alternative_language' => ['', 'fr', '']
+          }
+        end
+
+        let(:tagged_literals) do
+          [
+            'Exorcist, the',
+            RDF::Literal("L'exorciste", language: :fr)
+          ]
+        end
+
+        it { is_expected.to eq tagged_literals }
+      end
     end
   end
 end

--- a/spec/forms/hyrax/publication_form_spec.rb
+++ b/spec/forms/hyrax/publication_form_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe Hyrax::PublicationForm do
       expect(form.multiple?('issued')).to be false
       expect(form.multiple?('available')).to be false
       expect(form.multiple?('date_created')).to be false
+      expect(form.multiple?('title')).to be false
     end
   end
 
@@ -139,7 +140,7 @@ RSpec.describe Hyrax::PublicationForm do
       let(:tagged_literals) do
         [
           'the Exorcist',
-          RDF::Literal("L'exorciste", language: :fr),
+          RDF::Literal("L'exorciste", language: :fr)
         ]
       end
 

--- a/spec/services/spot/mappers/magazine_mapper_spec.rb
+++ b/spec/services/spot/mappers/magazine_mapper_spec.rb
@@ -46,9 +46,10 @@ RSpec.describe Spot::Mappers::MagazineMapper do
   describe '#description' do
     subject { mapper.description }
 
-    let(:field) { 'TitleInfoPartNumber' }
+    let(:metadata) { {'TitleInfoPartNumber' => ['A description']} }
+    let(:value) { [RDF::Literal('A description', language: :en)] }
 
-    it_behaves_like 'a mapped field'
+    it { is_expected.to eq value }
   end
 
   describe '#identifier' do
@@ -110,8 +111,8 @@ RSpec.describe Spot::Mappers::MagazineMapper do
   describe '#subtitle' do
     subject { mapper.subtitle }
 
-    let(:metadata) { {'TitleInfoSubtitle' => value} }
-    let(:value) { ['A prestigious publication'] }
+    let(:metadata) { {'TitleInfoSubtitle' => ['A prestigious publication']} }
+    let(:value) { [RDF::Literal('A prestigious publication', language: :en)] }
 
     it { is_expected.to eq value }
   end
@@ -120,7 +121,7 @@ RSpec.describe Spot::Mappers::MagazineMapper do
     subject { mapper.title }
 
     context 'when `TitleInfoNonSort` exists' do
-      let(:value) { ['The Lafayette'] }
+      let(:value) { [RDF::Literal('The Lafayette', language: :en)] }
       let(:metadata) do
         {
           'TitleInfoNonSort' => ['The'],
@@ -132,7 +133,7 @@ RSpec.describe Spot::Mappers::MagazineMapper do
     end
 
     context 'when `TitleInfoNonSort` does not exist' do
-      let(:value) { ['Lafayette'] }
+      let(:value) { [RDF::Literal('Lafayette', language: :en)] }
       let(:metadata) do
         {
           'TitleInfoNonSort' => [],
@@ -144,7 +145,7 @@ RSpec.describe Spot::Mappers::MagazineMapper do
     end
 
     context 'when `PartDate_NaturalLanguage` is present' do
-      let(:value) { ['The Lafayette (November 1930)'] }
+      let(:value) { [RDF::Literal('The Lafayette (November 1930)', language: :en)] }
       let(:metadata) do
         {
           'TitleInfoNonSort' => ['The'],

--- a/spec/services/spot/mappers/newspaper_mapper_spec.rb
+++ b/spec/services/spot/mappers/newspaper_mapper_spec.rb
@@ -55,9 +55,10 @@ RSpec.describe Spot::Mappers::NewspaperMapper do
   describe '#description' do
     subject { mapper.description }
 
-    let(:field) { 'dc:description' }
+    let(:metadata) { { 'dc:description' => ['Some informative words'] } }
+    let(:value) { [RDF::Literal('Some informative words', language: :en)] }
 
-    it_behaves_like 'a mapped field'
+    it { is_expected.to eq value }
   end
 
   describe '#identifier' do
@@ -122,8 +123,9 @@ RSpec.describe Spot::Mappers::NewspaperMapper do
   describe '#title' do
     subject { mapper.title }
 
-    let(:field) { 'dc:title' }
+    let(:metadata) { { 'dc:title' => ['A modern masterpiece'] } }
+    let(:value) { [RDF::Literal('A modern masterpiece', language: :en)] }
 
-    it_behaves_like 'a mapped field'
+    it { is_expected.to eq value }
   end
 end

--- a/spec/services/spot/mappers/shakespeare_bulletin_mapper_spec.rb
+++ b/spec/services/spot/mappers/shakespeare_bulletin_mapper_spec.rb
@@ -74,10 +74,29 @@ RSpec.describe Spot::Mappers::ShakespeareBulletinMapper do
     it_behaves_like 'a mapped field'
   end
 
+  describe '#subtitle' do
+    subject { mapper.subtitle }
+
+    let(:metadata) do
+      {
+        'titleInfo_subTitle' => ['2 be or not 2 be']
+      }
+    end
+
+    let(:value) { [RDF::Literal('2 be or not 2 be', language: :en)] }
+
+    it { is_expected.to eq value }
+  end
+
   describe '#title' do
     subject { mapper.title }
 
-    let(:title) { ['Shakespeare Bulletin (May, 1983) [vol. 1, no. 11]']}
+    let(:title) do
+      [
+        RDF::Literal('Shakespeare Bulletin (May, 1983) [vol. 1, no. 11]', language: :en)
+      ]
+    end
+
     let(:metadata) do
       {
         'titleInfo_Title' => ['Shakespeare Bulletin'],
@@ -92,7 +111,7 @@ RSpec.describe Spot::Mappers::ShakespeareBulletinMapper do
     it { is_expected.to eq title }
 
     context 'when just a title exists' do
-      let(:title) { ['Shakespeare Bulletin'] }
+      let(:title) { [RDF::Literal('Shakespeare Bulletin', language: :en)] }
       let(:metadata) { {'titleInfo_Title' => ['Shakespeare Bulletin']} }
 
       it { is_expected.to eq title }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-ENV['RAILS_ENV'] ||= 'test'
+ENV['RAILS_ENV'] = 'test'
 
 require File.expand_path('../../config/environment', __FILE__)
 

--- a/spec/support/shared_examples/language_tagged_literal.rb
+++ b/spec/support/shared_examples/language_tagged_literal.rb
@@ -1,0 +1,42 @@
+# can shared examples be nested? it feels redundant to have these
+# two split when the only difference is the +:params+ hash.
+
+shared_examples 'a parsed language-tagged literal (single)' do
+  subject { attributes[field] }
+
+  let(:params) do
+    {
+      "#{field}_value" => 'Terminator 2: Judgement Day',
+      "#{field}_language" => 'en'
+    }
+  end
+
+  let(:tagged_literals) do
+    [
+      RDF::Literal('Terminator 2: Judgement Day', language: :en)
+    ]
+  end
+
+  it { is_expected.to eq tagged_literals }
+end
+
+
+shared_examples 'a parsed language-tagged literal (multiple)' do
+  subject { attributes[field] }
+
+  let(:params) do
+    {
+      "#{field}_value" => ['Exorcist, the', 'L\'exorciste', ''],
+      "#{field}_language" => ['', 'fr', '']
+    }
+  end
+
+  let(:tagged_literals) do
+    [
+      'Exorcist, the',
+      RDF::Literal('L\'exorciste', language: :fr)
+    ]
+  end
+
+  it { is_expected.to eq tagged_literals }
+end


### PR DESCRIPTION
This doesn't directly affect the Publication model as much as the forthcoming Image/ScannedResource one, but to prepare for that we want to add the ability to language-tag free-text fields where necessary. 

In current metadata, we have fields such as `title_english`, `title_japanese`, `description_korean` (etc) for our scanned items (see: East Asia Image Collection) and we would like to retain this granularity. Using RDF language-tagged literals seems the best way to capture this. To accomplish this, we'll need to add form support as well as batch ingest support (and, if we're feeling limber, some kind of UI support, though that can get punted 'til later).

I'm trying to do this in a reusable way so that later integration with the Image work type won't require a lot of heavy lifting.

## Publication properties targeted:

- [x] title
- [x] subtitle
- [x] title_alternative
- [x] abstract
- [x] description

## to-do

- [x] form submission handling
- [x] input type for singular fields
- [x] input type for multi fields
- [x] add tagging to mappers
  - [x] lafayette newspaper
  - [x] lafayette magazine
  - [x] shakespeare bulletin
  - (skipping faculty publications as they're not all English-language titles)
- [x] add placeholder text for inputs
- [ ] ~fix styling warp when new rows are added~ (i _think_ this is a problem at the bootstrap layer. see #92)
- [x] can we do anything about making the language input a bit bigger? adding a label?

closes #79 