### PR TITLE
parse language from ldr title

### DIFF
--- a/app/services/spot/mappers/ldr_dspace_mapper.rb
+++ b/app/services/spot/mappers/ldr_dspace_mapper.rb
@@ -132,9 +132,15 @@ module Spot::Mappers
       []
     end
 
-    # @return [Array<String>]
+    # LDR titles are appended with `_<en>` (or whatever 2-letter language code
+    # necessary), so we'll strip those out and use them in the RDF::Literal we return.
+    #
+    # @return [Array<RDF::Literal>]
     def title
-      singularize_field('title')
+      singularize_field('title').map do |title|
+        next RDF::Literal.new(title) unless (m = title.match(/_<(\w\w)>$/))
+        RDF::Literal.new(title.gsub(m[0], ''), language: m[1].to_sym)
+      end
     end
 
     private

--- a/spec/services/spot/mappers/ldr_dspace_mapper_spec.rb
+++ b/spec/services/spot/mappers/ldr_dspace_mapper_spec.rb
@@ -259,9 +259,17 @@ RSpec.describe Spot::Mappers::LdrDspaceMapper do
 
     context 'when a semicolon was originally present' do
       let(:original_value) { ['first;second'] }
+      let(:expected_value) { original_value.map { |v| RDF::Literal.new(v) } }
       let(:value) { original_value.first.split(';') }
 
-      it { is_expected.to eq original_value }
+      it { is_expected.to eq expected_value }
+    end
+
+    context 'when a value has a language tag attached' do
+      let(:value) { ['Une bonne chose_<fr>'] }
+      let(:expected_value) { [RDF::Literal.new('Une bonne chose', language: :fr)] }
+
+      it { is_expected.to eq expected_value }
     end
   end
 


### PR DESCRIPTION
so that 

```
A very good title_<en>
```

becomes

```ruby
RDF::Literal.new('A very good title', language: :en)
```

closes #112 