### PR TITLE
Add (local/remote) status tasks

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -6,14 +6,10 @@
 # lets us mount it manually (and at a different endpoint) in config/routes.rb
 OkComputer.mount_at = false
 
-env = Rails.env
-
-solr_config =
-  YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'solr.yml'))).result)[env]
-redis_config =
-  YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'redis.yml'))).result)[env]
-fcrepo_config =
-  YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'fedora.yml'))).result)[env]
+solr_config = Rails.application.config_for(:solr)
+redis_config = Rails.application.config_for(:redis)
+fcrepo_config = Rails.application.config_for(:fedora)
+sidekiq_config = YAML.load(ERB.new(IO.read(Rails.root.join('config', 'sidekiq.yml'))).result)
 
 fcrepo_uri = URI.parse(fcrepo_config['url']).tap do |uri|
   uri.userinfo = "#{fcrepo_config['user']}:#{fcrepo_config['password']}"
@@ -24,4 +20,7 @@ end.to_s
 OkComputer::Registry.register 'solr', OkComputer::SolrCheck.new(solr_config['url'])
 OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(redis_config)
 OkComputer::Registry.register 'fedora', OkComputer::HttpCheck.new(fcrepo_uri)
-OkComputer::Registry.register 'queue_default', OkComputer::SidekiqLatencyCheck.new(:default)
+
+sidekiq_config[:queues].each do |queue|
+  OkComputer::Registry.register "sidekiq :#{queue}", OkComputer::SidekiqLatencyCheck.new(queue.to_sym)
+end

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -9,7 +9,10 @@ OkComputer.mount_at = false
 solr_config = Rails.application.config_for(:solr)
 redis_config = Rails.application.config_for(:redis)
 fcrepo_config = Rails.application.config_for(:fedora)
+
+# rubocop:disable Security/YAMLLoad
 sidekiq_config = YAML.load(ERB.new(IO.read(Rails.root.join('config', 'sidekiq.yml'))).result)
+# rubocop:enable Security/YAMLLoad
 
 fcrepo_uri = URI.parse(fcrepo_config['url']).tap do |uri|
   uri.userinfo = "#{fcrepo_config['user']}:#{fcrepo_config['password']}"

--- a/lib/capistrano/tasks/spot/remote_tasks.rake
+++ b/lib/capistrano/tasks/spot/remote_tasks.rake
@@ -37,5 +37,11 @@ namespace :spot do
       end
     end
   end
+
+  task :status do
+    on roles(:app) do
+      execute :bundle, :exec, 'spot:status'
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength

--- a/lib/tasks/spot/okcomputer.rake
+++ b/lib/tasks/spot/okcomputer.rake
@@ -11,7 +11,10 @@ namespace :spot do
     checks.run
 
     checks.collection.each_value do |check|
-      printf "%-25s %-6s %s\n", check.registrant_name, check.success?? 'OK' : 'FAIL', check.message
+      printf "%-25s %-6s %s\n",
+             check.registrant_name,
+             check.success? ? 'OK' : 'FAIL',
+             check.message
     end
   end
 end

--- a/lib/tasks/spot/okcomputer.rake
+++ b/lib/tasks/spot/okcomputer.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+#
+# Run OkComputer checks + print to STDOUT
+namespace :spot do
+  task status: :environment do
+    puts
+    puts 'Running system checks'
+    puts '---------------------'
+
+    checks = OkComputer::Registry.all
+    checks.run
+
+    checks.collection.each_value do |check|
+      printf "%-25s %-6s %s\n", check.registrant_name, check.success?? 'OK' : 'FAIL', check.message
+    end
+  end
+end


### PR DESCRIPTION
adds a rake task (`rake spot:status`) and a capistrano task (`cap <env> spot:status`) to run OkComputer checks + print the results to the CLI. helpful if something goes down + getting to the admin dashboard isn't possible / a hassle.