### PR TITLE
add support for zipped exports

### DIFF
--- a/app/controllers/concerns/spot/additional_formats_for_controller.rb
+++ b/app/controllers/concerns/spot/additional_formats_for_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+#
+# Adds additional metadata formats to a +Hyrax::WorksControllerBehavior+
+# controller by adding formats to the +additional_response_formats+ method.
+module Spot
+  module AdditionalFormatsForController
+    # Adds additional formats to our additional formats option
+    #
+    # @return [void]
+    def additional_response_formats(format)
+      format.csv { send_data(work_as_csv, type: 'text/csv', filename: csv_filename) }
+
+      super if defined?(super)
+    end
+
+    private
+
+      # @return [String]
+      def csv_filename
+        "#{presenter.id}.csv"
+      end
+
+      # @return [String]
+      def work_as_csv
+        Spot::WorkCSVService.new(presenter.solr_document).csv
+      end
+  end
+end

--- a/app/controllers/hyrax/publications_controller.rb
+++ b/app/controllers/hyrax/publications_controller.rb
@@ -4,6 +4,7 @@ module Hyrax
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
+    include Spot::AdditionalFormatsForController
     self.curation_concern_type = ::Publication
 
     # Use this line if you want to use a custom presenter

--- a/app/controllers/spot/export_controller.rb
+++ b/app/controllers/spot/export_controller.rb
@@ -9,7 +9,7 @@ module Spot
       # Hyrax::DownloadsController is already equipped to handle downloading
       # file_sets, so just forward those requests there (note: I'm not expecting
       # that to happen, but you never know)
-      redirect_to hyrax.download_path(work) and return if wants_file_set?
+      redirect_to hyrax.download_path(work) && return if wants_file_set?
 
       # for some reason, we need to reset the Fedora connection before
       # we can run an export of the members + metadata. my best guess is

--- a/app/controllers/spot/export_controller.rb
+++ b/app/controllers/spot/export_controller.rb
@@ -25,14 +25,13 @@ module Spot
       # about it, but this at least lets us get an export happening.
       ActiveFedora::Fedora.reset!
 
-      respond_to do |format|
-        format.zip do
-          send_file(export_work_to_cache!,
-                    filename: "#{solr_document.id}.zip",
-                    type: 'application/zip',
-                    disposition: 'attachment')
-        end
-      end
+      send_file(export_work_to_cache!,
+                filename: "#{solr_document.id}.zip",
+                type: 'application/zip',
+                disposition: 'attachment')
+
+      # this helps our specs, but does it have any negative effects?
+      head :ok, content_type: 'application/zip'
     end
     # rubocop:enable Style/AndOr
 
@@ -61,7 +60,7 @@ module Spot
 
       # @return [Spot::Exporters::ZippedWorkExporter]
       def exporter
-        Spot::Exporters::ZippedWorkExporter.new(solr_document, current_ability, request)
+        Spot::Exporters::ZippedWorkExporter.new(solr_document, request)
       end
 
       # Sets the @solr_document attribute from a single-item solr query.

--- a/app/controllers/spot/export_controller.rb
+++ b/app/controllers/spot/export_controller.rb
@@ -1,29 +1,34 @@
 # frozen_string_literal: true
 module Spot
   class ExportController < ApplicationController
-    attr_reader :work
+    include Blacklight::Base
+    include Blacklight::AccessControls::Catalog
+
+    class_attribute :search_builder_class
+    self.search_builder_class = Hyrax::WorkSearchBuilder
+
+    attr_reader :solr_document
 
     before_action :load_and_authorize_resource
 
     # rubocop:disable Style/AndOr
     def show
-      # Hyrax::DownloadsController is already equipped to handle downloading
-      # file_sets, so just forward those requests there (note: I'm not expecting
-      # that to happen, but you never know)
-      #
-      redirect_to hyrax.download_path(work, locale: nil) and return if wants_file_set?
+      redirect_to hyrax.download_path(solr_document.id, locale: nil) and return if wants_file_set?
+
+      file_sets = solr_document.file_set_ids
+      redirect_to hyrax.download_path(file_sets.first, locale: nil) and return if wants_only_file_set?
 
       # for some reason, we need to reset the Fedora connection before
       # we can run an export of the members + metadata. my best guess is
       # that number of requests in a short amount of time is too much
-      # for the repository to handle? I'm really unsure about it,
-      # but this at least lets us get an export happening.
+      # for the ActiveFedora's connection to handle? I'm really unsure
+      # about it, but this at least lets us get an export happening.
       ActiveFedora::Fedora.reset!
 
       respond_to do |format|
         format.zip do
