### PR TITLE
integrate hound-ci

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,9 @@
+# TODO: lint *.scss and *.js when we get to the UI sprint
+scss:
+  enabled: false
+
+jshint:
+  enabled: false
+
+rubocop:
+  config_file: .rubocop.yml

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -4,15 +4,12 @@ unless Rails.env.production?
   require 'active_fedora/rake_support'
   require 'rubocop/rake_task'
 
-  # borrowing from the Hyrax rubocop task
   desc 'run code-style checker (+ fail on errors)'
-  RuboCop::RakeTask.new(:rubocop_ci) do |task|
-    task.fail_on_error = true
-  end
+  RuboCop::RakeTask.new(:rubocop)
 
   namespace :spot do
     desc 'run tests in ci setting'
-    task ci: [:rubocop_ci, 'spot:spec_with_server']
+    task ci: ['spot:spec_with_server']
 
     task :spec_with_server do
       with_server 'test' do


### PR DESCRIPTION
- enables hound-ci integration
- removes rubocop from `spot:ci` task (ci won't fail if there's style issues, hound will leave a comment instead)