### PR TITLE
transform literals from form in the actor rather than the form

### DIFF
--- a/app/actors/concerns/deserializes_rdf_literals.rb
+++ b/app/actors/concerns/deserializes_rdf_literals.rb
@@ -1,12 +1,57 @@
 # frozen_string_literal: true
+#
+# Concern to allow us to pass around RDF values within jobs and have
+# them be applied to work objects as +RDF::Literal+s For this to work
+# properly, you'll have to make sure this syncs up with the Form object
+# for the corresponding work model.
+#
+# @example
+#   # app/models/work_type.rb
+#   class WorkType < ActiveFedora::Base
+#     property :title, predicate: ::RDF::Vocab::DC.title, multiple: false
+#     property :description, predicate: ::RDF::Vocab::DC.description
+#   end
+#
+#   # app/forms/hyrax/work_type_form.rb
+#   module Hyrax
+#     class WorkTypeForm < Hyrax::Forms::WorkForm
+#       include ::LanguageTaggedFormFields
+#       transforms_language_tags_for :title, :description
+#     end
+#   end
+#
+#   # app/actors/work_type_actor.rb
+#   class WorkTypeActor < Hyrax::Actors::BaseActor
+#     include ::DeserializesRdfLiterals
+#   end
+#
+# This mixin calls the singleton method +.language_tagged_fields+, which
+# is defined by {LanguageTaggedForm.transforms_language_tags_for}, to
+# know what fields to transform -- otherwise we'd have to loop through
+# _all_ of the fields and that seemed like more overhead.
+#
+# Note that this is required because the actor stack followed by a form
+# submission differs from the one followed by a command-line ingest task.
+# Also note that Rails edge (> 5.2, == 6?) adds the ability to define
+# serializers for jobs, which would make this convoluted mess unnecessary.
 module DeserializesRdfLiterals
   extend ActiveSupport::Concern
 
+  # We want our deserialization to happen _before_ the other jobs in the
+  # work actor, as we're changing the +env.curation_concern+ and +env.attributes+.
+  #
+  # @param env [Hyrax::Actors::Environment]
+  # @return [void]
   def create(env)
     deserialize_rdf_literals!(env)
     super
   end
 
+  # We want our deserialization to happen _before_ the other jobs in the
+  # work actor, as we're changing the +env.curation_concern+ and +env.attributes+.
+  #
+  # @param env [Hyrax::Actors::Environment]
+  # @return [void]
   def update(env)
     deserialize_rdf_literals!(env)
     super
@@ -14,34 +59,55 @@ module DeserializesRdfLiterals
 
   private
 
+    # Sets the tagged fields of +env.curation_concern+ with transformed
+    # literal values.
+    #
+    # @param env [Hyrax::Actors::Environment]
+    # @return [void]
     def deserialize_rdf_literals!(env)
       tagged_fields.each do |field|
         env.curation_concern[field] = value_for(field, env)
       end
     end
 
+    # Fetches the value for +field+. handles whether or not to return
+    # an array or single object based on whether or not the +env.attributes[field]+
+    # is an array or not.
+    #
+    # @param field [String,Symbol] the attributes field to fetch
+    # @param env [Hyrax::Actors::Environment]
+    # @return [RDF::Literal,Array<RDF::Literal>]
     def value_for(field, env)
-      if env.attributes[field].is_a? Array
-        env.attributes[field].map { |val| deserialize(val) }
-      else
-        deserialize(env.attributes[field])
-      end
+      raw = env.attributes.delete(field)
+      raw.is_a?(Array) ? raw.map { |val| deserialize(val) } : deserialize(raw)
     end
 
+    # @return [RDF::Literal]
     def deserialize(value)
       serializer.deserialize(value) || value
     end
 
+    # @return [RdfLiteralSerializer]
     def serializer
       @serializer ||= RdfLiteralSerializer.new
     end
 
+    # Fetches contents of the +language_tagged_fields+ singleton method defined
+    # by {LanguageTaggedForm.transforms_language_tags_for}. in the event that
+    # the class method was never called to define the fields, we fall back to
+    # an empty array
+    #
+    # @return [Array<Symbol>]
     def tagged_fields
       work_form.language_tagged_fields
     rescue NoMethodError
       []
     end
 
+    # Does the work of +Hyrax::WorkFormService.form_class+ but via self vs a passed-through
+    # work object
+    #
+    # @return [Hyrax::Forms::WorkForm]
     def work_form
       @work_form ||= begin
         klass = self.class.name.split('::').last.gsub(/Actor$/, '')