-          send_data(File.open(exported_work),
-                    filename: "#{work.id}.zip",
+          send_file(export_work_to_cache!,
+                    filename: "#{solr_document.id}.zip",
                     type: 'application/zip',
                     disposition: 'attachment')
         end
@@ -45,34 +50,54 @@ module Spot
 
       # @return [Pathname]
       def cache_path
-        cache_directory.join("#{work.id}-#{work.etag[3..-2]}.zip")
-      end
-
-      # @return [void]
-      def export_work_to_cache
-        exporter.export!(destination: cache_path)
+        cache_directory.join("#{solr_document.id}-#{solr_document['_version_']}.zip")
       end
 
       # @return [Pathname]
-      def exported_work
-        export_work_to_cache unless File.exist?(cache_path)
+      def export_work_to_cache!
+        exporter.export!(destination: cache_path) unless File.exist?(cache_path)
         cache_path
       end
 
       # @return [Spot::Exporters::ZippedWorkExporter]
       def exporter
-        Spot::Exporters::ZippedWorkExporter.new(work, current_ability, request)
+        Spot::Exporters::ZippedWorkExporter.new(solr_document, current_ability, request)
       end
 
-      # @return [ActiveFedora::Base]
-      # @todo Actually authorize the resource!
+      # Sets the @solr_document attribute from a single-item solr query.
+      # Getting the work this way (rather than calling +ActiveFedora::Base+)
+      # allows us to leverage the Hyrax permissions via Solr query and
+      # saves us the hassle of writing that logic ourselves. The downside
+      # is that we need to query the work
+      #
+      # @return [void]
+      # @raises WorkflowAuthorizationException if user can read but the doc is suppressed
+      # @raises CanCan::AccessDenied
       def load_and_authorize_resource
-        @work = ActiveFedora::Base.find(params[:id])
+        search_params = params
+        search_params.delete :page
+        search_params.delete :type
+
+        _, doc_list = search_results(search_params)
+        @solr_document = doc_list.first unless doc_list.empty?
+
+        return unless @solr_document.nil?
+
+        doc = SolrDocument.find(params[:id])
+        raise WorkflowAuthorizationException if doc.suppressed? && current_ability.can?(:read, doc)
+        raise CanCan::AccessDenied.new(nil, :show)
       end
 
       # @return [true, false]
       def wants_file_set?
-        work.is_a? FileSet
+        solr_document.hydra_model == FileSet
+      end
+
+      # Do we only want the files of a work that only has one file?
+      #
+      # @return [true, false]
+      def wants_only_file_set?
+        solr_document.file_set_ids.size == 1 && params[:export_type] == 'files'
       end
   end
 end

--- a/app/controllers/spot/export_controller.rb
+++ b/app/controllers/spot/export_controller.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+module Spot
+  class ExportController < ApplicationController
+    attr_reader :solr_document
+
+    before_action :load_and_authorize_resource
+
+    def show
+      # Hyrax::DownloadsController is already equipped to handle downloading
+      # file_sets, so just forward those requests there (note: I'm not expecting
+      # that to happen, but you never know)
+      redirect_to hyrax.download_path(solr_document) and return if wants_file_set?
+
+      send_file(exported_work, filename: "#{solr_document.id}.zip")
+    end
+
+    private
+
+      # I think in the future this could/should be moved to something offsite
+      # (read: more available storage) like S3. For now, we'll store it in 'tmp/'
+      # and have Capistrano ensure that it a) exists and b) is shared between
+      # deployments. We'll have to manually clean it out
+      #
+      # @return [Pathname]
+      def cache_directory
+        Rails.root.join('tmp', 'export')
+      end
+
+      # @return [Pathname]
+      def cache_path
+        cache_directory.join("#{solr_document.id}-#{solr_document['_version_']}.zip")
+      end
+
+      # @return [void]
+      def export_work_to_cache
+        exporter.export!(destination: cache_path)
+      end
+
+      # @return [Pathname]
+      def exported_work
+        export_work_to_cache unless File.exist?(cache_path)
+        cache_path
+      end
+
+      # @return [Spot::Exporters::ZippedWorkExporter]
+      def exporter
+        Spot::Exporters::ZippedWorkExporter.new(solr_document, current_ability, request)
+      end
+
+      # @return [SolrDocument]
+      # @todo Actually authorize the resource!
+      def load_and_authorize_resource
+        @solr_document = ::SolrDocument.find(params[:id])
+      end
+
+      # @return [true, false]
+      def wants_file_set?
+        solr_document.hydra_model == FileSet
+      end
+  end
+end

--- a/app/controllers/spot/export_controller.rb
+++ b/app/controllers/spot/export_controller.rb
@@ -25,13 +25,7 @@ module Spot
       # about it, but this at least lets us get an export happening.
       ActiveFedora::Fedora.reset!
 
-      send_file(export_work_to_cache!,
-                filename: "#{solr_document.id}.zip",
-                type: 'application/zip',
-                disposition: 'attachment')
-
-      # this helps our specs, but does it have any negative effects?
-      head :ok, content_type: 'application/zip'
+      send_file(export_work_to_cache!, filename: "#{solr_document.id}.zip")
     end
     # rubocop:enable Style/AndOr
 

--- a/app/models/concerns/spot/solr_document_attributes.rb
+++ b/app/models/concerns/spot/solr_document_attributes.rb
@@ -32,6 +32,7 @@ module Spot
       attribute :description,            ::Blacklight::Types::Array, 'description_tesim'
       attribute :division,               ::Blacklight::Types::Array, 'division_tesim'
       attribute :editor,                 ::Blacklight::Types::Array, 'editor_tesim'
+      attribute :file_set_ids,           ::Blacklight::Types::Array, 'file_set_ids_ssim'
       attribute :file_size,              ::Blacklight::Types::String, 'file_size_lts'
       attribute :identifier,             ::Blacklight::Types::Array, 'identifier_ssim'
       attribute :keyword,                ::Blacklight::Types::Array, 'keyword_tesim'

--- a/app/presenters/hyrax/publication_presenter.rb
+++ b/app/presenters/hyrax/publication_presenter.rb
@@ -11,6 +11,13 @@ module Hyrax
              :subtitle, :title_alternative,
              to: :solr_document
 
+    # Metadata formats we're able to export as.
+    #
+    # @return [Array<Symbol>]
+    def export_formats
+      %i[csv ttl nt jsonld]
+    end
+
     # Is the document's visibility public?
     #
     # @return [true, false]

--- a/app/search_builders/spot/work_and_file_set_search_builder.rb
+++ b/app/search_builders/spot/work_and_file_set_search_builder.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+#
+# Adds FileSets to the list of acceptable single-item search results (used for exports)
+module Spot
+  class WorkAndFileSetSearchBuilder < Hyrax::WorkSearchBuilder
+    private
+
+      # @return [Array<Class>]
+      def models
+        super + [FileSet]
+      end
+  end
+end

--- a/app/services/spot/exporters/work_members_exporter.rb
+++ b/app/services/spot/exporters/work_members_exporter.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+#
+# Exporter that writes all of a work's associated files to a destination.
+module Spot
+  module Exporters
+    class WorkMembersExporter
+      attr_reader :solr_document
+
+      # @param [SolrDocument] solr_document
+      def initialize(solr_document)
+        @solr_document = solr_document
+      end
+
+      # Writes each Hydra::PCDM::File of a work to the provided destination
+      #
+      # @param [Pathname, String] :destination
+      # @return [void]
+      def export!(destination:)
+        files.each do |file|
+          File.open(File.join(destination, file.file_name.first), 'wb') do |io|
+            file.stream.each { |chunk| io.write(chunk) }
+          end
+        end
+      end
+
+      # @return [Array<Hydra::PCDM::File>]
+      def files
+        work.file_sets.map(&:original_file)
+      end
+
+      def work
+        ActiveFedora::Base.find(solr_document.id)
+      end
+    end
+  end
+end

--- a/app/services/spot/exporters/work_members_exporter.rb
+++ b/app/services/spot/exporters/work_members_exporter.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 #
-# Exporter that writes all of a work's associated files to a destination.
+# This name _might_ be misleading, I'm not 100% sure. For now, we're only
+# exporting a work's FileSets with this. Our parity release doesn't nest works,
+# but works can have multiple FileSets.
 module Spot
   module Exporters
     class WorkMembersExporter
-      attr_reader :work
+      attr_reader :solr_document
 
-      # @param [ActiveFedora::Base] work
-      def initialize(work)
-        @work = work
+      # @param [SolrDocument] solr_document
+      def initialize(solr_document)
+        @solr_document = solr_document
       end
 
       # Writes each Hydra::PCDM::File of a work to the provided destination
@@ -23,9 +25,18 @@ module Spot
         end
       end
 
+      # @todo How do we export members that are themselves works?
+      # @return [Array<FileSet>]
+      def file_sets
+        @file_sets ||= ActiveFedora::Base.find(solr_document.file_set_ids)
+                                         .select { |fs| fs.is_a? FileSet }
+      end
+
+      # Selects all items that the current user can download.
+      #
       # @return [Array<Hydra::PCDM::File>]
       def files
-        work.file_sets.map(&:original_file)
+        file_sets.map(&:original_file)
       end
     end
   end

--- a/app/services/spot/exporters/work_members_exporter.rb
+++ b/app/services/spot/exporters/work_members_exporter.rb
@@ -4,11 +4,11 @@
 module Spot
   module Exporters
     class WorkMembersExporter
-      attr_reader :solr_document
+      attr_reader :work
 
-      # @param [SolrDocument] solr_document
-      def initialize(solr_document)
-        @solr_document = solr_document
+      # @param [ActiveFedora::Base] work
+      def initialize(work)
+        @work = work
       end
 
       # Writes each Hydra::PCDM::File of a work to the provided destination
@@ -26,10 +26,6 @@ module Spot
       # @return [Array<Hydra::PCDM::File>]
       def files
         work.file_sets.map(&:original_file)
-      end
-
-      def work
-        ActiveFedora::Base.find(solr_document.id)
       end
     end
   end

--- a/app/services/spot/exporters/work_metadata_exporter.rb
+++ b/app/services/spot/exporters/work_metadata_exporter.rb
@@ -49,7 +49,6 @@ module Spot
           when :nt then graph.dump(:ntriples)
           when :ttl then graph.dump(:ttl)
           when :jsonld then graph.dump(:jsonld, standard_prefixes: true)
-          else nil
           end
         end
 

--- a/app/services/spot/exporters/work_metadata_exporter.rb
+++ b/app/services/spot/exporters/work_metadata_exporter.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+#
+# Exports a work's metadata to files. I'm not very stoked on this implementation;
+# I'd rather just pass the work and use +Hyrax::GraphExporter+ to generate an RDF
+# graph and use +graph.dump(format)+, however this somehow ties up the Fedora connection
+# more than using Hyrax's presenters (which uses the same thing?). Again, truly miffed
+# about this.
+module Spot
+  module Exporters
+    class WorkMetadataExporter
+      attr_reader :solr_document, :ability, :request
+
+      # @param [SolrDocument]
+      # @param [Ability, nil]
+      # @param [#host]
+      def initialize(solr_document, ability = nil, request = nil)
+        @solr_document = solr_document
+        @ability = ability
+        @request = request
+      end
+
+      # @return [void]
+      def export!(destination:, format: :all)
+        format = all_formats if format == :all
+
+        Array.wrap(format).each do |f|
+          metadata = export_for_format(f)
+          next if metadata.nil? # unsupported format
+
+          out_path = File.join(destination, "#{solr_document.id}.#{f}")
+
+          File.open(out_path, 'w') { |io| io.write metadata }
+        end
+      end
+
+      private
+
+        # @return [Array<Symbol>]
+        def all_formats
+          %i[nt ttl jsonld]
+        end
+
+        # @param [Symbol] format
+        # @return [String, nil]
+        def export_for_format(format)
+          case format
+          when :nt then presenter.export_as_nt
+          when :ttl then presenter.export_as_ttl
+          when :jsonld then presenter.export_as_jsonld
+          else nil
+          end
+        end
+
+        # @return [Hyrax::WorkShowPresenter]
+        def presenter
+          presenter_for_solr_document.new(solr_document, ability, request)
+        end
+
+        # @return [Class]
+        def presenter_for_solr_document
+          Hyrax.const_get("#{solr_document.hydra_model}Presenter")
+        end
+    end
+  end
+end

--- a/app/services/spot/exporters/work_metadata_exporter.rb
+++ b/app/services/spot/exporters/work_metadata_exporter.rb
@@ -2,14 +2,13 @@
 module Spot
   module Exporters
     class WorkMetadataExporter
-      attr_reader :work, :ability, :request
+      attr_reader :solr_document, :request
 
       # @param [SolrDocument]
       # @param [Ability, nil]
       # @param [#host]
-      def initialize(work, ability = nil, request = nil)
-        @work = work
-        @ability = ability
+      def initialize(solr_document, request = nil)
+        @solr_document = solr_document
         @request = request
       end
 
@@ -29,7 +28,7 @@ module Spot
           metadata = export_for_format(f)
           next if metadata.nil? # unsupported format
 
-          out_path = File.join(destination, "#{work.id}.#{f}")
+          out_path = File.join(destination, "#{solr_document.id}.#{f}")
 
           File.open(out_path, 'w') { |io| io.write metadata }
         end
@@ -54,7 +53,7 @@ module Spot
 
         # @return [RDF::Graph]
         def graph
-          @graph ||= Hyrax::GraphExporter.new(SolrDocument.find(work.id), request).fetch
+          @graph ||= Hyrax::GraphExporter.new(solr_document, request).fetch
         end
     end
   end

--- a/app/services/spot/exporters/work_metadata_exporter.rb
+++ b/app/services/spot/exporters/work_metadata_exporter.rb
@@ -54,7 +54,7 @@ module Spot
 
         # @return [RDF::Graph]
         def graph
-          Hyrax::GraphExporter.new(SolrDocument.find(work.id), request).fetch
+          @graph ||= Hyrax::GraphExporter.new(SolrDocument.find(work.id), request).fetch
         end
     end
   end

--- a/app/services/spot/exporters/work_metadata_exporter.rb
+++ b/app/services/spot/exporters/work_metadata_exporter.rb
@@ -20,6 +20,7 @@ module Spot
       #     - :nt (ntriples)
       #     - :ttl (turtle)
       #     - :jsonld (json linked-data)
+      #     - :csv (comma-separated values)
       # @return [void]
       def export!(destination:, format: :all)
         format = all_formats if format == :all
@@ -38,7 +39,7 @@ module Spot
 
         # @return [Array<Symbol>]
         def all_formats
-          %i[nt ttl jsonld]
+          %i[nt ttl jsonld csv]
         end
 
         # @param [Symbol] format
@@ -48,7 +49,13 @@ module Spot
           when :nt then graph.dump(:ntriples)
           when :ttl then graph.dump(:ttl)
           when :jsonld then graph.dump(:jsonld, standard_prefixes: true)
+          when :csv then generate_csv_content
           end
+        end
+
+        # @return [String]
+        def generate_csv_content
+          Spot::WorkCSVService.new(solr_document).csv
         end
 
         # @return [RDF::Graph]

--- a/app/services/spot/exporters/zipped_work_exporter.rb
+++ b/app/services/spot/exporters/zipped_work_exporter.rb
@@ -30,6 +30,7 @@ module Spot
       end
 
       private
+
         attr_reader :tmpdir
 
         # @return [void]

--- a/app/services/spot/exporters/zipped_work_exporter.rb
+++ b/app/services/spot/exporters/zipped_work_exporter.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+require 'tmpdir'
+require 'fileutils'
+
+module Spot
+  module Exporters
+    class ZippedWorkExporter
+      attr_reader :solr_document, :ability, :request
+
+      def initialize(solr_document, ability, request)
+        @solr_document = solr_document
+        @ability = ability
+        @request = request
+      end
+
+      def export!(destination:, metadata_formats: :all)
+        @metadata_formats = metadata_formats
+
+        in_working_directory do
+          unless metadata_formats.nil?
+            export_metadata!(metadata_formats) if include_metadata?
+
+            # for some reason, we need to reset the Fedora connection after
+            # exporting the metadata or the members (one or the other).
+            # note: this only happens when being called from a controller;
+            # I'm able to get this working fine from the command line.
+            # I am truly miffed!
+            ActiveFedora::Fedora.reset!
+          end
+
+          export_members!
+          zip_export_to(destination)
+        end
+      end
+
+      private
+        attr_reader :tmpdir
+
+        def export_members!
+          files_path = tmpdir
+          files_path = File.join(files_path, 'files') if include_metadata?
+          FileUtils.mkdir_p(files_path) unless Dir.exist?(files_path)
+
+          members_exporter.export!(destination: files_path)
+        end
+
+        # @param [Symbol] :format what format we want our exports to be
+        # @return [void]
+        def export_metadata!(format)
+          metadata_exporter.export!(destination: tmpdir, format: format)
+        end
+
+        # @return [true, false]
+        def include_metadata?
+          !@metadata_formats.nil?
+        end
+
+        # Wraps our operations in a +Dir.mktmpdir+ block so we don't
+        # have to remember to delete the tmpdir when we're finished.
+        #
+        # @return [void]
+        # @yields
+        def in_working_directory
+          Dir.mktmpdir do |tmpdir|
+            @tmpdir = tmpdir
+            yield
+          end
+        end
+
+        # @return [Spot::Exporters::WorkMembersExporter]
+        def members_exporter
+          WorkMembersExporter.new(solr_document)
+        end
+
+        # @return [Spot::Exporters::WorkMetadataExporter]
+        def metadata_exporter
+          WorkMetadataExporter.new(solr_document, ability, request)
+        end
+
+        def zip_export_to(destination)
+          ::ZipService.new(src_path: tmpdir)
+                      .zip!(dest_path: destination)
+        end
+    end
+  end
+end

--- a/app/services/spot/work_csv_service.rb
+++ b/app/services/spot/work_csv_service.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+#
+# Taking notes from +Hyrax::FileSetCsvService+ this allows us to
+# export metadata from a Work. Technically, this will work for
+# anything that includes methods that map to
+require 'csv'
+
+module Spot
+  class WorkCSVService
+    attr_reader :work, :terms, :multi_value_separator, :include_headers
+
+    # @param [ActiveFedora::Base,SolrDocument] work
+    # @param [Array<Symbol>] :terms
+    # @param [String] :multi_value_separator
+    # @param [true, false] :include_headers
+    def initialize(work, terms: nil, multi_value_separator: '|', include_headers: true)
+      @work = work
+      @terms = terms || default_terms
+      @multi_value_separator = multi_value_separator
+      @include_headers = include_headers
+    end
+
+    # @return [String]
+    def csv
+      [].tap do |out|
+        out << headers if include_headers
+        out << content
+      end.join
+    end
+
+    # @return [String]
+    def content
+      ::CSV.generate do |csv|
+        csv << terms.map do |term|
+          values = work.respond_to?(term) ? work.send(term) : ''
+          values = values.respond_to?(:to_a) ? values.to_a : [values]
+          values = values.map(&:to_s)
+          values.join(multi_value_separator)
+        end
+      end
+    end
+
+    # @return [String]
+    def headers
+      ::CSV.generate { |csv| csv << terms }
+    end
+
+    private
+
+      # @return [Array<Symbol>]
+      # rubocop:disable Metrics/MethodLength
+      def default_terms
+        %i[
+          id
+          title
+          title_alternative
+          subtitle
+          creator
+          contributor
+          editor
+          source
+          resource_type
+          physical_medium
+          language
+          abstract
+          description
+          identifier
+          date_issued
+          date_available
+          academic_department
+          division
+          organization
+          subject
+          keyword
+          place
+          license
+          rights_statement
+          visibility
+        ]
+      end
+    # rubocop:enable Metrics/MethodLength
+  end
+end

--- a/app/views/hyrax/base/_export_tools.html.erb
+++ b/app/views/hyrax/base/_export_tools.html.erb
@@ -1,6 +1,8 @@
 <div class="work-export-tools btn-toolbar" style="margin-bottom:1rem;">
   <div class="btn-group">
-    <%= link_to main_app.export_path(presenter), class: 'btn btn-success' do %>
+    <%= link_to main_app.export_path(presenter),
+                class: 'btn btn-success',
+                data: { turbolinks: false } do %>
       <span class="fa fa-download"></span>
       <%= t('spot.work.export.download_work') %>
     <% end %>
@@ -20,12 +22,15 @@
         <%= t('spot.work.export.dropdown.file_header') %>
       </li>
       <li>
-        <%= link_to t('spot.work.export.primary_file'), presenter.download_url %>
+        <%= link_to t('spot.work.export.primary_file'),
+                    presenter.download_url,
+                    data: { turbolinks: false } %>
       </li>
       <% if presenter.list_of_item_ids_to_display.count > 1 %>
         <li>
           <%= link_to t('spot.work.export.all_files'),
-                      main_app.export_path(presenter, export_type: :files) %>
+                      main_app.export_path(presenter, export_type: :files),
+                      data: { turbolinks: false } %>
         </li>
       <% end %>
 

--- a/app/views/hyrax/base/_export_tools.html.erb
+++ b/app/views/hyrax/base/_export_tools.html.erb
@@ -1,0 +1,46 @@
+<div class="work-export-tools btn-toolbar" style="margin-bottom:1rem;">
+  <div class="btn-group">
+    <%= link_to main_app.export_path(presenter), class: 'btn btn-success' do %>
+      <span class="fa fa-download"></span>
+      <%= t('spot.work.export.download_work') %>
+    <% end %>
+  </div>
+
+  <div class="btn-group">
+    <button type="button"
+            class="btn btn-default dropdown-toggle"
+            data-toggle="dropdown"
+            aria-haspopup="true"
+            aria-expanded="false">
+      <%= t('spot.work.export.additional_options') %>
+      <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu">
+      <li class="dropdown-header">
+        <%= t('spot.work.export.dropdown.file_header') %>
+      </li>
+      <li>
+        <%= link_to t('spot.work.export.primary_file'), presenter.download_url %>
+      </li>
+      <% if presenter.list_of_item_ids_to_display.count > 1 %>
+        <li>
+          <%= link_to t('spot.work.export.all_files'),
+                      main_app.export_path(presenter, export_type: :files) %>
+        </li>
+      <% end %>
+
+      <li class="dropdown-header">
+        <%= t('spot.work.export.dropdown.metadata_header') %>
+      </li>
+      <% presenter.export_formats.each do |format| %>
+        <li>
+          <%= link_to main_app.polymorphic_path([presenter], format: format, locale: nil) do %>
+            <%= t "spot.work.export.metadata.#{format}",
+                  default: 'spot.work.export.metadata.default',
+                  format: format %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/hyrax/base/_metadata_and_viewer_panel.html.erb
+++ b/app/views/hyrax/base/_metadata_and_viewer_panel.html.erb
@@ -1,23 +1,24 @@
 <div class="panel panel-default">
   <div class="panel-heading">
-    <%= render 'work_title', presenter: @presenter %>
+    <%= render 'work_title', presenter: presenter %>
   </div>
   <div class="panel-body">
     <div class="row">
-      <%= render 'workflow_actions_widget', presenter: @presenter %>
+      <%= render 'workflow_actions_widget', presenter: presenter %>
       <div class="col-sm-12">
-        <%= render 'show_actions', presenter: @presenter %>
+        <%= render 'show_actions', presenter: presenter %>
       </div>
       <div class="col-sm-12 work-representative-media">
-        <%= render 'representative_media', presenter: @presenter, viewer: @presenter.iiif_viewer? %>
+        <%= render 'representative_media', presenter: presenter, viewer: presenter.iiif_viewer? %>
       </div>
       <%# <div class="col-sm-3 text-center"> %>
-        <%# render 'citations', presenter: @presenter %>
+        <%# render 'citations', presenter: presenter %>
         <%# render 'social_media' %>
       <%# </div> %>
       <div class="col-sm-12">
-        <%= render 'work_description', presenter: @presenter %>
-        <%= render 'metadata', presenter: @presenter %>
+        <%= render 'export_tools', presenter: presenter %>
+        <%= render 'work_description', presenter: presenter %>
+        <%= render 'metadata', presenter: presenter %>
         <%= render 'items_table', presenter: presenter %>
 
         <% if current_user && current_user.admin? %>

--- a/app/views/hyrax/file_sets/_download_button.html.erb
+++ b/app/views/hyrax/file_sets/_download_button.html.erb
@@ -1,0 +1,6 @@
+<div class="caption">
+  <%= link_to hyrax.download_path(presenter), class: 'btn btn-success btn-block' do %>
+    <span class="fa fa-download"></span>
+    Download
+  <% end %>
+</div>

--- a/app/views/hyrax/file_sets/_thumbnail.html.erb
+++ b/app/views/hyrax/file_sets/_thumbnail.html.erb
@@ -1,3 +1,5 @@
 <div class="thumbnail file-set">
   <img src="<%= presenter.solr_document.thumbnail_path %>" />
+
+  <%= render 'download_button', presenter: presenter %>
 </div>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,6 +33,6 @@ SSHKit.config.command_map[:solr] = '/opt/solr/bin/solr'
 
 # shared things
 append :linked_dirs, 'log'
-append :linked_dirs, 'tmp/cache', 'tmp/derivatives', 'tmp/ingest', 'tmp/pids', 'tmp/sockets'
+append :linked_dirs, 'tmp/cache', 'tmp/derivatives', 'tmp/export', 'tmp/ingest', 'tmp/pids', 'tmp/sockets'
 append :linked_dirs, 'vendor/bundle'
 append :linked_dirs, 'public/assets', 'public/branding', 'public/system', 'public/uploads'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   # config.action_controller.asset_host = 'http://assets.example.com'
 
   # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Mount Action Cable outside main process or domain

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -51,3 +51,19 @@ en:
     masthead:
       advanced_search: Advanced Search
       search_placeholder: Begin your search here
+
+    work:
+      export:
+        additional_options: Additional options
+        all_files: Download all files
+        primary_file: Download primary file
+        download_work: Download as .zip
+        dropdown:
+          file_header: Files
+          metadata_header: Metadata
+        metadata:
+          csv: View metadata as CSV
+          default: View metadata as .%{format}
+          jsonld: View metadata as JSON-LD
+          nt: View metadata as NTriples
+          ttl: View metadata as TTL

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,8 @@ Rails.application.routes.draw do
         resource :featured_collection, only: [:create, :destroy]
       end
     end
+
+    resources :export, only: :show
   end
 
   get '/handle/*id', to: 'identifier#handle', as: 'handle'

--- a/spec/controllers/hyrax/publications_controller_spec.rb
+++ b/spec/controllers/hyrax/publications_controller_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::PublicationsController do
-  context 'when visiting a known publication' do
-    let(:doc) { create(:publication, :public) }
+  let(:doc) { create(:publication, :public) }
 
+  context 'when visiting a known publication' do
     before do
       get :show, params: { id: doc.id }
     end
@@ -29,6 +29,20 @@ RSpec.describe Hyrax::PublicationsController do
     it 'redirects to the login page' do
       expect(response.status).to eq 302
       expect(response.headers['Location']).to include '/users/sign_in'
+    end
+  end
+
+  context 'when requesting the metadata as csv' do
+    let(:disposition)  { response.header.fetch('Content-Disposition') }
+    let(:content_type) { response.header.fetch('Content-Type') }
+
+    it 'downloads the file' do
+      get :show, params: { id: doc.id, format: 'csv' }
+
+      expect(response).to be_successful
+      expect(disposition).to include 'attachment'
+      expect(content_type).to eq 'text/csv'
+      expect(response.body).to start_with('id,title')
     end
   end
 end

--- a/spec/controllers/spot/export_controller_spec.rb
+++ b/spec/controllers/spot/export_controller_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'fileutils'
+
+RSpec.describe Spot::ExportController do
+  routes { Rails.application.routes }
+
+  before { allow(controller).to receive(:render) }
+
+  describe 'GET #show' do
+    subject(:get_export!) { get :show, params: { id: item_id, format: :zip } }
+
+    context 'when requesting a file_set' do
+      let(:item_id) { FileSet.create.id }
+
+      it { is_expected.to redirect_to Hyrax::Engine.routes.url_helpers.download_path(item_id) }
+    end
+
+    context 'when requesting a work' do
+      before { allow(controller).to receive(:send_data) }
+
+      after { FileUtils.rm(cached_file) }
+
+      let(:work) { create(:publication) }
+      let(:item_id) { work.id }
+      let(:cached_file) { Rails.root.join('tmp', 'export', "#{item_id}-#{work.etag[3..-2]}.zip") }
+
+      it 'calls :send_data' do
+        get_export!
+
+        expect(controller).to have_received(:send_data)
+      end
+    end
+  end
+end

--- a/spec/controllers/spot/export_controller_spec.rb
+++ b/spec/controllers/spot/export_controller_spec.rb
@@ -3,8 +3,9 @@ RSpec.describe Spot::ExportController do
   routes { Rails.application.routes }
 
   before do
-    allow(controller).to receive(:search_results).and_return([nil, [solr_document]])
     allow(Spot::Exporters::ZippedWorkExporter).to receive(:new).and_return(exporter)
+    allow(controller).to receive(:search_results).and_return([nil, doc_list])
+    allow(controller).to receive(:send_file)
     allow(controller.hyrax)
       .to receive(:download_path)
       .with(file_set.id, locale: nil)
@@ -14,38 +15,67 @@ RSpec.describe Spot::ExportController do
   let(:exporter) { instance_double(Spot::Exporters::ZippedWorkExporter, export!: true) }
   let(:work) { instance_double(Publication, id: 'pub000') }
   let(:file_set) { instance_double(FileSet, id: 'fs000') }
-  let(:params) { { id: item_id, format: :zip } }
-  let(:solr_document) do
-    SolrDocument.new id: 'pub000',
-                     file_set_ids_ssim: [file_set.id],
-                     has_model_ssim: ['Publication'],
-                     _version_: '1234567890'
-  end
+  let(:doc_list) { [solr_document] }
 
   describe 'GET #show' do
-    before do
-      allow(controller).to receive(:send_file)
-      get :show, params: params
-    end
+    let(:params) { { id: item_id } }
 
     context 'when requesting a file_set' do
+      before { get :show, params: params }
+
       let(:item_id) { file_set.id }
-      let(:solr_document) { SolrDocument.new id: 'fs000', has_model_ssim: ['FileSet'] }
+      let(:solr_document) { SolrDocument.new(id: item_id, has_model_ssim: ['FileSet']) }
 
       it { is_expected.to redirect_to Hyrax::Engine.routes.url_helpers.download_path(item_id) }
     end
 
     context 'when requesting the files of a work that only has one' do
-      let(:item_id) { work.id }
-      let(:params) { { id: item_id, format: :zip, export_type: :files } }
+      before { get :show, params: params }
+
+      let(:solr_document) do
+        SolrDocument.new(id: item_id,
+                         has_model_ssim: ['Publication'],
+                         file_set_ids_ssim: [file_set.id],
+                         _version_: 123)
+      end
+
+      let(:item_id) { 'abc123' }
+      let(:params) { { id: item_id, export_type: :files } }
 
       it { is_expected.to redirect_to Hyrax::Engine.routes.url_helpers.download_path(file_set.id) }
     end
 
-    context 'when requesting a work' do
-      let(:item_id) { work.id }
+    context 'when requesting a private file' do
+      before do
+        allow(SolrDocument).to receive(:find).with(item_id).and_return(solr_document)
+        allow(controller.current_ability).to receive(:can?).with(:read, solr_document).and_return true
 
-      it 'calls :send_data' do
+        get :show, params: params
+      end
+
+      let(:doc_list) { [] }
+      let(:item_id) { work.id }
+      let(:solr_document) { SolrDocument.new(id: item_id, read_access_group_ssim: []) }
+
+      it 'redirects to login' do
+        expect(response)
+          .to redirect_to(Rails.application.routes.url_helpers.new_user_session_path(locale: :en))
+      end
+    end
+
+    context 'when requesting a work' do
+      before { allow(controller).to receive(:send_file) }
+
+      let(:item_id) { work.id }
+      let(:solr_document) do
+        SolrDocument.new(id: work.id,
+                         has_model_ssim: ['Publication'],
+                         _version_: 123)
+      end
+
+      it 'calls :send_file' do
+        get :show, params: params
+
         expect(controller).to have_received(:send_file)
       end
     end

--- a/spec/controllers/spot/export_controller_spec.rb
+++ b/spec/controllers/spot/export_controller_spec.rb
@@ -4,29 +4,39 @@ require 'fileutils'
 RSpec.describe Spot::ExportController do
   routes { Rails.application.routes }
 
-  before { allow(controller).to receive(:render) }
+  before do
+    allow(controller).to receive(:render)
+    allow(Spot::Exporters::ZippedWorkExporter).to receive(:new).and_return(exporter)
+    allow(File).to receive(:open)
+    allow(ActiveFedora::Base).to receive(:find).with('fs000').and_return(file_set)
+    allow(ActiveFedora::Base).to receive(:find).with('pub000').and_return(work)
+    allow(file_set).to receive(:is_a?).with(FileSet).and_return(true)
+    allow(controller.hyrax)
+      .to receive(:download_path)
+      .with(file_set, locale: nil)
+      .and_return("/downloads/#{file_set.id}")
+  end
+
+  let(:exporter) { instance_double(Spot::Exporters::ZippedWorkExporter, export!: true) }
+  let(:work) { instance_double(Publication, id: 'pub000', etag: 'W/"xxxxxx"') }
+  let(:file_set) { instance_double(FileSet, id: 'fs000') }
 
   describe 'GET #show' do
-    subject(:get_export!) { get :show, params: { id: item_id, format: :zip } }
+    before do
+      allow(controller).to receive(:send_data)
+      get :show, params: { id: item_id, format: :zip }
+    end
 
     context 'when requesting a file_set' do
-      let(:item_id) { FileSet.create.id }
+      let(:item_id) { file_set.id }
 
       it { is_expected.to redirect_to Hyrax::Engine.routes.url_helpers.download_path(item_id) }
     end
 
     context 'when requesting a work' do
-      before { allow(controller).to receive(:send_data) }
-
-      after { FileUtils.rm(cached_file) }
-
-      let(:work) { create(:publication) }
       let(:item_id) { work.id }
-      let(:cached_file) { Rails.root.join('tmp', 'export', "#{item_id}-#{work.etag[3..-2]}.zip") }
 
       it 'calls :send_data' do
-        get_export!
-
         expect(controller).to have_received(:send_data)
       end
     end

--- a/spec/controllers/spot/export_controller_spec.rb
+++ b/spec/controllers/spot/export_controller_spec.rb
@@ -1,43 +1,52 @@
 # frozen_string_literal: true
-require 'fileutils'
-
 RSpec.describe Spot::ExportController do
   routes { Rails.application.routes }
 
   before do
-    allow(controller).to receive(:render)
+    allow(controller).to receive(:search_results).and_return([nil, [solr_document]])
     allow(Spot::Exporters::ZippedWorkExporter).to receive(:new).and_return(exporter)
-    allow(File).to receive(:open)
-    allow(ActiveFedora::Base).to receive(:find).with('fs000').and_return(file_set)
-    allow(ActiveFedora::Base).to receive(:find).with('pub000').and_return(work)
-    allow(file_set).to receive(:is_a?).with(FileSet).and_return(true)
     allow(controller.hyrax)
       .to receive(:download_path)
-      .with(file_set, locale: nil)
+      .with(file_set.id, locale: nil)
       .and_return("/downloads/#{file_set.id}")
   end
 
   let(:exporter) { instance_double(Spot::Exporters::ZippedWorkExporter, export!: true) }
-  let(:work) { instance_double(Publication, id: 'pub000', etag: 'W/"xxxxxx"') }
+  let(:work) { instance_double(Publication, id: 'pub000') }
   let(:file_set) { instance_double(FileSet, id: 'fs000') }
+  let(:params) { { id: item_id, format: :zip } }
+  let(:solr_document) do
+    SolrDocument.new id: 'pub000',
+                     file_set_ids_ssim: [file_set.id],
+                     has_model_ssim: ['Publication'],
+                     _version_: '1234567890'
+  end
 
   describe 'GET #show' do
     before do
-      allow(controller).to receive(:send_data)
-      get :show, params: { id: item_id, format: :zip }
+      allow(controller).to receive(:send_file)
+      get :show, params: params
     end
 
     context 'when requesting a file_set' do
       let(:item_id) { file_set.id }
+      let(:solr_document) { SolrDocument.new id: 'fs000', has_model_ssim: ['FileSet'] }
 
       it { is_expected.to redirect_to Hyrax::Engine.routes.url_helpers.download_path(item_id) }
+    end
+
+    context 'when requesting the files of a work that only has one' do
+      let(:item_id) { work.id }
+      let(:params) { { id: item_id, format: :zip, export_type: :files } }
+
+      it { is_expected.to redirect_to Hyrax::Engine.routes.url_helpers.download_path(file_set.id) }
     end
 
     context 'when requesting a work' do
       let(:item_id) { work.id }
 
       it 'calls :send_data' do
-        expect(controller).to have_received(:send_data)
+        expect(controller).to have_received(:send_file)
       end
     end
   end

--- a/spec/controllers/spot/export_controller_spec.rb
+++ b/spec/controllers/spot/export_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Spot::ExportController do
     end
 
     context 'when requesting a work' do
-      before { allow(controller).to receive(:send_file) }
+      before { allow(controller).to receive(:send_file) { controller.head :ok } }
 
       let(:item_id) { work.id }
       let(:solr_document) do

--- a/spec/factories/publication.rb
+++ b/spec/factories/publication.rb
@@ -68,9 +68,8 @@ FactoryBot.define do
         actor.attach_to_work(work)
 
         if evaluator.ingest_file
-          Hydra::Works::UploadFileToFileSet.call(fs, evaluator.file, additional_services: [
-            ->(fs) { fs.original_file.file_name = File.basename(evaluator.file.path) }
-          ])
+          change_filename = ->(file_set) { file_set.original_file.file_name = File.basename(evaluator.file.path) }
+          Hydra::Works::UploadFileToFileSet.call(fs, evaluator.file, additional_services: [change_filename])
         end
       end
     end

--- a/spec/jobs/spot/repository_fixity_check_job_spec.rb
+++ b/spec/jobs/spot/repository_fixity_check_job_spec.rb
@@ -3,17 +3,15 @@ RSpec.describe Spot::RepositoryFixityCheckJob do
   subject(:perform_job!) { described_class.perform_now(job_opts) }
 
   let(:service_double) { instance_double(Hyrax::FileSetFixityCheckService) }
-  let(:fs) { FileSet.create! }
+  let(:fs) { instance_double(FileSet, id: 'abc123') }
   let(:job_opts) { {} }
 
   before do
     allow(Hyrax::FileSetFixityCheckService).to receive(:new).and_return(service_double)
     allow(service_double).to receive(:fixity_check)
-    fs
+    allow(FileSet).to receive(:find_each).and_yield(fs)
     perform_job!
   end
-
-  after { FileSet.destroy_all }
 
   context 'default implementation' do
     let(:opts) { { async_jobs: false } }

--- a/spec/jobs/spot/repository_fixity_check_job_spec.rb
+++ b/spec/jobs/spot/repository_fixity_check_job_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Spot::RepositoryFixityCheckJob do
         .to have_received(:new)
         .with(fs, opts)
 
-      expect(service_double).to have_received(:fixity_check)
+      expect(service_double).to have_received(:fixity_check).at_least(1).times
     end
   end
 

--- a/spec/jobs/spot/repository_fixity_check_job_spec.rb
+++ b/spec/jobs/spot/repository_fixity_check_job_spec.rb
@@ -34,10 +34,9 @@ RSpec.describe Spot::RepositoryFixityCheckJob do
     it do
       expect(Hyrax::FileSetFixityCheckService)
         .to have_received(:new)
-        .at_least(1)
-        .times.with(fs, opts)
+        .with(fs, opts)
 
-      expect(service_double).to have_received(:fixity_check)
+      expect(service_double).to have_received(:fixity_check).at_least(1).times
     end
   end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe SolrDocument do
     description: { type: Array, suffix: 'tesim' },
     division: { type: Array, suffix: 'tesim' },
     editor: { type: Array, suffix: 'tesim' },
+    file_set_ids: { type: Array, suffix: 'ssim', value: ['abc123', 'def456'] },
     file_size: { type: String, suffix: 'lts' },
     identifier: { type: Array, suffix: 'ssim' },
     keyword: { type: Array, suffix: 'tesim' },

--- a/spec/presenters/hyrax/publication_presenter_spec.rb
+++ b/spec/presenters/hyrax/publication_presenter_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Hyrax::PublicationPresenter do
 
   it_behaves_like 'it renders an attribute to HTML'
 
+  describe '#export_formats' do
+    subject { presenter.export_formats }
+
+    it { is_expected.to include :csv, :ttl, :nt, :jsonld }
+  end
+
   describe '#public?' do
     subject { presenter.public? }
 

--- a/spec/search_builders/spot/work_and_file_set_search_builder_spec.rb
+++ b/spec/search_builders/spot/work_and_file_set_search_builder_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+RSpec.describe Spot::WorkAndFileSetSearchBuilder do
+  let(:builder) { described_class.new([]) }
+
+  describe '#filter_models' do
+    subject(:params) { {} }
+
+    before { builder.filter_models(params) }
+
+    it 'adds a :fq key' do
+      expect(params).to include :fq
+    end
+
+    it 'is an array' do
+      expect(params[:fq]).to be_an Array
+    end
+
+    it 'adds FileSet to the list of models to search' do
+      expect(params[:fq].first).to start_with '{!terms f=has_model_ssim}'
+      expect(params[:fq].first).to include 'FileSet'
+    end
+  end
+end

--- a/spec/services/spot/exporters/work_members_exporter_spec.rb
+++ b/spec/services/spot/exporters/work_members_exporter_spec.rb
@@ -4,9 +4,9 @@ require 'fileutils'
 # Is this too much mocking? I didn't want to go down the rabbit hole
 # of generating a full item just for this spec.
 RSpec.describe Spot::Exporters::WorkMembersExporter, perform_enqueued: true do
-  subject(:exporter) { described_class.new(work) }
+  subject(:exporter) { described_class.new(solr_document) }
 
-  let(:work) { instance_double(Publication, id: 'abc123') }
+  let(:solr_document) { instance_double(SolrDocument, file_set_ids: ['abc123']) }
   let(:file_set) { instance_double(FileSet, original_file: file) }
   let(:path_to_file) { Rails.root.join('spec', 'fixtures', 'image.png') }
   let(:file) do
@@ -14,18 +14,19 @@ RSpec.describe Spot::Exporters::WorkMembersExporter, perform_enqueued: true do
                     stream: [File.read(path_to_file)],
                     file_name: ['test-image.png'])
   end
