### PR TITLE
reorder blacklight-range-limit js require

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,26 +10,18 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//=
 //= require turbolinks
-//
+
 // Required by Blacklight
 //= require jquery
-//= require 'blacklight_advanced_search'
-
-
+//= require blacklight_advanced_search
+//= require blacklight_range_limit
 //= require jquery_ujs
 //= require dataTables/jquery.dataTables
 //= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
 //= require blacklight/blacklight
-//
+
 //= require hyrax
-//
+
 //= require almond
 //= require_tree .
-
-
-// For blacklight_range_limit built-in JS, if you don't want it you don't need
-// this:
-//= require 'blacklight_range_limit'
-


### PR DESCRIPTION
changes the order in which the blacklight_range_limit js is required. i _believe_ this should fix a problem we encountered where the canvas wasn't being rendered in production (for some reason)

fixes #134 