--- a/app/actors/concerns/deserializes_rdf_literals.rb
+++ b/app/actors/concerns/deserializes_rdf_literals.rb
@@ -35,8 +35,6 @@
 # Also note that Rails edge (> 5.2, == 6?) adds the ability to define
 # serializers for jobs, which would make this convoluted mess unnecessary.
 module DeserializesRdfLiterals
-  extend ActiveSupport::Concern
-
   # We want our deserialization to happen _before_ the other jobs in the
   # work actor, as we're changing the +env.curation_concern+ and +env.attributes+.
   #
@@ -59,14 +57,14 @@ module DeserializesRdfLiterals
 
   private
 
-    # Sets the tagged fields of +env.curation_concern+ with transformed
-    # literal values.
+    # Sets the tagged fields of +env.attributes+ with transformed
+    # literal values unless that field is empty
     #
     # @param env [Hyrax::Actors::Environment]
     # @return [void]
     def deserialize_rdf_literals!(env)
       tagged_fields.each do |field|
-        env.curation_concern[field] = value_for(field, env)
+        env.attributes[field] = value_for(field, env) if env.attributes[field]
       end
     end
 

--- a/app/actors/concerns/deserializes_rdf_literals.rb
+++ b/app/actors/concerns/deserializes_rdf_literals.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+module DeserializesRdfLiterals
+  extend ActiveSupport::Concern
+
+  def create(env)
+    deserialize_rdf_literals!(env)
+    super
+  end
+
+  def update(env)
+    deserialize_rdf_literals!(env)
+    super
+  end
+
+  private
+
+    def deserialize_rdf_literals!(env)
+      tagged_fields.each do |field|
+        env.curation_concern[field] = value_for(field, env)
+      end
+    end
+
+    def value_for(field, env)
+      if env.attributes[field].is_a? Array
+        env.attributes[field].map { |val| deserialize(val) }
+      else
+        deserialize(env.attributes[field])
+      end
+    end
+
+    def deserialize(value)
+      serializer.deserialize(value) || value
+    end
+
+    def serializer
+      @serializer ||= RdfLiteralSerializer.new
+    end
+
+    def tagged_fields
+      work_form.language_tagged_fields
+    rescue NoMethodError
+      []
+    end
+
+    def work_form
+      @work_form ||= begin
+        klass = self.class.name.split('::').last.gsub(/Actor$/, '')
+        Hyrax.const_get("#{klass}Form")
+      end
+    end
+end

--- a/app/actors/hyrax/actors/publication_actor.rb
+++ b/app/actors/hyrax/actors/publication_actor.rb
@@ -2,6 +2,8 @@
 module Hyrax
   module Actors
     class PublicationActor < Hyrax::Actors::BaseActor
+      include ::DeserializesRdfLiterals
+
       private
 
         # Overrides the BaseActor method to allow us to stuff in

--- a/app/forms/concerns/language_tagged_form_fields.rb
+++ b/app/forms/concerns/language_tagged_form_fields.rb
@@ -22,7 +22,7 @@ module LanguageTaggedFormFields
     #
     # @todo is there a better way to do this? my meta-programming naivity
     #       might be showing?
-    # @param [Array<Symbol>] *fields The fields to transform
+    # @param *fields [Array<Symbol>] The fields to transform
     # @return [void]
     def transforms_language_tags_for(*fields)
       define_singleton_method(:language_tagged_fields) { fields.flatten }
@@ -54,7 +54,7 @@ module LanguageTaggedFormFields
     # Calls our transformation method as part of the chain of
     # {.model_attributes} calls.
     #
-    # @param [ActiveController::Parameters, Hash<String => *>]
+    # @param form_params [ActiveController::Parameters, Hash<String => *>]
     # @return [Hash]
     def model_attributes(form_params)
       super.tap do |params|
@@ -64,10 +64,10 @@ module LanguageTaggedFormFields
 
     private
 
-      # transforms arrays of field values + languages into RDF::Literals
+      # transforms arrays of field values + languages into serialized RDF::Literals
       # tagged with said language
       #
-      # @param [ActiveController::Parameters, Hash<String => Array<String>>] params
+      # @param params [ActiveController::Parameters, Hash<String => Array<String>>]
       # @return [void]
       def transform_language_tagged_fields!(params)
         language_tagged_fields.flatten.each do |field|
@@ -86,10 +86,10 @@ module LanguageTaggedFormFields
         end
       end
 
-      # Transforms an array of value/language pairs into Literals or values
+      # Transforms an array of value/language pairs into serialized literals
       #
