### PR TITLE
update facet order

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -47,23 +47,29 @@ class CatalogController < ApplicationController
     config.add_facet_field 'creator_ssim',
                            label: I18n.t('blacklight.search.fields.creator'),
                            limit: 5
-    config.add_facet_field 'contributor_sim',
-                           label: I18n.t('blacklight.search.fields.contributor'),
+    config.add_facet_field 'publisher_sim',
+                           label: I18n.t('blacklight.search.fields.publisher'),
                            limit: 5
-    config.add_facet_field 'keyword_sim',
-                           label: I18n.t('blacklight.search.fields.keyword'),
+    config.add_facet_field 'organization_sim',
+                           label: I18n.t('blacklight.search.fields.organization'),
                            limit: 5
-    config.add_facet_field 'subject_sim',
-                           label: I18n.t('blacklight.search.fields.subject'),
+    config.add_facet_field 'division_sim',
+                           label: I18n.t('blacklight.search.fields.division'),
                            limit: 5
     config.add_facet_field 'academic_department_sim',
                            label: I18n.t('blacklight.search.fields.academic_department'),
                            limit: 5
+    config.add_facet_field 'subject_sim',
+                           label: I18n.t('blacklight.search.fields.subject'),
+                           limit: 5
+    config.add_facet_field 'keyword_sim',
+                           label: I18n.t('blacklight.search.fields.keyword'),
+                           limit: 5
+    config.add_facet_field 'language_label_ssim',
+                           label: I18n.t('blacklight.search.fields.language'),
+                           limit: 5
     config.add_facet_field 'location_label_ssim',
                            label: I18n.t('blacklight.search.fields.location'),
-                           limit: 5
-    config.add_facet_field 'publisher_sim',
-                           label: I18n.t('blacklight.search.fields.publisher'),
                            limit: 5
     config.add_facet_field 'years_encompassed_iim',
                            include_in_advanced_search: false,

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -44,7 +44,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'resource_type_ssim',
                            label: I18n.t('blacklight.search.fields.resource_type'),
                            limit: 5
-    config.add_facet_field 'creator_ssim',
+    config.add_facet_field 'creator_sim',
                            label: I18n.t('blacklight.search.fields.creator'),
                            limit: 5
     config.add_facet_field 'publisher_sim',

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -16,6 +16,7 @@ en:
         date_uploaded: Date Uploaded
         depositor: Deposited by
         description: Description
+        division: Division
         file_format: File Format
         file_size: File Size
         identifier: Standard Identifier
@@ -25,6 +26,7 @@ en:
         license: License
         location: Location
         member_of_collections: Collections
+        organization: Organization
         original_checksum: Original Checksum (MD5)
         page_count: Page Count
         proxy_depositor: Proxy Depositor


### PR DESCRIPTION
using @noraegloff's suggested order:

> Collection
> Resource Type
> Publisher
> Organization
> Division
> Academic Department
> Subject
> Keyword
> Language
> Location
> Year

but also adds **creator** below **publisher**, as that facet exists in the current LDR

closes #193 