### PR TITLE
add date_issued sorting

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -8,16 +8,6 @@ class CatalogController < ApplicationController
   # This filter applies the hydra access controls
   before_action :enforce_show_permissions, only: :show
 
-  def self.uploaded_field
-    # solr_name('system_create', :stored_sortable, type: :date)
-    'system_create_dtsi'
-  end
-
-  def self.modified_field
-    # solr_name('system_modified', :stored_sortable, type: :date)
-    'system_modified_dtsi'
-  end
-
   configure_blacklight do |config|
     # default advanced config values
     config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
@@ -212,11 +202,11 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     # label is key, solr field is value
-    config.add_sort_field "score desc, #{uploaded_field} desc", label: "relevance"
-    config.add_sort_field "#{uploaded_field} desc", label: "date uploaded \u25BC"
-    config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
-    config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
-    config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
+    config.add_sort_field 'score desc, system_create_dtsi desc', label: I18n.t('blacklight.sort.fields.relevance')
+    config.add_sort_field 'date_issued_sort_dtsi asc', label: I18n.t('blacklight.sort.fields.date_issued.asc')
+    config.add_sort_field 'date_issued_sort_dtsi desc', label: I18n.t('blacklight.sort.fields.date_issued.desc')
+    config.add_sort_field 'system_create_dtsi asc', label: I18n.t('blacklight.sort.fields.date_added.asc')
+    config.add_sort_field 'system_create_dtsi desc', label: I18n.t('blacklight.sort.fields.date_added.desc')
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/indexers/concerns/indexes_sortable_date.rb
+++ b/app/indexers/concerns/indexes_sortable_date.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+#
+# Adds a +date_issued_sort_dtsi+ field to the Solr document, allowing sorting
+# by the +date_issued+ property. If that property is missing, it falls back
+# to the object's +create_date+. If multiple dates are provided, it choses the
+# earlier date. (Note: the last choice can absolutely be altered if need be).
+#
+# @example
+#
+#    class PostcardIndexer < Hyrax::WorkIndexer
+#      # ... the other includes
+#      include IndexesSortableDate
+#    end
+#
+#    indexer = PostcardIndexer.new(Postcard.new(date_issued: ['1991-09-04']))
+#    solr_doc = indexer.generate_solr_document
+#    puts solr_doc['date_issued_sort_dtsi']
+#    # => '1991-09-04T00:00:00Z'
+#
+module IndexesSortableDate
+  # @return [Hash<String => *>]
+  def generate_solr_document
+    super.tap do |doc|
+      doc['date_issued_sort_dtsi'] = parse_sortable_date if date_exist? && date_matches_pattern?
+      doc['date_issued_sort_dtsi'] ||= object.create_date
+    end
+  end
+
+  private
+
+    # Does the +date_issued+ property have values?
+    #
+    # @return [true, false]
+    def date_exist?
+      object.date_issued.present?
+    end
+
+    # Does our date_value match the pattern of YYYY(-MM(-DD))?
+    #
+    # @return [true, false]
+    def date_matches_pattern?
+      date_value.match?(/^\d{4}(-\d{2}(-\d{2})?)?/)
+    end
+
+    # The value we're working with. Abstracted here in the event that
+    # we want to change which value gets priority.
+    #
+    # @return [String, nil]
+    def date_value
+      object.date_issued.sort.first
+    end
+
+    # Converts whatever our +date_value+ is to a YYYY-MM-DDT00:00:00Z
+    # string for Solr to use in sorting.
+    #
+    # @return [String]
+    def parse_sortable_date
+      date_array = date_value.gsub(/T.*$/, '').split('-').map(&:to_i)
+      Date.new(*date_array).strftime('%FT%TZ')
+    end
+end

--- a/app/indexers/publication_indexer.rb
+++ b/app/indexers/publication_indexer.rb
@@ -3,6 +3,7 @@ class PublicationIndexer < Hyrax::WorkIndexer
   include IndexesRightsStatements
   include IndexesEnglishLanguageDates
   include IndexesLanguageAndLabel
+  include IndexesSortableDate
 
   # Overriding the default +Hyrax::DeepIndexingService+ for our own, which
   # doesn't require +Hyrax::BasicMetadata+

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -34,3 +34,12 @@ en:
         subject: Subject
         title: Title
         years_encompassed: Year
+    sort:
+      fields:
+        date_added:
+          asc: "Date Added \u25B2"
+          desc: "Date Added \u25BC"
+        date_issued:
+          asc: "Issue Date \u25B2"
+          desc: "Issue Date \u25BC"
+        relevance: Relevance

--- a/spec/indexers/publication_indexer_spec.rb
+++ b/spec/indexers/publication_indexer_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe PublicationIndexer do
 
   it_behaves_like 'it indexes English-language dates'
   it_behaves_like 'it indexes ISO language and label'
+  it_behaves_like 'it indexes a sortable date'
 
   describe 'title' do
     # :stored_searchable

--- a/spec/support/shared_examples/indexing/indexes_sortable_date.rb
+++ b/spec/support/shared_examples/indexing/indexes_sortable_date.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+#
+# Since this does some meta-programming to determine the factory to use,
+# it's best to call this from within a specific Indexer spec.
+#
+# @example invoking the shared spec
+#   RSpec.describe PublicationIndexer do
+#     # ...
+#
+#     it_behaves_like 'it indexes a sortable date'
+#   end
+RSpec.shared_examples 'it indexes a sortable date' do
+  subject(:date_sort) { solr_doc['date_issued_sort_dtsi'] }
+
+  let(:solr_doc) { indexer.generate_solr_document }
+
+  # mEtA-pRoGrAmMiNg
+  let(:work_klass) { described_class.name.gsub(/Indexer$/, '').downcase.to_sym }
+  let(:work) { build(work_klass, date_issued: example_date, create_date: '2019-01-01T12:34:56Z') }
+
+  context 'when date_issued is YYYY' do
+    let(:example_date) { ['2019'] }
+
+    it { is_expected.to eq '2019-01-01T00:00:00Z' }
+  end
+
+  context 'when date_issued is YYYY-MM' do
+    let(:example_date) { ['2019-05'] }
+
+    it { is_expected.to eq '2019-05-01T00:00:00Z' }
+  end
+
+  context 'when date_issued is YYYY-MM-DD' do
+    let(:example_date) { ['2019-05-07'] }
+
+    it { is_expected.to eq '2019-05-07T00:00:00Z' }
+  end
+
+  context 'when date_issued is empty' do
+    let(:example_date) { [] }
+
+    it { is_expected.to eq work.create_date }
+  end
+
+  context 'when date_issued contains multiple values' do
+    let(:example_date) { ['2019-05-07', '1991-09-04'] }
+
+    it 'uses the earlier date' do
+      expect(date_sort).to eq '1991-09-04T00:00:00Z'
+    end
+  end
+end


### PR DESCRIPTION
- adds a `date_issued_sort_dtsi` field to Publications via mixin
- updates the catalog_controller sort fields
  - relevance
  - date_issued asc/desc
  - date added to repository asc/desc