### PR TITLE
update cas attributes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,8 @@ class User < ApplicationRecord
 
   devise :cas_authenticatable, :rememberable
 
+  before_save :ensure_username
+
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for
   # the account.
@@ -38,4 +40,18 @@ class User < ApplicationRecord
     self.email = attributes['email']
     self.display_name = "#{attributes['givenName']} #{attributes['surname']}".strip
   end
+
+  private
+
+    # Callback to ensure that we store a username, as that's what's used for uniqueness.
+    # We occasionally provide a depositor in some ingest cases, but that relies on the
+    # email address and _not_ the username. We'll capture the username as anything
+    # before the +@+ symbol of the email.
+    #
+    # @return [void]
+    def ensure_username
+      return unless username.blank?
+
+      self.username = email.gsub(/@.*$/, '')
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,18 +27,15 @@ class User < ApplicationRecord
     email
   end
 
-  # Sets up attributes returned from CAS
+  # Sets up attributes returned from CAS. No need to save the object: that's done
+  # via devise_cas_authenticatable.
   #
   # @param [Hash<String => String>] attributes
   # @return [void]
+  # @todo when/if released, capture: memberOf, affiliation, department
   def cas_extra_attributes=(attributes)
     self.username = attributes['uid']
-    self.email = attributes['mail']
-
-    self.display_name = "#{attributes['givenName']} #{attributes['sn']}".strip
-
-    # self.member_of = attributes['memberOf']
-    # self.affiliation = attributes['affiliation'] if attributes['affiliation']
-    # self.department = attributes['department'] if attributes['department']
+    self.email = attributes['email']
+    self.display_name = "#{attributes['givenName']} #{attributes['surname']}".strip
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe User do
       {
         'uid' => 'wishmand',
         'givenName' => 'Doris',
-        'sn' => 'Wishman',
-        'mail' => 'wishmand@lafayette.edu'
+        'surname' => 'Wishman',
+        'email' => 'wishmand@lafayette.edu'
       }
     end
 
@@ -25,19 +25,29 @@ RSpec.describe User do
     end
 
     it 'stores the email' do
-      expect(user.email).to eq attrs['mail']
+      expect(user.email).to eq attrs['email']
     end
 
-    it 'constructs :display_name from "sn" + "givenName"' do
-      expect(user.display_name).to eq "#{attrs['givenName']} #{attrs['sn']}"
+    it 'constructs :display_name from "surname" + "givenName"' do
+      expect(user.display_name).to eq "#{attrs['givenName']} #{attrs['surname']}"
     end
 
     context 'when "givenName" not present' do
-      let(:attrs) { { 'uid' => 'spotapp', 'sn' => 'spot' } }
+      let(:attrs) { { 'uid' => 'spotapp', 'surname' => 'spot' } }
 
-      it 'uses only the "sn"' do
-        expect(user.display_name).to eq attrs['sn']
+      it 'uses only the "surname"' do
+        expect(user.display_name).to eq attrs['surname']
       end
+    end
+  end
+
+  describe '#ensure_username (before_save callback)' do
+    let(:user) { User.new(email: 'cool_beans@lafayette.edu') }
+
+    it 'creates a username where missing' do
+      expect(user.username).to be nil
+      user.save!
+      expect(user.username).to eq 'cool_beans'
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe User do
   end
 
   describe '#ensure_username (before_save callback)' do
-    let(:user) { User.new(email: 'cool_beans@lafayette.edu') }
+    let(:user) { described_class.new(email: 'cool_beans@lafayette.edu') }
 
     it 'creates a username where missing' do
       expect(user.username).to be nil


### PR DESCRIPTION
- `sn => surname`
- `mail => email`
- adds callback to ensure a username is present (used when we're creating a user server-side that may need to sign in later)

