### PR TITLE
[wip] update mappers

### DIFF
--- a/app/services/spot/mappers/magazine_mapper.rb
+++ b/app/services/spot/mappers/magazine_mapper.rb
@@ -10,6 +10,7 @@ module Spot::Mappers
     self.fields_map = {
       creator: 'NamePart_DisplayForm_PersonalAuthor',
       publisher: 'OriginInfoPublisher',
+      rights_statement: 'dc:rights',
       source: 'RelatedItemHost_1_TitleInfoTitle'
     }.freeze
 
@@ -26,6 +27,7 @@ module Spot::Mappers
         resource_type
         subtitle
         title
+        title_alternative
       ]
     end
 
@@ -55,11 +57,11 @@ module Spot::Mappers
       end
     end
 
-    # Maps magazine descriptions to English-tagged RDF literals
+    # Maps magazine notes to English-tagged RDF literals
     #
     # @return [Array<RDF::Literal>]
     def description
-      metadata['TitleInfoPartNumber'].reject(&:blank?).map do |desc|
+      metadata['Note'].reject(&:blank?).map do |desc|
         RDF::Literal(desc, language: :en)
       end
     end
@@ -87,7 +89,7 @@ module Spot::Mappers
     #
     # @return [Array<String>]
     def resource_type
-      ['Journal']
+      ['Periodical']
     end
 
     # Maps subtitles to English-tagged RDF literals
@@ -106,6 +108,13 @@ module Spot::Mappers
       Array(parsed_title)
         .reject(&:blank?) # just in case / you never know
         .map { |title| RDF::Literal(title, language: :en) }
+    end
+
+    # @return [Array<RDF::Literal>]
+    def title_alternative
+      metadata['TitleInfoPartNumber'].reject(&:blank?).map do |alt|
+        RDF::Literal(alt, language: :en)
+      end
     end
 
     private

--- a/spec/services/spot/mappers/magazine_mapper_spec.rb
+++ b/spec/services/spot/mappers/magazine_mapper_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe Spot::Mappers::MagazineMapper do
   describe '#description' do
     subject { mapper.description }
 
-    let(:metadata) { { 'TitleInfoPartNumber' => ['A description'] } }
-    let(:value) { [RDF::Literal('A description', language: :en)] }
+    let(:metadata) { { 'Note' => ['some information'] } }
+    let(:value) { [RDF::Literal('some information', language: :en)] }
 
     it { is_expected.to eq value }
   end
@@ -97,7 +97,15 @@ RSpec.describe Spot::Mappers::MagazineMapper do
   describe '#resource_type' do
     subject { mapper.resource_type }
 
-    it { is_expected.to eq ['Journal'] }
+    it { is_expected.to eq ['Periodical'] }
+  end
+
+  describe '#rights_statement' do
+    subject { mapper.rights_statement }
+
+    let(:field) { 'dc:rights' }
+
+    it_behaves_like 'a mapped field'
   end
 
   describe '#source' do
@@ -196,5 +204,15 @@ RSpec.describe Spot::Mappers::MagazineMapper do
 
       it { is_expected.to eq value }
     end
+  end
+
+  describe '#title_alternative' do
+    subject { mapper.title_alternative }
+
+    let(:value) { [RDF::Literal(alt_title, language: :en)] }
+    let(:alt_title) { 'Supplement to The Lafayette Alumnus, Nov., 1937' }
+    let(:metadata) { { 'TitleInfoPartNumber' => [alt_title] } }
+
+    it { is_expected.to eq value }
   end
 end


### PR DESCRIPTION
there's been some changes to the metadata model that we're now out of sync with. this should remediate that.

see https://gist.github.com/malantonio/cb064a20217c51bce5cf41fc9d5647b3 for a text-based listing of all the properties + mappings/remediations needed.

## todos

- [ ] ldr mapper
- [x] magazine mapper
- [ ] newspaper mapper
- [ ] shakespeare mapper

---

closes #124 