+  let(:destination) { '/tmp/spot-work_members_exporter_spec' }
 
   before do
-    allow(ActiveFedora::Base).to receive(:find).with('abc123').and_return(work)
-    allow(work).to receive(:file_sets).and_return [file_set]
+    allow(ActiveFedora::Base).to receive(:find).with(['abc123']).and_return([file_set])
+    allow(file_set).to receive(:is_a?).with(FileSet).and_return true
+    FileUtils.mkdir_p(destination)
   end
 
   describe '#export!' do
-    let(:destination) { '/tmp' }
     let(:expected_file) { File.join(destination, 'test-image.png') }
 
     before { exporter.export!(destination: destination) }
-    after { FileUtils.rm(expected_file) }
+    after { FileUtils.rm_r(destination) }
 
     it 'writes the file to the destination' do
       expect(File.exist?(expected_file)).to be true

--- a/spec/services/spot/exporters/work_members_exporter_spec.rb
+++ b/spec/services/spot/exporters/work_members_exporter_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'fileutils'
+
+# Is this too much mocking? I didn't want to go down the rabbit hole
+# of generating a full item just for this spec.
+RSpec.describe Spot::Exporters::WorkMembersExporter, perform_enqueued: true do
+  subject(:exporter) { described_class.new(work) }
+
+  let(:work) { instance_double(Publication, id: 'abc123') }
+  let(:file_set) { instance_double(FileSet, original_file: file) }
+  let(:path_to_file) { Rails.root.join('spec', 'fixtures', 'image.png') }
+  let(:file) do
+    instance_double(Hydra::PCDM::File,
+                    stream: [File.read(path_to_file)],
+                    file_name: ['test-image.png'])
+  end
+
+  before do
+    allow(ActiveFedora::Base).to receive(:find).with('abc123').and_return(work)
+    allow(work).to receive(:file_sets).and_return [file_set]
+  end
+
+  describe '#export!' do
+    let(:destination) { '/tmp' }
+    let(:expected_file) { File.join(destination, 'test-image.png') }
+
+    before { exporter.export!(destination: destination) }
+    after { FileUtils.rm(expected_file) }
+
+    it 'writes the file to the destination' do
+      expect(File.exist?(expected_file)).to be true
+    end
+  end
+end

