### PR TITLE
UI enhancements

### DIFF
--- a/app/forms/hyrax/publication_form.rb
+++ b/app/forms/hyrax/publication_form.rb
@@ -98,6 +98,14 @@ module Hyrax
       self['date_issued'].first
     end
 
+    # Prevents noids (and other identifiers we don't want
+    # to be able to edit) from appearing in the form.
+    #
+    # @return [String]
+    def identifier
+      self['identifier'].reject { |id| id =~ /^noid\:/ }
+    end
+
     # @return [String, RDF::Literal]
     def title
       self['title'].first

--- a/app/presenters/hyrax/publication_presenter.rb
+++ b/app/presenters/hyrax/publication_presenter.rb
@@ -18,6 +18,14 @@ module Hyrax
       %i[csv ttl nt jsonld]
     end
 
+    # Overrides {Hyrax::WorkShowPresenter#page_title} by only using
+    # the work's title + our product name.
+    #
+    # @return [String]
+    def page_title
+      "#{title.first} || #{I18n.t('hyrax.product_name')}"
+    end
+
     # For now, overriding the ability to feature individual works
     # on the homepage. This should prevent the 'Feature'/'Unfeature'
     # button from rendering on the work edit page.

--- a/app/presenters/hyrax/publication_presenter.rb
+++ b/app/presenters/hyrax/publication_presenter.rb
@@ -23,7 +23,7 @@ module Hyrax
     #
     # @return [String]
     def page_title
-      "#{title.first} || #{I18n.t('hyrax.product_name')}"
+      "#{title.first} // #{I18n.t('hyrax.product_name')}"
     end
 
     # For now, overriding the ability to feature individual works

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,0 +1,10 @@
+<%# copied from hyrax:/app/catalog/index.html.erb solely so we can change the page title %>
+<% content_for(:page_title, t('spot.catalog.index.page_title', name: t('hyrax.product_name'))) %>
+
+<div id="content" class="col-md-9 col-md-push-3 col-sm-8 col-sm-push-4">
+    <%= render 'search_results' %>
+</div>
+
+<div id="sidebar" class="col-md-3 col-md-pull-9 col-sm-4 col-sm-pull-8">
+  <%= render 'search_sidebar' %>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -19,7 +19,7 @@
           <ul>
             <li><%= link_to 'Learn more about the repostory', about_path %></li>
             <li><%= link_to 'Get help using the repository', help_path %></li>
-            <li><%= link_to 'Contact us', contact_path %></li>
+            <li><%= link_to 'Contact us', hyrax.contact_path %></li>
           </ul>
         </p>
       </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -19,6 +19,7 @@
           <ul>
             <li><%= link_to 'Learn more about the repostory', about_path %></li>
             <li><%= link_to 'Get help using the repository', help_path %></li>
+            <li><%= link_to 'Contact us', contact_path %></li>
           </ul>
         </p>
       </div>

--- a/app/views/spot/page/about.html.erb
+++ b/app/views/spot/page/about.html.erb
@@ -2,10 +2,70 @@
   About // <%= t('hyrax.product_name') %>
 <% end %>
 
-<h1>About <%= t('hyrax.product_name') %></h1>
+<h2>About <%= t('hyrax.product_name') %></h2>
 <p>
-  The Lafayette Digital Repository is an online archive designed to
-  preserve and make accessible materials from Lafayette College, including
-  administrative publications, scholarly work of Lafayette faculty, and
-  digitized materials from the college's Special Collections and Archives.
+  The Lafayette Digital Repository (LDR) is both an institutional repository and
+  an access portal to Lafayette College Library’s Digital Collections. In
+  accordance with the departmental <a href="https://dss.lafayette.edu/about/" target="_blank">mission</a>
+  of Digital Scholarship Services, the LDR supports the activities of the
+  College’s faculty, researchers, students, and community partners by preserving,
+  curating, and disseminating digital resources.  The LDR enacts the Libraries’
+  ongoing <a href="https://library.lafayette.edu/about/about-the-lafayette-libraries/" target="_blank">mission</a>
+  of providing information resources and services to help Lafayette faculty
+  and students attain their goals as teachers, scholars, and learners, through
+  the creation and maintenance of accessible digital collections, scholarly
+  output, and other digital materials that have enduring value for intellectual
+  inquiry and documentation of College activities.
+</p>
+
+<h2>Faculty Scholarship and the LDR</h2>
+<p>
+  The Lafayette College faculty passed an open access resolution in April, 2011.
+  Faculty are encouraged to share their research outputs via inclusion in the
+  Lafayette Digital Repository. Flexible access and visibility controls are
+  available for deposited content.
+</p>
+
+<h2>Why submit your content to the LDR?</h2>
+<ul>
+  <li>boost the search engine discoverability of your research</li>
+  <li>provide persistent access to your research over time (i.e. prevent “link rot” in citations to your work)</li>
+  <li>satisfy funding agency requirements for sharing and preserving research data and published findings</li>
+  <li>preserve your work for the long term in an institutional environment</li>
+</ul>
+<p>
+  Members of the faculty and administrative departments may use the LDR submission form to deposit
+  articles to the Lafayette Digital Repository.  For other content types, such as presentations,
+  research data, audiovisual materials, etc. please contact Nora Egloff, Digital Repository Librarian,
+  at egloffn@lafayette.edu for more information.
+</p>
+
+<h2>Policies</h2>
+
+<h3>Copyright and Use</h3>
+<p>
+  Please consult the <a href="https://dss.lafayette.edu/copyright-and-use/" target="_blank">Digital Scholarship Services Copyright & Use Guidelines</a>
+  for information about using and sharing content in the LDR. If you have further
+  questions, please contact us at dss@lafayette.edu.
+</p>
+
+<h3>Preservation Support Policy</h3>
+<p>
+  The Lafayette Digital Repository is committed to providing sustainable
+  and trustworthy long-term access to content according to international
+  best practices for digital preservation.
+</p>
+<p>
+  All resources in the LDR are assigned unique persistent identifiers by
+  the repository system, as well as persistent URLs through the Handle.net
+  registry. Bit-level preservation of digital objects and metadata is
+  managed through the generation of checksum hashes and performance of
+  fixity checking at regular intervals.
+</p>
+
+<p>
+  Beyond these initial preservation activities, the LDR team is developing
+  a broader preservation policy and action plan.  Details about new services
+  and preservation planning will be announced as they are approved by
+  Library and College stakeholders.
 </p>