-      # @param [Array<Array<String>>] tuples
-      # @return [Array<RDF::Literal, String>]
+      # @param tuples [Array<Array<String>>]
+      # @return [Array<String>]
       def map_rdf_strings(tuples)
         tuples.map do |(value, language)|
           # need to skip blank entries here, otherwise we get a blank literal
@@ -101,6 +101,7 @@ module LanguageTaggedFormFields
         end.reject(&:blank?)
       end
 
+      # @return [RdfLiteralSerializer]
       def serializer
         @serializer ||= RdfLiteralSerializer.new
       end

--- a/app/services/rdf_literal_serializer.rb
+++ b/app/services/rdf_literal_serializer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'rdf/ntriples'
+
+class RdfLiteralSerializer
+  # @return [String]
+  def serialize(literal)
+    writer.format_literal(literal)
+  end
+
+  # @return [RDF::Literal]
+  def deserialize(string)
+    reader.parse_literal(string)
+  end
+
+  private
+
+    # @return [Symbol]
+    def type
+      :ntriples
+    end
+
+    # @return [RDF::Reader]
+    def reader
+      @reader ||= RDF::Reader.for(type)
+    end
+
+    # @return [RDF::Writer]
+    def writer
+      @writer ||= RDF::Writer.for(type).new
+    end
+end

--- a/spec/actors/concerns/deserializes_rdf_literals_spec.rb
+++ b/spec/actors/concerns/deserializes_rdf_literals_spec.rb
@@ -38,13 +38,20 @@ RSpec.describe DeserializesRdfLiterals do
     }
   end
 
+  let(:literal_attributes) do
+    {
+      title: RDF::Literal('Cool Beans', language: :en),
+      description: [RDF::Literal('A work of importance')]
+    }
+  end
+
   shared_examples 'it transforms fields' do
     it 'transforms single fields' do
-      expect(work.title).to eq RDF::Literal('Cool Beans', language: :en)
+      expect(env.attributes[:title]).to eq RDF::Literal('Cool Beans', language: :en)
     end
 
     it 'transforms multiple fields' do
-      expect(work.description).to eq [RDF::Literal('A work of importance')]
+      expect(env.attributes[:description]).to eq [RDF::Literal('A work of importance')]
     end
   end
 
@@ -54,12 +61,7 @@ RSpec.describe DeserializesRdfLiterals do
     it_behaves_like 'it transforms fields'
 
     context 'when attributes are already RDF::Literals (from ingest)' do
-      let(:attributes) do
-        {
-          title: RDF::Literal('Cool Beans', language: :en),
-          description: [RDF::Literal('A work of importance')]
-        }
-      end
+      let(:attributes) { literal_attributes }
 
       it_behaves_like 'it transforms fields'
     end
@@ -71,12 +73,7 @@ RSpec.describe DeserializesRdfLiterals do
     it_behaves_like 'it transforms fields'
 
     context 'when attributes are already RDF::Literals (from ingest)' do
-      let(:attributes) do
-        {
-          title: RDF::Literal('Cool Beans', language: :en),
-          description: [RDF::Literal('A work of importance')]
-        }
-      end
+      let(:attributes) { literal_attributes }
 
       it_behaves_like 'it transforms fields'
     end

--- a/spec/actors/concerns/deserializes_rdf_literals_spec.rb
+++ b/spec/actors/concerns/deserializes_rdf_literals_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+RSpec.describe DeserializesRdfLiterals do
+  before do
+    class WorkType < ActiveFedora::Base
+      property :title, predicate: ::RDF::Vocab::DC.title, multiple: false
+      property :description, predicate: ::RDF::Vocab::DC.description
+    end
+
+    # need to define this to be able to access the `language_tagged_fields` array
+    class Hyrax::WorkTypeForm < Hyrax::Forms::WorkForm
+      include LanguageTaggedFormFields
+      transforms_language_tags_for :title, :description
+    end
+
+    class WorkTypeActor < Hyrax::Actors::AbstractActor
+      include DeserializesRdfLiterals
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :WorkType)
+    Object.send(:remove_const, :WorkTypeActor)
+    Hyrax.send(:remove_const, :WorkTypeForm)
+  end
+
+  let(:work) { WorkType.new }
+  let(:ability) { Ability.new(build(:user)) }
+  let(:attributes) { {} }
+  let(:env) { Hyrax::Actors::Environment.new(work, ability, attributes) }
+  let(:actor) { WorkTypeActor.new(Hyrax::Actors::Terminator.new) }
+
+  # when the actor receives the form attributes, it should have already
+  # been run through the serializer
+  let(:attributes) do
+    {
+      title: '"Cool Beans"@en',
+      description: ['"A work of importance"']
+    }
+  end
+
+  shared_examples 'it transforms fields' do
+    it 'transforms single fields' do
+      expect(work.title).to eq RDF::Literal('Cool Beans', language: :en)
+    end
+
+    it 'transforms multiple fields' do
+      expect(work.description).to eq [RDF::Literal('A work of importance')]
+    end
+  end
+
+  describe '#create' do
+    before { actor.create(env) }
+
+    it_behaves_like 'it transforms fields'
+
+    context 'when attributes are already RDF::Literals (from ingest)' do
+      let(:attributes) do
+        {
+          title: RDF::Literal('Cool Beans', language: :en),
+          description: [RDF::Literal('A work of importance')]
+        }
+      end
+
+      it_behaves_like 'it transforms fields'
+    end
+  end
+
+  describe '#update' do
+    before { actor.update(env) }
+
+    it_behaves_like 'it transforms fields'
+
+    context 'when attributes are already RDF::Literals (from ingest)' do
+      let(:attributes) do
+        {
+          title: RDF::Literal('Cool Beans', language: :en),
+          description: [RDF::Literal('A work of importance')]
+        }
+      end
+
+      it_behaves_like 'it transforms fields'
+    end
+  end
+end