--- a/spec/services/spot/exporters/work_metadata_exporter_spec.rb
+++ b/spec/services/spot/exporters/work_metadata_exporter_spec.rb
@@ -2,8 +2,7 @@
 require 'fileutils'
 
 RSpec.describe Spot::Exporters::WorkMetadataExporter do
-  let(:exporter) { described_class.new(work, ability, request) }
-
+  let(:exporter) { described_class.new(solr_doc, request) }
   let(:work) { create(:publication, title: ['cool beans']) }
   let(:ability) { Ability.new(nil) }
   let(:request) { instance_double(ActionDispatch::Request, host: 'localhost') }

--- a/spec/services/spot/exporters/work_metadata_exporter_spec.rb
+++ b/spec/services/spot/exporters/work_metadata_exporter_spec.rb
@@ -64,6 +64,10 @@ RSpec.describe Spot::Exporters::WorkMetadataExporter do
 
       let(:format) { :jsonld }
 
+      it 'saves the file as <id>.jsonld' do
+        expect(File.exist?(expected_output_file)).to be true
+      end
+
       it 'contains @id' do
         expect(parsed['@id']).to eq object_url
       end
@@ -73,12 +77,33 @@ RSpec.describe Spot::Exporters::WorkMetadataExporter do
       end
     end
 
