### PR TITLE
🐛 fix ldr mapper to properly sort publisher/source

### DIFF
--- a/app/services/spot/mappers/ldr_dspace_mapper.rb
+++ b/app/services/spot/mappers/ldr_dspace_mapper.rb
@@ -140,7 +140,7 @@ module Spot::Mappers
       #
       # @return [true, false]
       def chapter_or_book?
-        ['Book chapter', 'Part of Book'].include? metadata['type']
+        ['Book chapter', 'Part of Book'].include? metadata['type'].first
       end
 
       # Gathers identifiers for DOI, ISBN, ISSN, and Handle.net urls

--- a/spec/services/spot/mappers/ldr_dspace_mapper_spec.rb
+++ b/spec/services/spot/mappers/ldr_dspace_mapper_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Spot::Mappers::LdrDspaceMapper do
   describe '#publisher' do
     subject { mapper.publisher }
 
-    let(:metadata) { { 'type' => type, 'publisher' => ['Some journal'] } }
+    let(:metadata) { { 'type' => [type], 'publisher' => ['Some journal'] } }
 
     context 'when an item is a Book chapter' do
       let(:type) { 'Book chapter' }
@@ -245,7 +245,7 @@ RSpec.describe Spot::Mappers::LdrDspaceMapper do
   describe '#source' do
     subject { mapper.source }
 
-    let(:metadata) { { 'type' => type, 'publisher' => ['Some journal'] } }
+    let(:metadata) { { 'type' => [type], 'publisher' => ['Some journal'] } }
 
     context 'when an item is a Book chapter' do
       let(:type) { 'Book chapter' }


### PR DESCRIPTION
see [@noraegloff's comment on #65](https://github.com/LafayetteCollegeLibraries/spot/pull/65#issuecomment-497815167). looks like i forgot that `metadata['type']` is an array and _not_ a string.