### PR TITLE
exclude range from advanced-search form

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -82,7 +82,8 @@ class CatalogController < ApplicationController
                            limit: 5
     config.add_facet_field 'years_encompassed_iim',
                            label: I18n.t('blacklight.search.fields.years_encompassed'),
-                           range: true
+                           range: true,
+                           include_in_advanced_search: false
 
     # The generic_type isn't displayed on the facet list
     # It's used to give a label to the filter that comes from the user profile


### PR DESCRIPTION
there's a [known-incompatibility] with `blacklight_range_limit` and `blacklight_advanced_search` where range facets will not render on the advanced search form. i _think_ we might be able to include the range as just input fields (no slider) on the form later. (/famous-last-words)

closes #141 

[known-incompatibility]: https://github.com/projectblacklight/blacklight_range_limit/issues/58