### PR TITLE
allow roles_management to add user if not exist

### DIFF
--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+#
+# Expanding the hydra-role-management controller so that
+# a user can be added + assigned a role _before_ logging
+# in for the first time.
+class UserRolesController < ApplicationController
+  include Hydra::RoleManagement::UserRolesBehavior
+
+  # Overriding the Hydra::RoleManagement::UserRolesBehavior#create implementation
+  # to allow users to be created if they don't exist.
+  def create
+    authorize! :add_user, @role
+    user = ::User.find_or_initialize_by(find_column => params[:user_key])
+
+    flash_message =
+      if user.new_record?
+        I18n.t('roles.edit.user_created_added_to_role', user: params[:user_key], role: @role.name)
+      else
+        I18n.t('roles.edit.user_added_to_role', user: params[:user_key], role: @role.name)
+      end
+
+    user.roles << @role
+    user.save!
+    redirect_to role_management.role_path(@role), flash: { user: flash_message }
+  end
+end

--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -16,12 +16,29 @@ end %>
   </div>
 </div>
 
+
 <div class="panel panel-default">
   <div class="panel-heading">
     <h3 class="panel-title">
       <%= t('.accounts') %>
     </h3>
   </div>
+
+  <% if flash[:user] %>
+    <div class="panel-body">
+      <div class="alert alert-info alert-dismissable user-alert" role="alert">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+
+        <%= flash[:user].html_safe %>
+      </div>
+    </div>
+
+    <script>
+      $('.user-alert').on('close.bs.alert', function () { $(this).parent().remove() })
+    </script>
+  <%- end -%>
 
   <% unless @role.users.empty? %>
   <table id="users" class="table table-bordered">

--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -16,7 +16,6 @@ end %>
   </div>
 </div>
 
-
 <div class="panel panel-default">
   <div class="panel-heading">
     <h3 class="panel-title">

--- a/config/locales/roles.en.yml
+++ b/config/locales/roles.en.yml
@@ -21,16 +21,18 @@ en:
       cancel: Cancel
       page_title: 'Viewing %{name} // Roles // %{app_name}'
     edit:
-      title: 'Editing role: %{name}'
-      field_name: Role name
-      update: Update Role
       accounts: Accounts
+      add: Add User
+      add_user_label: Add an account to this role
+      cancel: Cancel
       delete: Delete Role
       delete_warning: Deleting this role could have unexpected consequences. Please be sure you want to do this!
-      remove: Remove User
-      add_user_label: Add an account to this role
-      user: User
-      user_placeholder: name@lafayette.edu
-      add: Add User
-      cancel: Cancel
+      field_name: Role name
       page_title: 'Editing %{name} // Roles // %{app_name}'
+      remove: Remove User
+      title: 'Editing role: %{name}'
+      update: Update Role
+      user: User
+      user_added_to_role: 'User <strong>%{user}</strong> was assigned <strong>%{role}</strong> status'
+      user_created_added_to_role: 'User <strong>%{user}</strong> was created and assigned <strong>%{role}</strong> status'
+      user_placeholder: name@lafayette.edu

--- a/spec/features/roles_management_spec.rb
+++ b/spec/features/roles_management_spec.rb
@@ -44,4 +44,21 @@ RSpec.feature 'Role management' do
       expect(page).not_to have_css 'table#users'
     end
   end
+
+  describe 'adding a non-existing user to a role' do
+    let(:role) { Role.find_or_create_by(name: role_name) }
+    let(:new_user_email) { 'new-user@lafayette.edu' }
+
+    scenario do
+      visit "/admin/roles/#{role.id}/edit"
+
+      fill_in 'user_key', with: new_user_email
+      click_button 'Add User'
+
+      expect(User.find_by(email: new_user_email)).not_to be_nil
+
+      expect(page).to have_css 'div.alert.alert-info'
+      expect(page.find('table#users')).to have_content new_user_email
+    end
+  end
 end


### PR DESCRIPTION
previously, adding a user that does not exist to a role would result in an error that the user does not exist. this way, the workflow for adding a user to a role is:

- user log in
- request access to role through some means (probably email/phone)
- another user assigns user to role

this PR changes the hydra-role-management controller to create the user record if it does not already exist, so that when the user logs in for the first time they will already have the role(s) needed.

closes #201 