### PR TITLE
add i18n misses to local hyrax.en.yml file

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1,19 +1,34 @@
+---
 en:
   activefedora:
     models:
       publication: 'Publication'
   hyrax:
-    product_name: Lafayette Digital Repository
+    account_name:           "My Institution Account Id"
+
+    collection_type:
+      admin_set_title: Administrative Set
+      default_title: User Collection
+
+    dashboard:
+      my:
+        heading:
+          collection_type: Collection Type
+          visibility: Visibility
+
+    directory:
+      suffix:               "@example.org"
+
+    institution_name:       "Lafayette College"
+    institution_name_full:  "Lafayette College"
+
     product_description: |
       %{name} is an online archive designed to preserve and make accessible materials from
       Lafayette College, including administrative publications and the scholarly work of
       Lafayette faculty.
+    product_name: Lafayette Digital Repository
     product_twitter_handle: "@LafLib"
-    institution_name:       "Lafayette College"
-    institution_name_full:  "Lafayette College"
-    account_name:           "My Institution Account Id"
-    directory:
-      suffix:               "@example.org"
+
     footer:
       copyright_html: "<strong>Copyright &copy; 2017 Samvera</strong> Licensed under the Apache License, Version 2.0"
       service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.


### PR DESCRIPTION
look, i have absolutely no idea why the hyrax gem locales don't load occasionally. these are the things i'm worried that it might be related to:

- bootsnap (clearing `tmp/cache` sometimes helps)
- `config.to_prepare` callback being used to load overrides (clearing this sometimes helps)
- some other mysterious Rails dark force that i don't know about?

i don't have a good fix + i can't find _anything_ on the internet about it, so i'm worried it's a local goof somewhere. but for now, whenever there's a translation miss, we'll just fill in the local `hyrax.en.yml` file.

oh also, the fix for the collection_type badges was editing their value in the database; when they were created, a translation missing error was raised and became their forever titles 😞 

closes #208 