### PR TITLE
quick fix for universal viewer

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -36,3 +36,17 @@ append :linked_dirs, 'log'
 append :linked_dirs, 'tmp/cache', 'tmp/derivatives', 'tmp/export', 'tmp/ingest', 'tmp/pids', 'tmp/sockets'
 append :linked_dirs, 'vendor/bundle'
 append :linked_dirs, 'public/assets', 'public/branding', 'public/system', 'public/uploads'
+
+# hotfix (for the moment)
+# we need to keep public/universalviewer intact between deploys
+# until the improved universal viewer work in hyrax is release
+# (see: https://github.com/samvera/hyrax/commit/0e02c4adf26e74f2d892f575c93789bc166e53ad)
+#
+# until then, this directory should contain a git clone of the
+# universalviewer repository, checked out to 'v2.0.1':
+#
+#   git clone https://github.com/universalviewer/universalviewer $SPOT_ROOT/public/universalviewer
+#   cd $SPOT_ROOT/public/universalviewer
+#   git checkout v2.0.1
+#
+append :linked_dirs, 'public/universalviewer'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,8 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  # config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,8 +22,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  # config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
-  config.public_file_server.enabled = true
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 Riiif::Image.file_resolver = Riiif::HTTPFileResolver.new
+Riiif::Image.file_resolver.basic_auth_credentials = [
+  ENV.fetch('FEDORA_USER') { 'fedoraAdmin' },
+  ENV.fetch('FEDORA_PASSWORD')
+]
 Riiif::Image.info_service = lambda do |id, _file|
   # id will look like a path to a pcdm:file
   # (e.g. rv042t299%2Ffiles%2F6d71677a-4f80-42f1-ae58-ed1063fd79c7)


### PR DESCRIPTION
for some reason, the universal viewer files included with the `pul_uv_rails` gem are not showing up, causing our image viewer to render blank. it's been temporarily fixed by cloning the repository into `public/universalviewer` and checking out the`v2.0.1` branch (the version used by the princeton gem).

this ensures that the `public/universalviewer` directory is shared across deployments so we don't have to repeat the whole dance each time. 