### PR TITLE
allow definition of multi_value_character for ingest task

### DIFF
--- a/app/jobs/spot/ingest_bag_job.rb
+++ b/app/jobs/spot/ingest_bag_job.rb
@@ -24,11 +24,16 @@ module Spot
     # @raise [ArgumentError] if +work_class:+ not a valid Work type
     # @raise [ValidationError] if the file to parse is invalid
     #   (from Darlingtonia::Parser)
-    def perform(bag_path:, source:, work_class:, collection_ids: [])
+    def perform(bag_path:,
+                source:,
+                work_class:,
+                collection_ids: [],
+                multi_value_character: ';')
       @bag_path = bag_path
       @source = source
       @work_class = work_class.constantize
       @collection_ids = collection_ids
+      @multi_value_character = multi_value_character
 
       raise ArgumentError, "Unknown source: #{source}." unless source_available?
       raise ArgumentError, "Unknown work_class: #{work_class}" unless work_class_valid?
@@ -65,7 +70,8 @@ module Spot
       # @return [Spot::Importers::Bag::Parser]
       def parser
         @parser ||= Spot::Importers::Bag::Parser.new(directory: bag_path,
-                                                     mapper: mapper)
+                                                     mapper: mapper,
+                                                     multi_value_character: @multi_value_character)
       end
 
       # @return [Spot::Importers::Bag::RecordImporter]

--- a/app/jobs/spot/ingest_zipped_bag_job.rb
+++ b/app/jobs/spot/ingest_zipped_bag_job.rb
@@ -7,7 +7,9 @@
 # before the job has a chance to perform)
 #
 # @todo clean up working directory after ingest (via callback?)
-
+# @todo fix rubocop warning; is this _too_ configurable?
+#
+# rubocop:disable Metrics/ParameterLists
 require 'fileutils'
 
 module Spot
@@ -18,14 +20,18 @@ module Spot
     # @param [String] source Source collection / which mapper to use
     # @param [String] work_class Work Type to use for new object
     # @param [String] working_path Directory to unzip the object
+    # @param [Array<String>] collection_ids Array of collection ids to add this item to
+    # @param [String] multi_value_character The character used in the metadata to indicate multiple values
     # @return [void]
-    # @raose [ArgumentError] if +working_path:+ is not a directory
+    #
+    # @raise [ArgumentError] if +working_path:+ is not a directory
     # @raise [ArgumentError] if +source:+ is not defined in {Spot::Mappers.available_mappers}
     #   (from Spot::IngestBagJob)
     # @raise [ArgumentError] if +work_class:+ not a valid Work type
     #   (from Spot::IngestBagJob)
     # @raise [ValidationError] if the file to parse is invalid
     #   (from Darlingtonia::Parser)
+    #
     def perform(zip_path:,
                 source:,
                 work_class:,
@@ -47,3 +53,4 @@ module Spot
     end
   end
 end
+# rubocop:enable Metrics/ParameterLists

--- a/app/jobs/spot/ingest_zipped_bag_job.rb
+++ b/app/jobs/spot/ingest_zipped_bag_job.rb
@@ -26,7 +26,12 @@ module Spot
     #   (from Spot::IngestBagJob)
     # @raise [ValidationError] if the file to parse is invalid
     #   (from Darlingtonia::Parser)
-    def perform(zip_path:, source:, work_class:, working_path:, collection_ids: [])
+    def perform(zip_path:,
+                source:,
+                work_class:,
+                working_path:,
+                collection_ids: [],
+                multi_value_character: ';')
       raise ArgumentError, "#{working_path} is not a directory" unless File.directory?(working_path)
 
       destination = File.join(working_path, File.basename(zip_path, '.zip'))
@@ -37,7 +42,8 @@ module Spot
       Spot::IngestBagJob.perform_now(bag_path: destination,
                                      source: source,
                                      work_class: work_class,
-                                     collection_ids: collection_ids)
+                                     collection_ids: collection_ids,
+                                     multi_value_character: multi_value_character)
     end
   end
 end

--- a/app/services/spot/importers/bag/parser.rb
+++ b/app/services/spot/importers/bag/parser.rb
@@ -25,8 +25,6 @@ module Spot::Importers::Bag
       Spot::Validators::BagMetadataValidator.new
     ].freeze
 
-    MULTI_VALUE_CHARACTER = ';'
-
     # +Darlingtonia::Parser+'s initializer uses the +file+ kwarg
     # for the object, but because we're dealing with directories,
     # we're redefining that attribute here and aliasing the +file+
@@ -36,9 +34,10 @@ module Spot::Importers::Bag
     #
     # @param [String, Pathname] directory
     # @param [Darlingtonia::MetadataMapper] mapper
-    def initialize(directory:, mapper:)
+    def initialize(directory:, mapper:, multi_value_character: ';')
       super(file: directory)
       @mapper = mapper
+      @multi_value_character = multi_value_character
     end
 
     alias directory file
@@ -114,13 +113,13 @@ module Spot::Importers::Bag
       end
 
       # Parses the +metadata.csv+ file into a +CSV::Table+ and splits values
-      # on the {MULTI_VALUE_CHARACTER} constant.
+      # on the {@multi_value_character} instance variable.
       #
       # @return [CSV::Table]
       def read_csv
         CSV.read(metadata_path,
                  headers: true,
-                 converters: ->(v) { v.split(MULTI_VALUE_CHARACTER) })
+                 converters: ->(v) { v.split(@multi_value_character) })
       end
   end
 end

--- a/lib/tasks/spot/ingest.rake
+++ b/lib/tasks/spot/ingest.rake
@@ -7,7 +7,8 @@ namespace :spot do
     path = ENV['path']
     work_class = ENV['work_class']
     collection_ids = ENV['collection_ids'].to_s.split(',')
-    working_path = ENV.fetch('working_path') { Rails.root.join('tmp', 'ingest').to_s }
+    multi_value_character = ENV.fetch('multi_value_character', ';')
+    working_path = ENV.fetch('working_path', Rails.root.join('tmp', 'ingest').to_s)
 
     error_message = if    !source       then 'No `source` provided!'
                     elsif !path         then 'No `path` provided!'
@@ -31,6 +32,7 @@ namespace :spot do
       Spot::IngestZippedBagJob.perform_later(zip_path: entry,
                                              source: source,
                                              collection_ids: collection_ids,
+                                             multi_value_character: multi_value_character,
                                              work_class: work_class,
                                              working_path: working_path)
     end

--- a/spec/jobs/spot/ingest_zipped_bag_job_spec.rb
+++ b/spec/jobs/spot/ingest_zipped_bag_job_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Spot::IngestZippedBagJob do
                                 work_class: work_class,
                                 source: source,
                                 collection_ids: collection_ids,
+                                multi_value_character: '|',
                                 working_path: working_path)
   end
 
@@ -30,7 +31,7 @@ RSpec.describe Spot::IngestZippedBagJob do
       expect(Spot::IngestBagJob)
         .to have_received(:perform_now)
         .with(bag_path: working_path.join('bag').to_s, source: source,
-              work_class: work_class, collection_ids: collection_ids)
+              work_class: work_class, collection_ids: collection_ids, multi_value_character: '|')
     end
 
     context 'when working path isn\'t a directory' do


### PR DESCRIPTION
adds the ability to define a custom multi-value character when ingesting (part of an effort to move us towards bars (`|`) rather than semicolons (`;`) as separators)