### PR TITLE
add access_master derivative creation service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,10 @@ gem 'kaminari', '1.1.1'
 # require it as we're explicitly using it.
 gem 'faraday', '0.15.4'
 
+# mini_magick is a dependency of hydra-derivatives, but since we're
+# calling it explicitly, we should require it.
+gem 'mini_magick', '4.9.3'
+
 # development dependencies (not as necessary to
 # lock down versions here)
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -952,6 +952,7 @@ DEPENDENCIES
   jquery-rails (= 4.3.3)
   kaminari (= 1.1.1)
   listen (>= 3.0.5, < 3.2)
+  mini_magick (= 4.9.3)
   okcomputer (= 1.17.3)
   pg (= 1.1.4)
   puma (= 3.12.0)

--- a/app/services/spot/file_set_access_master_service.rb
+++ b/app/services/spot/file_set_access_master_service.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+module Spot
+  class FileSetAccessMasterService
+    attr_reader :file_set
+    delegate :uri, :mime_type, to: :file_set
+
+    # @param [FileSet] file_set
+    def initialize(file_set)
+      @file_set = file_set
+    end
+
+    # @return [void]
+    def cleanup_derivatives
+      derivative_path_factory.derivatives_for_reference(file_set).each do |path|
+        FileUtils.rm_f(path)
+      end
+    end
+
+    # +Hyrax::FileSetDerivativesService+ already handles creating
+    # the thumbnail. We just want to create an access_master for
+    # an image server to be able to retrieve.
+    #
+    # @param [String,Pathname] filename
+    # @return [void]
+    def create_derivatives(filename)
+      Hydra::Derivatives::ImageDerivatives.create(filename, outputs: access_master_outputs)
+    end
+
+    # copied from https://github.com/samvera/hyrax/blob/5a9d1be1/app/services/hyrax/file_set_derivatives_service.rb#L32-L37
+    # but modifies the filename it writes out to.
+    #
+    # @param [String] destination_name
+    # @return [String]
+    def derivative_url(destination_name)
+      path = derivative_path_factory.derivative_path_for_reference(file_set, destination_name)
+
+      # +#derivative_path_for_reference+ will duplicate the destination name by default,
+      # resulting in "/path/to/derivatives/ab/cd/ef/gh/i-access.jpg.access.jpg"
+      URI("file://#{path}").to_s.gsub(%r{\.#{destination_name}$}, '')
+    end
+
+    # @return [true, false]
+    def valid?
+      file_set.class.image_mime_types.include? mime_type
+    end
+
+    private
+
+      # @return [Array<Hash>]
+      def access_master_outputs
+        [{
+          label: :access,
+          format: 'jpg',
+          url: derivative_url('access.jpg'),
+          layer: 0
+        }]
+      end
+
+      # @return [Class]
+      def derivative_path_factory
+        Hyrax::DerivativePath
+      end
+  end
+end

--- a/app/services/spot/file_set_access_master_service.rb
+++ b/app/services/spot/file_set_access_master_service.rb
@@ -1,4 +1,30 @@
 # frozen_string_literal: true
+#
+# +Hyrax::FileSetDerivativesService+ already handles creating
+# the thumbnail. We just want to create an access master for
+# an image server to be able to retrieve.
+#
+# Note: for now we're going with pyramidal TIFs as a uniform
+# format for our access masters. The community consensus seems
+# to point to JPEG2000s or pyramidal TIFs as access masters.
+# The former seems to require Kakadu (a paid software) to get
+# the best results, while the later seems to be fairly standard.
+#
+# From https://mw2016.museumsandtheweb.com/paper/iiif-unshackle-your-images/:
+#
+# > If you want a free performant option, we would suggest the use
+# > of Pyramidal TIFFs. When used in conjunction with a high-performance
+# > image server, this format will give you the performance required
+# > to implement IIIF.
+#
+# @example basic usage
+#   fs = FileSet.find('abc123def')
+#   working_dir = Hyrax::WorkingDirectory.new(fs.files.first.id, fs.id)
+#   service = Spot::FileSetAccessMasterService.new(fs)
+#   service.create_derivatives(working_dir)
+#   File.exist?(Rails.root.join('tmp/derivatives/ab/c1/23/de/f-access.tif'))
+#   # => true
+#
 module Spot
   class FileSetAccessMasterService
     attr_reader :file_set
@@ -16,15 +42,17 @@ module Spot
       end
     end
 
-    # +Hyrax::FileSetDerivativesService+ already handles creating
-    # the thumbnail. We just want to create an access_master for
-    # an image server to be able to retrieve.
+    # Since we want to pass some extended options to the creation process,
+    # we'll just use MiniMagick, rather than use
+    # Hydra::Derviatives::ImageDerivatives.
     #
     # @param [String,Pathname] filename the src path of the file
     # @return [void]
     def create_derivatives(filename)
       MiniMagick::Tool::Magick.new do |magick|
         magick << filename
+        # note: we need to use an array for each piece of this command;
+        # using a string will cause an error
         magick.merge! %w[-define tiff:tile-geometry=128x128]
         magick << "ptif:#{derivative_url('access.tif')}"
       end
@@ -47,16 +75,6 @@ module Spot
     end
 
     private
-
-      # @return [Array<Hash>]
-      def access_master_outputs
-        [{
-          label: :access,
-          format: 'tif',
-          url: derivative_url('access.tif'),
-          layer: 0
-        }]
-      end
 
       # @return [Class]
       def derivative_path_factory

--- a/config/initializers/hyrax_overrides.rb
+++ b/config/initializers/hyrax_overrides.rb
@@ -35,6 +35,8 @@ load_overrides = lambda do
 
   Hyrax::CollectionsController.presenter_class = Spot::CollectionPresenter
 
+  Hyrax::DerivativeService.services = [Hyrax::FileSetDerivativesService, Spot::FileSetAccessMasterService]
+
   # We've dropped the navbar + banner image that come with Hyrax, and the
   # 'homepage' layout that the PagesController calls defines content for
   # this block. By switching to the 'hyrax' layout (which we're using for

--- a/spec/services/spot/file_set_access_master_service_spec.rb
+++ b/spec/services/spot/file_set_access_master_service_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'hyrax/specs/shared_specs'
+
+RSpec.describe Spot::FileSetAccessMasterService do
+  before do
+    allow(valid_file_set).to receive(:mime_type).and_return('image/jpeg')
+  end
+
+  let(:valid_file_set) { FileSet.new }
+
+  it_behaves_like 'a Hyrax::DerivativeService'
+end


### PR DESCRIPTION
currently stores alongside generated thumbnail. to be used for the iiif server to circumvent having to retrieve the file from fedora each time