### PR TITLE
🐜 fix bug where only one RdfLabel was being stored

### DIFF
--- a/app/models/spot/controlled_vocabularies/base.rb
+++ b/app/models/spot/controlled_vocabularies/base.rb
@@ -51,7 +51,6 @@ module Spot
         RdfLabel.where(uri: rdf_subject.to_s).first_or_create(&block)
       end
 
-
       # Does this value have a label or is it just an URI?
       #
       # @return [TrueClass,FalseClass]

--- a/app/models/spot/controlled_vocabularies/base.rb
+++ b/app/models/spot/controlled_vocabularies/base.rb
@@ -29,9 +29,7 @@ module Spot
         tries = 3
         begin
           super(*args).tap do
-            RdfLabel.first_or_create(uri: rdf_subject.to_s) do |label|
-              label.value = pick_preferred_label
-            end
+            find_or_create_from_cache { |label| label.value = pick_preferred_label }
             @preferred_label = nil
           end
         rescue StandardError => e
@@ -41,6 +39,18 @@ module Spot
           retry
         end
       end
+
+      # Fetches a label for +#rdf_subject+ from the RdfLabel cache if it exists,
+      # otherwise passes a block to +.first_or_create+. We're calling +.where+
+      # _before_ +.first_or_create+, as just calling +.first_or_create+ will
+      # return the first RdfLabel it finds and ignores the :uri parameter.
+      #
+      # @yield [RdfLabel] newly created label
+      # @return [RdfLabel]
+      def find_or_create_from_cache(&block)
+        RdfLabel.where(uri: rdf_subject.to_s).first_or_create(&block)
+      end
+
 
       # Does this value have a label or is it just an URI?
       #

--- a/app/models/spot/controlled_vocabularies/location.rb
+++ b/app/models/spot/controlled_vocabularies/location.rb
@@ -31,7 +31,7 @@ module Spot::ControlledVocabularies
       #
       # @return [String]
       def pick_preferred_label
-        RdfLabel.first_or_create(uri: rdf_subject.to_s) do |label|
+        find_or_create_from_cache do |label|
           label.value = authority_class.label.call(fetch_geonames_data)
         end.value
       end

--- a/spec/models/spot/controlled_vocabularies/location_spec.rb
+++ b/spec/models/spot/controlled_vocabularies/location_spec.rb
@@ -63,5 +63,21 @@ RSpec.describe Spot::ControlledVocabularies::Location do
         expect(WebMock).not_to have_requested(:get, api_base)
       end
     end
+
+    context 'when one exists but not what we want' do
+      let(:existing_uri) { 'http://sws.geonames.org/0123456/' }
+      let(:existing_label) { 'Mokhdān' }
+
+      before do
+        RdfLabel.delete_all
+        RdfLabel.create!(uri: existing_uri, value: existing_label)
+      end
+
+      it 'adds a new label' do
+        preferred_label
+
+        expect(RdfLabel.count).to be > 1
+      end
+    end
   end
 end


### PR DESCRIPTION
we were calling `RdfLabel.first_or_create(uri: uri)`, which was always returning the first `RdfLabel` item, regardless of if it matched the uri. changing it to `RdfLabel.where(uri: uri).first_or_create` does what we expect it to.

i _think_ we should be able to push this upstream, clear the `RdfLabel` contents from postgres, and run a reindex to fix the existing labels. 🤞 

closes #217 