+    context 'when requesting csv' do
+      let(:content) { CSV.parse(File.open(expected_output_file)) }
+      let(:format) { :csv }
+
+      it 'saves as <id>.csv' do
+        expect(File.exist?(expected_output_file)).to be true
+      end
+
+      it 'only writes two rows' do
+        expect(content.size).to eq 2
+      end
+
+      it 'outputs the headers' do
+        expect(content.first.join(',')).to start_with 'id,title'
+      end
+
+      it 'outputs the content' do
+        expect(content.last.first).to eq work.id
+      end
+    end
+
     context 'when requesting all formats' do
       subject { Dir["#{destination}/*"].map { |f| File.basename(f) } }
 
       let(:format) { :all }
       let(:id) { work.id }
-      let(:files) { %w[nt ttl jsonld].map { |ext| "#{id}.#{ext}" } }
+      let(:files) { %w[nt ttl jsonld csv].map { |ext| "#{id}.#{ext}" } }
 
       it { is_expected.to include(*files) }
     end

--- a/spec/services/spot/exporters/work_metadata_exporter_spec.rb
+++ b/spec/services/spot/exporters/work_metadata_exporter_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+require 'fileutils'
+
+RSpec.describe Spot::Exporters::WorkMetadataExporter do
+  let(:exporter) { described_class.new(work, ability, request) }
+
+  let(:work) { create(:publication, title: ['cool beans']) }
+  let(:ability) { Ability.new(nil) }
+  let(:request) { instance_double(ActionDispatch::Request, host: 'localhost') }
+  let(:destination) { '/tmp/spot-work_metadata_exporter_spec' }
+  let(:attributes) { { title: ['cool beans'] } }
+  let(:solr_doc) { SolrDocument.find(work.id) }
+
+  before do
+    FileUtils.mkdir_p(destination)
+    ActiveFedora::Fedora.reset!
+  end
+  after { FileUtils.rm_r(destination) }
+
+  describe '#export!' do
+    subject(:content) do
+      File.open(expected_output_file)
+          .read
+          .gsub(/\s+/, ' ')
+          .strip
+    end
+
+    before { exporter.export!(destination: destination, format: format) }
+
+    let(:expected_output_file) { File.join(destination, "#{work.id}.#{format}") }
+    let(:graph) { Hyrax::GraphExporter.new(solr_doc, request).fetch }
+    let(:output) { graph.dump(format, *args) }
+    let(:args) { {} }
+    let(:object_url) { "http://localhost/concern/publications/#{work.id}"}
+
+    context 'when requesting ttl' do
+      let(:format) { :ttl }
+      let(:title_ttl) do
+        %(<http://purl.org/dc/terms/title> "#{work.title.first}";)
+      end
+
+      it 'saves the file as <id>.ttl' do
+        expect(File.exist?(expected_output_file)).to be true
+      end
+
+      it { is_expected.to start_with "<#{object_url}> a"}
+      it { is_expected.to include title_ttl }
+    end
+
+    context 'when requesting ntriples' do
+      let(:format) { :nt }
+      let(:title_nt) do
+        %(<#{object_url}> <http://purl.org/dc/terms/title> "#{work.title.first}" .)
+      end
+
+      it 'saves the file as <id>.nt' do
+        expect(File.exist?(expected_output_file)).to be true
+      end
+
+      it { is_expected.to include title_nt }
+    end
+
+    context 'when requesting jsonld' do
+      subject(:parsed) { JSON.parse(content) }
+
+      let(:format) { :jsonld }
+
+      it 'contains @id' do
+        expect(parsed['@id']).to eq object_url
+      end
+
+      it do
+        expect(parsed['dc:title']).to eq work.title.first
+      end
+    end
+
+    context 'when requesting all formats' do
+      subject { Dir["#{destination}/*"].map { |f| File.basename(f) } }
+
+      let(:format) { :all }
+      let(:id) { work.id }
+      let(:files) { %w[nt ttl jsonld].map { |ext| "#{id}.#{ext}" } }
+
+      it { is_expected.to include(*files) }
+    end
+  end
+end

--- a/spec/services/spot/exporters/work_metadata_exporter_spec.rb
+++ b/spec/services/spot/exporters/work_metadata_exporter_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Spot::Exporters::WorkMetadataExporter do
     let(:graph) { Hyrax::GraphExporter.new(solr_doc, request).fetch }
     let(:output) { graph.dump(format, *args) }
     let(:args) { {} }
-    let(:object_url) { "http://localhost/concern/publications/#{work.id}"}
+    let(:object_url) { "http://localhost/concern/publications/#{work.id}" }
 
     context 'when requesting ttl' do
       let(:format) { :ttl }
@@ -43,7 +43,7 @@ RSpec.describe Spot::Exporters::WorkMetadataExporter do
         expect(File.exist?(expected_output_file)).to be true
       end
 
-      it { is_expected.to start_with "<#{object_url}> a"}
+      it { is_expected.to start_with "<#{object_url}> a" }
       it { is_expected.to include title_ttl }
     end
 

--- a/spec/services/spot/exporters/zipped_work_exporter_spec.rb
+++ b/spec/services/spot/exporters/zipped_work_exporter_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require 'fileutils'
+
+RSpec.describe Spot::Exporters::ZippedWorkExporter do
+  let(:exporter) { described_class.new(work, ability, request) }
+  let(:path_to_file) { Rails.root.join('spec', 'fixtures', 'image.png') }
+  let(:ability) { Ability.new(nil) }
+  let(:request) { instance_double(ActionDispatch::Request, host: 'localhost') }
+  let(:destination) { '/tmp/spot-zipped_work_exporter_spec' }
+  let(:work) do
+    create(:publication, file: File.open(path_to_file),
+                         file_set_params: { label: 'image.png' },
+                         ingest_file: true)
+  end
+
+  before do
+    FileUtils.mkdir_p(destination)
+    ActiveFedora::Fedora.reset!
+  end
+
+  after { FileUtils.rm_r(destination) }
+
+  describe '#export!' do
+    before do
+      exporter.export!(destination: output_file, metadata_formats: formats)
+      ::ZipService.new(src_path: output_file).unzip!(dest_path: unzipped_location)
+    end
+
+    # the default
+    let(:formats) { :all }
+    let(:metadata_files) { %w[nt ttl jsonld].map { |ext| "#{work.id}.#{ext}" } }
+    let(:expected_entries) { metadata_files + ['files', 'files/image.png'] }
+    let(:output_file) { File.join(destination, "#{work.id}.zip") }
+    let(:unzipped_location) { File.join(destination, 'unzipped') }
+
+    it 'creates a zip file at <work_id>.zip' do
+      expect(File.exist?(output_file)).to be true
+    end
+
+    it 'includes all metadata formats + files' do
+      expect(file_entries(unzipped_location)).to contain_exactly(*expected_entries)
+    end
+
+    context 'when no metadata files requested' do
+      let(:formats) { nil }
+      let(:expected_entries) { ['test-image.png'] }
+
+      it 'zips only the file_sets' do
+        expect(file_entries(unzipped_location)).to contain_exactly('image.png')
+      end
+    end
+  end
+
+  def file_entries(path)
+    Dir[File.join(path, '**', '*')].map { |e| e.sub(path.to_s + '/', '') }
+  end
+end

--- a/spec/services/spot/exporters/zipped_work_exporter_spec.rb
+++ b/spec/services/spot/exporters/zipped_work_exporter_spec.rb
@@ -2,7 +2,7 @@
 require 'fileutils'
 
 RSpec.describe Spot::Exporters::ZippedWorkExporter do
-  let(:exporter) { described_class.new(work, ability, request) }
+  let(:exporter) { described_class.new(work, request) }
   let(:path_to_file) { Rails.root.join('spec', 'fixtures', 'image.png') }
   let(:ability) { Ability.new(nil) }
   let(:request) { instance_double(ActionDispatch::Request, host: 'localhost') }

--- a/spec/services/spot/exporters/zipped_work_exporter_spec.rb
+++ b/spec/services/spot/exporters/zipped_work_exporter_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Spot::Exporters::ZippedWorkExporter do
 
     # the default
     let(:formats) { :all }
-    let(:metadata_files) { %w[nt ttl jsonld].map { |ext| "#{work.id}.#{ext}" } }
+    let(:metadata_files) { %w[nt ttl jsonld csv].map { |ext| "#{work.id}.#{ext}" } }
     let(:expected_entries) { metadata_files + ['files', 'files/image.png'] }
     let(:output_file) { File.join(destination, "#{work.id}.zip") }
     let(:unzipped_location) { File.join(destination, 'unzipped') }

--- a/spec/services/spot/work_csv_service_spec.rb
+++ b/spec/services/spot/work_csv_service_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require 'tmpdir'
+
+# rubocop:disable RSpec/ExampleLength
+RSpec.describe Spot::WorkCSVService do
+  let(:service) { described_class.new(work, terms: terms) }
+  let(:work) { build(:publication, id: 'abc123', title: ['one title', 'two titles']) }
+  let(:terms) { %i[id title creator] }
+  let(:expected_headers) { "id,title,creator\n" }
+  let(:expected_content) do
+    %(#{work.id},#{work.title.map(&:to_s).join('|')},"#{work.creator.map(&:to_s).join('|')}"\n)
+  end
+
+  describe '#headers' do
+    subject { service.headers }
+
+    it { is_expected.to be_a String }
+    it { is_expected.to eq expected_headers }
+
+    # this is gross but i want to confirm that we're using the default terms
+    context 'when no terms are provided' do
+      subject { described_class.new(work).headers }
+
+      it { is_expected.to eq service.send(:default_terms).join(',') + "\n" }
+    end
+  end
+
+  describe '#content' do
+    subject { service.content }
+
+    it { is_expected.to be_a String }
+    it { is_expected.to eq expected_content }
+
+    context 'when a field does not exist on a work' do
+      let(:service) { described_class.new(work, terms: [:id, :nope_not_here]) }
+
+      it { is_expected.to eq %(#{work.id},""\n) }
+    end
+  end
+
+  describe '#csv' do
+    subject { service.csv }
+
+    let(:content) { expected_headers + expected_content }
+
+    it { is_expected.to eq content }
+
+    context 'when no headers wanted' do
+      let(:service) { described_class.new(work, terms: terms, include_headers: false) }
+
+      it { is_expected.to eq expected_content }
+      it { is_expected.not_to include expected_headers }
+    end
+  end
+end
+# rubocop:enable RSpec/ExampleLength

--- a/spec/services/spot/work_csv_service_spec.rb
+++ b/spec/services/spot/work_csv_service_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'tmpdir'
 
-# rubocop:disable RSpec/ExampleLength
 RSpec.describe Spot::WorkCSVService do
   let(:service) { described_class.new(work, terms: terms) }
   let(:work) { build(:publication, id: 'abc123', title: ['one title', 'two titles']) }
@@ -53,4 +52,3 @@ RSpec.describe Spot::WorkCSVService do
     end
   end
 end
-# rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
we're going to want to export not only representative files but also all filesets belonging to an item. as well as metadata for the item. this aims to do that.

- [x] service for exporting items
- [x] controller for exports
- [x] access control for export (`:load_and_authorize_resource`)
- [x] add button to work view
- [x] add ability to export csv of metadata

closes #169 