### PR TITLE
fix solr >=7.2.0 bug in identifier_controller

### DIFF
--- a/app/controllers/identifier_controller.rb
+++ b/app/controllers/identifier_controller.rb
@@ -62,6 +62,9 @@ class IdentifierController < ApplicationController
     # @param id [Spot::Identifier, #to_s] the identifier (with prefix)
     # @return [Hash<Symbol => String>]
     def query_for_identifier(id)
-      { q: "{!terms f=#{identifier_solr_field}}#{id}" }
+      {
+        q: "{!terms f=#{identifier_solr_field}}#{id}",
+        defType: 'lucene'
+      }
     end
 end


### PR DESCRIPTION
fixes a bug we were encountering where the `IdentifierController` spec was failing because we weren't specifying the `lucene` parser when querying the identifiers.

see: https://lucene.apache.org/solr/7_2_0/changes/Changes.html#v7.2.0.upgrade_notes