### PR TITLE
move all overrides to their own files

### DIFF
--- a/app/overrides/controllers/hyrax/collections_controller_override.rb
+++ b/app/overrides/controllers/hyrax/collections_controller_override.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+#
+# Uses our own CollectionPresenter, which itself is a subclass of the Hyrax one
+Hyrax::CollectionsController.class_eval do
+  self.presenter_class = Spot::CollectionPresenter
+end

--- a/app/overrides/controllers/hyrax/dashboard/collections_controller_override.rb
+++ b/app/overrides/controllers/hyrax/dashboard/collections_controller_override.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+#
+# Since we've altered the properites of Collections,
+# we'll need to provide our own form (which is a subclass
+# of the Hyrax one).
+Hyrax::Dashboard::CollectionsController.class_eval do
+  self.form_class = Spot::Forms::CollectionForm
+end

--- a/config/initializers/hyrax_overrides.rb
+++ b/config/initializers/hyrax_overrides.rb
@@ -7,7 +7,6 @@
 # case is necessary, we'll put the file into +app/overrides+ and load
 # all of them here, after initialization.
 Rails.application.config.after_initialize do
-
   # Load all of our overrides/class_evals
   # (adapted from https://github.com/sciencehistory/chf-sufia/blob/d1c7d58/config/application.rb#L43-L48)
   Dir.glob(Rails.root.join('app', 'overrides', '**', '*.rb')) do |c|

--- a/config/initializers/hyrax_overrides.rb
+++ b/config/initializers/hyrax_overrides.rb
@@ -7,19 +7,6 @@
 # case is necessary, we'll put the file into +app/overrides+ and load
 # all of them here, after initialization.
 Rails.application.config.after_initialize do
-  # Removes the TransactionalRequest from the actor stack, as it's the culprit
-  # for the nasty Ldp::Gone errors that happen when an item fails in the
-  # actor stack. hyrax#3282 accomplishes the same thing, so this should be
-  # on the chopping-block for the hyrax@3 upgrade
-  #
-  # @todo remove this when upgrading to Hyrax@3
-  Hyrax::CurationConcern.actor_factory.delete(Hyrax::Actors::TransactionalRequest)
-
-  # Uses our own CollectionPresenter, which itself is a subclass of the Hyrax one
-  Hyrax::CollectionsController.presenter_class = Spot::CollectionPresenter
-
-  # Uses our own CollectionForm, which itself is a subclass of the Hyrax one
-  Hyrax::Dashboard::CollectionsController.form_class = Spot::Forms::CollectionForm
 
   # Load all of our overrides/class_evals
   # (adapted from https://github.com/sciencehistory/chf-sufia/blob/d1c7d58/config/application.rb#L43-L48)


### PR DESCRIPTION
i've been running into issues locally where every-so-often `Hyrax::CollectionsController` will forget that i've set the `presenter_class` attribute to `Spot::CollectionPresenter` and will get errors about not-defined methods. my guess is that this is because of classes being reloaded after boot and not remembering the attribute changes from the initializers.

so it's not a production problem but it _is_ really annoying when dev-ing. moving the definitions into `class_eval` calls should prevent this, i think.