### PR TITLE
add indexing of english-language dates

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -164,8 +164,15 @@ class CatalogController < ApplicationController
     # search field configuration
     #
     config.add_search_field('all_fields', label: 'All fields') do |field|
+      fields = %w[
+        all_fields_search_timv
+        english_language_date_teim
+        file_format_tesim
+        all_text_timv
+      ]
+
       field.solr_parameters = {
-        qf: 'all_fields_search_timv file_format_tesim all_text_timv',
+        qf: fields.join(' '),
         pf: 'all_text_timv'
       }
     end

--- a/app/indexers/concerns/indexes_english_language_dates.rb
+++ b/app/indexers/concerns/indexes_english_language_dates.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+#
+# Adds the ability to index dates in various English forms.
+#
+# Currently adds:
+#   - full month (ex. 'February 8 2019')
+#   - abbreviated month (ex. 'Feb 8 2019')
+#   - season (ex. 'Winter 2019')
+#
+# By default, it uses the +:date_issued+ property of the object
+# and stores the values under +'english_language_date_teim'+, but
+# these are configurable by class attributes.
+#
+# @example configuring the mixin
+#   class ImageIndexer < Hyrax::WorkIndexer
+#     include IndexesEnglishLanguageDates
+#
+#     self.english_language_date_field = 'english_readable_date_tesim'
+#     self.date_property_for_english_language_indexing = :date_created
+#   end
+#
+module IndexesEnglishLanguageDates
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :english_language_date_field
+    self.english_language_date_field = 'english_language_date_teim'
+
+    class_attribute :date_property_for_english_language_indexing
+    self.date_property_for_english_language_indexing = :date_issued
+  end
+
+  # @return [Hash]
+  def generate_solr_document
+    super.tap do |solr_doc|
+      add_english_language_dates(solr_doc)
+    end
+  end
+
+  private
+
+    # @param solr_doc [Hash]
+    # @return [void]
+    def add_english_language_dates(solr_doc)
+      solr_doc[english_language_date_field] = dates.map do |date|
+        begin
+          parsed = Date.parse(date)
+        rescue ArgumentError
+          next date unless date.match?(/^\d{4}-\d{2}/)
+          parsed = Date.new(*date.split('-').map(&:to_i))
+        end
+
+        season_names_for_date(parsed) + spelled_out_for_date(parsed)
+      end.flatten.reject(&:blank?)
+    end
+
+    # Determines the season based on the month:
+    #   Spring => March, April, May
+    #   Summer => June, July, August
+    #   Autumn/Fall => September, October, November
+    #   Winter => December, January, February
+    #
+    # @param date [#strftime, #year]
+    # @return [Array<String>]
+    def season_names_for_date(date)
+      seasons = case date.strftime('%-m').to_i
+                when 3..5 then  %w[Spring]
+                when 6..8 then  %w[Summer]
+                when 9..11 then %w[Autumn Fall]
+                else %w[Winter]
+                end
+      year = date.year
+      seasons.map { |season| "#{season} #{year}" }
+    end
+
+    # Transforms our date into English-language dates.
+    #
+    # @example
+    #   spelled_out_dates_for_date(Date.parse('2019-02-08'))
+    #   => ['February 8 2019', 'Feb 8 2019']
+    #
+    # @param date [#strftime, #day, #year]
+    # @return [Array<String>]
+    def spelled_out_for_date(date)
+      [
+        date.strftime("%B #{date.day} #{date.year}"),
+        date.strftime("%b #{date.day} #{date.year}")
+      ]
+    end
+
+    # Saves us the hassle of having to type out that long attribute
+    #
+    # @return [Array<String>]
+    def dates
+      object.send(date_property_for_english_language_indexing)
+    end
+end

--- a/app/indexers/publication_indexer.rb
+++ b/app/indexers/publication_indexer.rb
@@ -44,6 +44,17 @@ class PublicationIndexer < Hyrax::WorkIndexer
     # @param [SolrDocument] doc
     # @return [void]
     def store_years_encompassed(doc)
-      doc['years_encompassed_iim'] = object.date_issued.map { |d| DateTime.parse(d).utc.year }
+      doc['years_encompassed_iim'] = object.date_issued.map { |d| parse_year(d) }.reject(&:blank?)
+    end
+
+    # @param date [String]
+    # @return [Number]
+    def parse_year(date)
+      DateTime.parse(d).utc.year
+    rescue
+      year_match = date.match(/^(\d{4})/)
+      return nil if year_match.nil?
+
+      year_match[1].to_i
     end
 end

--- a/app/indexers/publication_indexer.rb
+++ b/app/indexers/publication_indexer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class PublicationIndexer < Hyrax::WorkIndexer
   include IndexesRightsStatements
