### PR TITLE
fix factory_bot deprecations

### DIFF
--- a/spec/factories/hyrax_uploaded_files.rb
+++ b/spec/factories/hyrax_uploaded_files.rb
@@ -6,11 +6,11 @@
 FactoryBot.define do
   factory :uploaded_pdf, class: Hyrax::UploadedFile do
     user
-    file File.open('spec/fixtures/document.pdf')
+    file { File.open('spec/fixtures/document.pdf') }
   end
 
   factory :uploaded_image, class: Hyrax::UploadedFile do
     user
-    file File.open('spec/fixtures/image.png')
+    file { File.open('spec/fixtures/image.png') }
   end
 end

--- a/spec/factories/publication.rb
+++ b/spec/factories/publication.rb
@@ -2,43 +2,43 @@
 
 FactoryBot.define do
   factory :publication do
-    abstract ['A short description of the thing']
-    academic_department ['Art']
-    based_near []
-    bibliographic_citation ['Lastname, First. Title of piece.']
-    contributor ['Contributor, First-Name', 'Person, Another']
-    creator ['Creator, First-Name']
-    date_issued ['1986-02-11']
-    date_available ['2018-08-24']
-    description ['A description describes a thing', 'it contains multitudes']
-    division ['Humanities']
-    editor ['Sweeney, Mary']
-    identifier ['hdl:123/456', 'doi:00.000/00000']
-    keyword ['test', 'item', 'topic']
-    language ['en']
-    organization ['Lafayette College']
-    publisher ['Prestigious Press', 'Lafayette College']
-    resource_type ['Article']
-    rights_statement []
-    related_resource ['http://cool-resource.org']
-    source ['Lafayette College', '_The_ Source for Good Publications']
-    subject ['Cheese - Other']
-    subtitle ['An exploration']
-    title ['A Prestigious Publication']
-    title_alternative ['A Pretty Popular Publication']
+    abstract { ['A short description of the thing'] }
+    academic_department { ['Art'] }
+    based_near { [] }
+    bibliographic_citation { ['Lastname, First. Title of piece.'] }
+    contributor { ['Contributor, First-Name', 'Person, Another'] }
+    creator { ['Creator, First-Name'] }
+    date_issued { ['1986-02-11'] }
+    date_available { ['2018-08-24'] }
+    description { ['A description describes a thing', 'it contains multitudes'] }
+    division { ['Humanities'] }
+    editor { ['Sweeney, Mary'] }
+    identifier { ['hdl:123/456', 'doi:00.000/00000'] }
+    keyword { ['test', 'item', 'topic'] }
+    language { ['en'] }
+    organization { ['Lafayette College'] }
+    publisher { ['Prestigious Press', 'Lafayette College'] }
+    resource_type { ['Article'] }
+    rights_statement { [] }
+    related_resource { ['http://cool-resource.org'] }
+    source { ['Lafayette College', '_The_ Source for Good Publications'] }
+    subject { ['Cheese - Other'] }
+    subtitle { ['An exploration'] }
+    title { ['A Prestigious Publication'] }
+    title_alternative { ['A Pretty Popular Publication'] }
 
-    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
 
     trait :public do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
     trait :authenticated do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
     end
 
     trait :private do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     transient do

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -3,11 +3,11 @@ FactoryBot.define do
     email { FFaker::Internet.unique.email }
     password { FFaker::Internet.password }
     display_name { "#{FFaker::Name.last_name}, #{FFaker::Name.first_name}" }
-    guest false
-    roles []
+    guest { false }
+    roles { [] }
 
     factory :guest_user do
-      guest true
+      guest { true }
     end
 
     factory :admin_user do


### PR DESCRIPTION
updates factories to use dynamic attributes. addresses the following deprecation:

> DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
> attributes instead by wrapping the attribute value in a block.