### PR TITLE
Parse date_uploaded from newspapers

### DIFF
--- a/app/actors/hyrax/actors/publication_actor.rb
+++ b/app/actors/hyrax/actors/publication_actor.rb
@@ -2,6 +2,39 @@
 module Hyrax
   module Actors
     class PublicationActor < Hyrax::Actors::BaseActor
+      private
+
+        # Overrides the BaseActor method to allow us to stuff in
+        # `date_uploaded` values where necessary.
+        #
+        # @return [void]
+        def apply_deposit_date(env)
+          return super unless date_uploaded_present?(env)
+          env.curation_concern.date_uploaded = get_date_uploaded_value(env)
+        end
+
+        # @param [Hyrax::Actors::Environment] env
+        # @return [true, false]
+        def date_uploaded_present?(env)
+          env.attributes[:date_uploaded].present? || env.curation_concern.date_uploaded.present?
+        end
+
+        # @param [Hyrax::Actors::Environment] env
+        # @return [DateTime]
+        def get_date_uploaded_value(env)
+          concern = env.curation_concern
+
+          if concern.date_uploaded.present?
+            # calling `#to_s` allows us to recycle a previous Time value
+            # or use a string attached to the model (not recommended!)
+            DateTime.parse(concern.date_uploaded.to_s).utc
+          elsif env.attributes[:date_uploaded].present?
+            DateTime.parse(env.attributes[:date_uploaded]).utc
+          else
+            # Probably unnecessary but I don't want to leave any mystery
+            TimeService.time_in_utc
+          end
+        end
     end
   end
 end

--- a/app/services/spot/mappers/newspaper_mapper.rb
+++ b/app/services/spot/mappers/newspaper_mapper.rb
@@ -2,9 +2,13 @@
 #
 # Metadata mapper for the Lafayette newspaper archive collection.
 # See {Spot::Mappers::BaseMapper} for usage information.
+require 'date'
+
 module Spot::Mappers
   class NewspaperMapper < BaseMapper
     include NestedAttributes
+
+    MAGIC_DATE_UPLOADED = '2010-09-16T00:00:00Z'
 
     self.fields_map = {
       identifier: 'dc:identifier',
@@ -21,6 +25,7 @@ module Spot::Mappers
     def fields
       super + %i[
         based_near_attributes
+        date_available
         date_issued
         description
         rights_statement
@@ -41,9 +46,14 @@ module Spot::Mappers
       end
     end
 
+    # @return [DateTime] The original date uploaded (when present)
+    def date_uploaded
+      MAGIC_DATE_UPLOADED if metadata['dc:date'].include? MAGIC_DATE_UPLOADED
+    end
+
     # @return [Array<String>] the date in YYYY-MM-DD format
     def date_issued
-      metadata['dc:date'].map do |raw_date|
+      (metadata['dc:date'] - [MAGIC_DATE_UPLOADED]).map do |raw_date|
         Date.parse(raw_date).strftime('%Y-%m-%d')
       end
     end

--- a/spec/actors/hyrax/actors/publication_actor_spec.rb
+++ b/spec/actors/hyrax/actors/publication_actor_spec.rb
@@ -1,6 +1,54 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Actors::PublicationActor do
-  it "has tests" do
-    skip "Add your tests here"
+  let(:actor) { described_class.new(Hyrax::Actors::Terminator.new) }
+
+  # thumbs-down to testing a private method, but this is (currently) the only
+  # thing we've changed in PublicationActor
+  describe '#apply_deposit_date' do
+    subject(:apply_date) { actor.send(:apply_deposit_date, env) }
+
+    let(:work) { Publication.new }
+    let(:user) { build(:user) }
+    let(:ability) { Ability.new(user) }
+    let(:attributes) { {} }
+    let(:env) { Hyrax::Actors::Environment.new(work, ability, attributes) }
+    let(:date_uploaded) { '2018-01-08T00:00:00Z' }
+
+    context 'when no date_uploaded value is provided' do
+      before do
+        allow(Hyrax::TimeService).to receive(:time_in_utc).and_return(time_value)
+      end
+
+      let(:time_value) { DateTime.now.utc }
+
+      it 'sets the date to TimeService.time_in_utc' do
+        expect { apply_date }
+          .to change { work.date_uploaded }
+          .from(nil)
+          .to(time_value)
+      end
+    end
+
+    context 'when a date_uploaded is provided to the attributes' do
+      let(:attributes) { { date_uploaded: date_uploaded } }
+
+      it 'sets the date_uploaded of the work to a DateTime of the value' do
+        expect { apply_date }
+          .to change { work.date_uploaded }
+          .from(nil)
+          .to(DateTime.parse(date_uploaded).utc)
+      end
+    end
+
+    context 'when a date_uploaded value is present on the work' do
+      let(:work) { Publication.new(date_uploaded: date_uploaded) }
+
+      it 'ensures the value is a DateTime' do
+        expect { apply_date }
+          .to change { work.date_uploaded }
+          .from(date_uploaded)
+          .to(DateTime.parse(date_uploaded).utc)
+      end
+    end
   end
 end

--- a/spec/services/spot/mappers/newspaper_mapper_spec.rb
+++ b/spec/services/spot/mappers/newspaper_mapper_spec.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'date'
+
 RSpec.describe Spot::Mappers::NewspaperMapper do
   let(:mapper) { described_class.new }
   let(:metadata) { {} }
@@ -51,6 +53,44 @@ RSpec.describe Spot::Mappers::NewspaperMapper do
     end
 
     it { is_expected.to eq value }
+
+    context 'when the MAGIC_DATE_UPLOADED is present' do
+      let(:magic_date) { described_class::MAGIC_DATE_UPLOADED }
+      let(:metadata) do
+        {
+          'dc:date' => [
+            '2019-01-08T00:00:00Z',
+            magic_date
+          ]
+        }
+      end
+
+      it { is_expected.to eq ['2019-01-08'] }
+    end
+  end
+
+  describe '#date_uploaded' do
+    subject { mapper.date_uploaded }
+
+    context "when the MAGIC_DATE_UPLOADED isn't present" do
+      let(:metadata) { { 'dc:date' => ['2019-01-08T00:00:00Z'] } }
+
+      it { is_expected.to be nil }
+    end
+
+    context 'when the MAGIC_DATE_UPLOADED is present' do
+      let(:magic_date) { described_class::MAGIC_DATE_UPLOADED }
+      let(:metadata) do
+        {
+          'dc:date' => [
+            '2019-01-08T00:00:00Z',
+            magic_date
+          ]
+        }
+      end
+
+      it { is_expected.to eq magic_date }
+    end
   end
 
   describe '#description' do


### PR DESCRIPTION
A small subset of our Newspaper collection have two values for `dc:date`: one that will map to `Publication#date_issued` and one that indicates the date of previous ingestion. As it turns out, there's no way to set this value with attributes in the ActorStack (in stock Hyrax): the `BaseActor` class sets the value to the current time in UTC on `create` (see: [base_actor.rb#L63-L65]).

This updates the `PublicationActor` to allow a value to be passed via attributes.

Note: we'll probably need to move this to a concern for other work types that have a previous ingest date.

closes #103 

[base_actor.rb#L63-L65]: https://github.com/samvera/hyrax/blob/199b159/app/actors/hyrax/actors/base_actor.rb#L63-L65