### PR TITLE
add support for specifying collections on ingest

### DIFF
--- a/app/jobs/spot/ingest_bag_job.rb
+++ b/app/jobs/spot/ingest_bag_job.rb
@@ -22,10 +22,11 @@ module Spot
     # @raise [ArgumentError] if +work_class:+ not a valid Work type
     # @raise [ValidationError] if the file to parse is invalid
     #   (from Darlingtonia::Parser)
-    def perform(bag_path:, source:, work_class:)
+    def perform(bag_path:, source:, work_class:, collection_ids: [])
       @bag_path = bag_path
       @source = source
       @work_class = work_class.constantize
+      @collection_ids = collection_ids
 
       raise ArgumentError, "Unknown source: #{source}." unless source_available?
       raise ArgumentError, "Unknown work_class: #{work_class}" unless work_class_valid?
@@ -71,6 +72,7 @@ module Spot
           info = Spot::StreamLogger.new(logger, level: ::Logger::INFO)
           error = Spot::StreamLogger.new(logger, level: ::Logger::WARN)
           Spot::Importers::Bag::RecordImporter.new(work_class: @work_class,
+                                                   collection_ids: @collection_ids,
                                                    info_stream: info,
                                                    error_stream: error)
         end

--- a/app/jobs/spot/ingest_doi_job.rb
+++ b/app/jobs/spot/ingest_doi_job.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 module Spot
   class IngestDOIJob < ::ApplicationJob
-    def perform(doi:, work_class:)
+    def perform(doi:, work_class:, collection_ids: [])
       @doi = doi
       @work_class = work_class.constantize
+      @collection_ids = collection_ids
 
       raise ArgumentError, "Unknown work_class: #{@work_class}" unless work_class_valid?
 
@@ -30,6 +31,7 @@ module Spot
           info = Spot::StreamLogger.new(logger, level: ::Logger::INFO)
           error = Spot::StreamLogger.new(logger, level: ::Logger::WARN)
           Spot::Importers::Unpaywall::RecordImporter.new(work_class: @work_class,
+                                                         collection_ids: @collection_ids,
                                                          info_stream: info,
                                                          error_stream: error)
         end

--- a/app/jobs/spot/ingest_zipped_bag_job.rb
+++ b/app/jobs/spot/ingest_zipped_bag_job.rb
@@ -24,7 +24,7 @@ module Spot
     #   (from Spot::IngestBagJob)
     # @raise [ValidationError] if the file to parse is invalid
     #   (from Darlingtonia::Parser)
-    def perform(zip_path:, source:, work_class:, working_path:)
+    def perform(zip_path:, source:, work_class:, working_path:, collection_ids: [])
       raise ArgumentError, "#{working_path} is not a directory" unless File.directory?(working_path)
 
       destination = File.join(working_path, File.basename(zip_path, '.zip'))
@@ -34,7 +34,8 @@ module Spot
 
       Spot::IngestBagJob.perform_now(bag_path: destination,
                                      source: source,
-                                     work_class: work_class)
+                                     work_class: work_class,
+                                     collection_ids: collection_ids)
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,4 +7,9 @@ Rake::Task['hyrax:default_collection_types:create'].invoke
 # create a depositor user
 deposibot = User.find_or_create_by(email: 'dss@lafayette.edu') do |bot|
   bot.display_name = 'DeposiBot'
+
+  # give the depositor user admin access
+  admin_role = Role.find_by_name('admin')
+  bot.roles << admin_role if admin_role
 end
+

--- a/lib/tasks/spot/ingest.rake
+++ b/lib/tasks/spot/ingest.rake
@@ -6,6 +6,7 @@ namespace :spot do
     source = ENV['source']
     path = ENV['path']
     work_class = ENV['work_class']
+    collection_ids = ENV['collection_ids'].to_s.split(',')
     working_path = ENV.fetch('working_path') { Rails.root.join('tmp', 'ingest').to_s }
 
     error_message = if    !source       then 'No `source` provided!'
@@ -27,8 +28,11 @@ namespace :spot do
     paths = File.directory?(path) ? Dir[File.join(path, '*.zip')] : [path]
 
     paths.each do |entry|
-      Spot::IngestZippedBagJob.perform_later(zip_path: entry, source: source,
-                                             work_class: work_class, working_path: working_path)
+      Spot::IngestZippedBagJob.perform_later(zip_path: entry,
+                                             source: source,
+                                             collection_ids: collection_ids,
+                                             work_class: work_class,
+                                             working_path: working_path)
     end
   end
 end

--- a/spec/jobs/spot/ingest_zipped_bag_job_spec.rb
+++ b/spec/jobs/spot/ingest_zipped_bag_job_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Spot::IngestZippedBagJob do
     described_class.perform_now(zip_path: zip_path,
                                 work_class: work_class,
                                 source: source,
+                                collection_ids: collection_ids,
                                 working_path: working_path)
   end
 
@@ -14,6 +15,7 @@ RSpec.describe Spot::IngestZippedBagJob do
   let(:work_class) { 'Publication' }
   let(:source) { 'ldr' }
   let(:zip_service_double) { instance_double(ZipService, unzip!: true) }
+  let(:collection_ids) { ['abc123def'] }
 
   describe '#perform' do
     before do
@@ -27,7 +29,8 @@ RSpec.describe Spot::IngestZippedBagJob do
 
       expect(Spot::IngestBagJob)
         .to have_received(:perform_now)
-        .with(bag_path: working_path.join('bag').to_s, source: source, work_class: work_class)
+        .with(bag_path: working_path.join('bag').to_s, source: source,
+              work_class: work_class, collection_ids: collection_ids)
     end
 
     context 'when working path isn\'t a directory' do

--- a/spec/support/shared_examples/record_importer.rb
+++ b/spec/support/shared_examples/record_importer.rb
@@ -3,6 +3,7 @@ RSpec.shared_examples 'a RecordImporter' do |params|
   subject(:importer) do
     described_class.new(work_class: work_class,
                         admin_set_id: admin_set_id,
+                        collection_ids: [collection_id],
                         info_stream: info_stream,
                         error_stream: error_stream)
   end
@@ -12,6 +13,7 @@ RSpec.shared_examples 'a RecordImporter' do |params|
   let(:admin_set_id) { 'an_admin_set' }
   let(:info_stream) { dev_null }
   let(:error_stream) { dev_null }
+  let(:collection_id) { 'collection123' }
 
   describe '#import' do
     subject(:import_record!) { importer.import(record: record) }
@@ -38,7 +40,10 @@ RSpec.shared_examples 'a RecordImporter' do |params|
         keyword: metadata['dc:keyword'],
         visibility: mapper.class.default_visibility,
         remote_files: [{ url: 'file://image.png', name: 'image.png' }],
-        admin_set_id: admin_set_id
+        admin_set_id: admin_set_id,
+        member_of_collections_attributes: {
+          '0' => { 'id' => collection_id }
+        }
       }
     end
 


### PR DESCRIPTION
adds the option to pass collection ids to the record importer to add new items to a collection

```bash
bundle exec rails spot:ingest \
  work_class=Publication \
  source=ldr \
  path=/path/to/ldr-bags \
  collection_ids=abc123,def456
```

from the command-line, use a comma (no space!) separator

closes #69 