+  include IndexesEnglishLanguageDates
 
   # Overriding the default +Hyrax::DeepIndexingService+ for our own, which
   # doesn't require +Hyrax::BasicMetadata+

--- a/spec/indexers/publication_indexer_spec.rb
+++ b/spec/indexers/publication_indexer_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe PublicationIndexer do
   let(:work) { build(:publication) }
   let(:indexer) { described_class.new(work) }
 
+  it_behaves_like 'it indexes English-language dates'
+
   describe 'title' do
     # :stored_searchable
     let(:fields) { %w[title_tesim] }

--- a/spec/support/shared_examples/indexes_english_language_dates.rb
+++ b/spec/support/shared_examples/indexes_english_language_dates.rb
@@ -5,12 +5,12 @@ RSpec.shared_examples 'it indexes English-language dates' do
   let(:indexer) { described_class.new(work) }
   let(:work_klass) { described_class.name.gsub(/Indexer$/, '').downcase.to_sym }
   let(:work) { build(work_klass) }
-  let(:date) { ['2019-02-08T00:00:00Z'] }
+  let(:date) { '2019-02-08T00:00:00Z' }
   let(:field_name) { described_class.english_language_date_field }
   let(:date_field) { described_class.date_property_for_english_language_indexing }
 
   before do
-    work.send(:"#{date_field}=", date)
+    work.send(:"#{date_field}=", [date])
   end
 
   it { is_expected.to include field_name }
@@ -36,10 +36,23 @@ RSpec.shared_examples 'it indexes English-language dates' do
       next if values.nil?
 
       context do
-        let(:date) { [Date.new(2019, idx, 8).strftime('%Y-%m-%d')] }
+        let(:date) { Date.new(2019, idx, 8).strftime('%Y-%m-%d') }
 
         it { is_expected.to include(*values) }
       end
+    end
+
+    context 'when the year is YYYY-MM' do
+      let(:date) { '2019-02' }
+      let(:expected_values) { ['February 2019', 'Feb 2019', 'Winter 2019'] }
+
+      it { is_expected.to include(*expected_values) }
+    end
+
+    context 'when only YYYY' do
+      let(:date) { '2019' }
+
+      it { is_expected.to be_empty }
     end
   end
 end

--- a/spec/support/shared_examples/indexes_english_language_dates.rb
+++ b/spec/support/shared_examples/indexes_english_language_dates.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'it indexes English-language dates' do
+  subject(:solr_doc) { indexer.generate_solr_document }
+
+  let(:indexer) { described_class.new(work) }
+  let(:work_klass) { described_class.name.gsub(/Indexer$/, '').downcase.to_sym }
+  let(:work) { build(work_klass) }
+  let(:date) { ['2019-02-08T00:00:00Z'] }
+  let(:field_name) { described_class.english_language_date_field }
+  let(:date_field) { described_class.date_property_for_english_language_indexing }
+
+  before do
+    work.send(:"#{date_field}=", date)
+  end
+
+  it { is_expected.to include field_name }
+
+  describe 'the date field' do
+    subject { solr_doc[field_name] }
+
+    [
+      nil,
+      ['January 8 2019', 'Jan 8 2019', 'Winter 2019'],
+      ['February 8 2019', 'Feb 8 2019', 'Winter 2019'],
+      ['March 8 2019', 'Mar 8 2019', 'Spring 2019'],
+      ['April 8 2019', 'Apr 8 2019', 'Spring 2019'],
+      ['May 8 2019', 'May 8 2019', 'Spring 2019'],
+      ['June 8 2019', 'Jun 8 2019', 'Summer 2019'],
+      ['July 8 2019', 'Jul 8 2019', 'Summer 2019'],
+      ['August 8 2019', 'Aug 8 2019', 'Summer 2019'],
+      ['September 8 2019', 'Sep 8 2019', 'Fall 2019', 'Autumn 2019'],
+      ['October 8 2019', 'Oct 8 2019', 'Fall 2019', 'Autumn 2019'],
+      ['November 8 2019', 'Nov 8 2019', 'Fall 2019', 'Autumn 2019'],
+      ['December 8 2019', 'Dec 8 2019', 'Winter 2019']
+    ].each_with_index do |values, idx|
+      next if values.nil?
+
+      context do
+        let(:date) { [Date.new(2019, idx, 8).strftime('%Y-%m-%d')] }
+
+        it { is_expected.to include(*values) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
during a check-in with @noraegloff this morning we discussed the adding the ability to search with English dates/seasons in the full text, so that an item with a `date_issued` of 1971-11-01 could be found with `"november 1971"` or `"fall 1971"`. this is a stab at that.

**note to self:** don't merge until you play with this on dev