--- a/config/initializers/hyrax_overrides.rb
+++ b/config/initializers/hyrax_overrides.rb
@@ -51,6 +51,9 @@ load_overrides = lambda do
         action_name == 'show' ? 'hyrax' : 'hyrax/dashboard'
       end
   end
+
+  # see above
+  Hyrax::ContactFormController.class_eval { layout 'hyrax' }
 end
 
 Rails.application.config.after_initialize do

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -40,6 +40,10 @@ en:
         subject: Subject
         title: Title
         years_encompassed: Year
+
+        facet:
+          resource_type_sim: Type
+          source_sim: Source
     sort:
       fields:
         date_added:

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -12,6 +12,10 @@ en:
 
     log_in: Library staff log-in
 
+    catalog:
+      index:
+        page_title: 'Search Results // %{name}'
+
     dashboard:
       fixity:
         frequency: Checks are run every Monday at midnight.

--- a/spec/features/show_publication_spec.rb
+++ b/spec/features/show_publication_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Show Publication page', js: false do
 
   scenario 'metadata fields are present' do
     expect(page).to have_content pub.title.first
-    expect(page.title).to eq "#{pub.title.first} || Lafayette Digital Repository"
+    expect(page.title).to eq "#{pub.title.first} // Lafayette Digital Repository"
 
     # descriptions are treated differently
     # expect(page.all('.work_description').map(&:text))

--- a/spec/features/show_publication_spec.rb
+++ b/spec/features/show_publication_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature 'Show Publication page', js: false do
 
   scenario 'metadata fields are present' do
     expect(page).to have_content pub.title.first
+    expect(page.title).to eq "#{pub.title.first} || Lafayette Digital Repository"
 
     # descriptions are treated differently
     # expect(page.all('.work_description').map(&:text))

--- a/spec/forms/hyrax/publication_form_spec.rb
+++ b/spec/forms/hyrax/publication_form_spec.rb
@@ -154,4 +154,14 @@ RSpec.describe Hyrax::PublicationForm do
       end
     end
   end
+
+  describe 'identifier field' do
+    subject { form.identifier }
+
+    let(:form) { described_class.new(pub, nil, nil) }
+    let(:pub) { Publication.new(identifier: ['noid:abc123def', 'issn:1234-5678']) }
+
+    it { is_expected.not_to include 'noid:abc123def' }
+    it { is_expected.to include 'issn:1234-5678' }
+  end
 end

--- a/spec/presenters/hyrax/publication_presenter_spec.rb
+++ b/spec/presenters/hyrax/publication_presenter_spec.rb
@@ -75,6 +75,13 @@ RSpec.describe Hyrax::PublicationPresenter do
     it { is_expected.to eq [[uri, label]] }
   end
 
+  describe '#page_title' do
+    subject { presenter.page_title }
+
+    it { is_expected.to include presenter.title.first }
+    it { is_expected.to include 'Lafayette Digital Repository' }
+  end
+
   describe '#rights_statement_merged' do
     subject { presenter.rights_statement_merged }
 


### PR DESCRIPTION
kind of a catch-all for a handful of ui tweaks

## locales
- updates `PublicationPresenter#page_title` to display as `"#{work_title} || Lafayette Digital Repository"`

## html
- adds contact link to the footer / updates the layout used
- adds text for the 'about' page

closes #223 
closes #227