--- a/spec/features/spot_workflow_spec.rb
+++ b/spec/features/spot_workflow_spec.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 #
 # rubocop:disable RSpec/InstanceVariable
-require 'rails_helper'
-include Warden::Test::Helpers
-
 RSpec.feature 'SPOT one step workflow', :perform_jobs, :clean, :js do
   let(:depositing_user) { FactoryBot.create(:user) }
   let(:admin_user) { FactoryBot.create(:admin_user) }

--- a/spec/services/rdf_literal_serializer_spec.rb
+++ b/spec/services/rdf_literal_serializer_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+RSpec.describe RdfLiteralSerializer do
+  let(:serializer) { described_class.new }
+
+  describe '#deserialize' do
+    subject { serializer.deserialize(value) }
+
+    let(:value) { '"Cool Beans"' }
+
+    it { is_expected.to eq RDF::Literal('Cool Beans') }
+
+    context 'when it has a language' do
+      let(:value) { '"Cool Beans"@en' }
+
+      it { is_expected.to eq RDF::Literal('Cool Beans', language: :en) }
+    end
+  end
+
+  describe '#serialize' do
+    subject { serializer.serialize(value) }
+
+    context 'when it is an RDF::Literal' do
+      let(:value) { RDF::Literal('Cool Beans', language: :en) }
+
+      it { is_expected.to eq '"Cool Beans"@en' }
+    end
+
+    context 'when it is not an RDF::Literal' do
+      let(:value) { 'Uh oh' }
+
+      it { is_expected.to eq '"Uh oh"' }
+    end
+  end
+end

--- a/spec/support/shared_examples/language_tagged_literal.rb
+++ b/spec/support/shared_examples/language_tagged_literal.rb
@@ -12,13 +12,7 @@ shared_examples 'a parsed language-tagged literal (single)' do
     }
   end
 
-  let(:tagged_literals) do
-    [
-      RDF::Literal('Terminator 2: Judgement Day', language: :en)
-    ]
-  end
-
-  it { is_expected.to eq tagged_literals }
+  it { is_expected.to eq ['"Terminator 2: Judgement Day"@en'] }
 end
 
 shared_examples 'a parsed language-tagged literal (multiple)' do
@@ -32,10 +26,7 @@ shared_examples 'a parsed language-tagged literal (multiple)' do
   end
 
   let(:tagged_literals) do
-    [
-      'Exorcist, the',
-      RDF::Literal('L\'exorciste', language: :fr)
-    ]
+    ['"Exorcist, the"', '"L\'exorciste"@fr']
   end
 
   it { is_expected.to eq tagged_literals }


### PR DESCRIPTION
moves the transformation of language-tagged values out of the form and into the actor, via a concern.

ran into this while submitting/updating an item via the form, rather than batch ingest. `Hyrax::Actors::CreateWithFilesActor#attach_files` chokes on serializing the form attributes for `AttachFilesToWorkJob` (see: https://github.com/samvera/hyrax/blob/b054b77/app/actors/hyrax/actors/create_with_files_actor.rb#L42)

this is more convoluted than i'd like, but is the best solution i could come up with: we can't move all of the work into the actor because we need to retain the form concern for the fields to be added to the form.

rails edge makes this _so_ much simpler with [job serializers], but we're a ways away from that

fixes #125 

[job serializers]: https://edgeguides.rubyonrails.org/active_job_basics.html#serializers