### PR TITLE
ensure that collections from config have permission_templates

### DIFF
--- a/app/controllers/spot/homepage_controller.rb
+++ b/app/controllers/spot/homepage_controller.rb
@@ -19,7 +19,7 @@ module Spot
 
       # @return [Array<SolrDocument>]
       def recent_works
-        _, docs = search_results(q: '', sort: 'date_uploaded_dtsi desc', rows: 6)
+        _, docs = search_results(q: recent_items_query, sort: 'date_uploaded_dtsi desc', rows: 6)
         docs
       rescue Blacklight::Exceptions::ECONNREFUSED, Blacklight::Exceptions::InvalidRequest
         []
@@ -40,6 +40,10 @@ module Spot
       # @return [Class]
       def presenter_class
         Spot::HomepagePresenter
+      end
+
+      def recent_items_query
+        "{!terms f=has_model_ssim}#{Hyrax.config.curation_concerns.join(',')}"
       end
   end
 end

--- a/app/services/spot/collection_from_config.rb
+++ b/app/services/spot/collection_from_config.rb
@@ -58,7 +58,7 @@ module Spot
         col.attributes = { title: [title] }.merge(metadata)
         col.collection_type = collection_type
         col.visibility = visibility
-        col.apply_depositor_metadata(deposit_user.user_key)
+        col.apply_depositor_metadata(deposit_user&.user_key) if deposit_user
       end
 
       # add permissions to the collection
@@ -93,6 +93,7 @@ module Spot
       end
 
       # @return [User]
+      # @todo Use a configuration variable (or class_attribute) to set this
       def deposit_user
         @deposit_user ||= User.find_by_email('dss@lafayette.edu')
       end

--- a/app/services/spot/collection_from_config.rb
+++ b/app/services/spot/collection_from_config.rb
@@ -54,11 +54,11 @@ module Spot
       existing = Collection.where(title: [title])&.first
       return existing unless existing.nil?
 
-      collection = Collection.create!(title: [title]) do |col|
+      collection = Collection.create! do |col|
         col.attributes = { title: [title] }.merge(metadata)
         col.collection_type = collection_type
         col.visibility = visibility
-        col.depositor = deposit_user
+        col.apply_depositor_metadata(deposit_user.user_key)
       end
 
       # add permissions to the collection

--- a/app/views/spot/homepage/index.html.erb
+++ b/app/views/spot/homepage/index.html.erb
@@ -7,4 +7,4 @@
 <hr />
 
 <%= render 'featured_collections', presenter: @presenter %>
-<%= render 'recent_items', presenter: @presenter %>
+<%= render 'recent_items', presenter: @presenter unless @presenter.recent_items.empty? %>

--- a/lib/tasks/spot/collections.rake
+++ b/lib/tasks/spot/collections.rake
@@ -7,7 +7,7 @@ namespace :spot do
       config_path = ENV.fetch('config') { Rails.root.join('config', 'collections.yml') }
 
       YAML.safe_load(File.open(config_path)).each do |config|
-        Rails.logger.info "Creating collection: #{config['title']}"
+        puts "Creating collection: #{config['title']}"
         Spot::CollectionFromConfig.from_yaml(config).create
       end
     end

--- a/spec/forms/spot/forms/collection_form_spec.rb
+++ b/spec/forms/spot/forms/collection_form_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Spot::Forms::CollectionForm do
   subject(:form) { described_class.new(Collection.new, Ability.new(user), nil) }
 
   let(:user) { build(:admin_user) }
+  let(:hyrax_fields) { %i[visibility representative_id collection_type_gid thumbnail_id] }
 
   shared_context 'required fields' do
     it 'contains required fields' do
@@ -30,10 +31,7 @@ RSpec.describe Spot::Forms::CollectionForm do
     it { is_expected.to include :sponsor }
 
     # hyrax jawns
-    it { is_expected.to include :visibility }
-    it { is_expected.to include :representative_id }
-    it { is_expected.to include :collection_type_gid }
-    it { is_expected.to include :thumbnail_id }
+    it { is_expected.to include(*hyrax_fields) }
   end
 
   describe '.singular_fields' do
@@ -41,7 +39,7 @@ RSpec.describe Spot::Forms::CollectionForm do
 
     let(:fields) { %i[title abstract description] }
 
-    it { is_expected.to contain_exactly(*fields) }
+    it { is_expected.to contain_exactly(*(fields + hyrax_fields)) }
   end
 
   describe '.multiple?' do

--- a/spec/services/spot/collection_from_config_spec.rb
+++ b/spec/services/spot/collection_from_config_spec.rb
@@ -81,6 +81,11 @@ RSpec.describe Spot::CollectionFromConfig do
 
     it { is_expected.to be_a Collection }
 
+    it 'creates a default permission_template' do
+      expect(created.permission_template).not_to be nil
+      expect(created.permission_template.access_grants).not_to be_empty
+    end
+
     context 'when metadata is provided' do
       let(:title) { 'a new collection' }
       let(:metadata) { { description: ['A very nice collction'] } }


### PR DESCRIPTION
~i think the reason we weren't able to add items to some collections, or change the permissions on some, is because they were being created without permission_templates.~

~need to deploy to dev + double-check, but i think this should fix that.~

okay, so it wasn't _exactly_ that, but adding that code shouldn't hurt. the problem was in `Spot::Forms::CollectionForm.model_attributes`, where the hyrax fields, by being excluded
from the `.singular_fields` attribute, were being converted into arrays on submit. thankfully, this shouldn't need a complete reset of the repository contents, just a deploy.

closes #203 