### PR TITLE
cache iiif manifests at the controller level

### DIFF
--- a/app/controllers/concerns/spot/cached_manifest_behavior.rb
+++ b/app/controllers/concerns/spot/cached_manifest_behavior.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+#
+# Overrides the Hyrax::WorksControllerBehavior#manifest method to prevent
+# generating a new manifest on every request. Uses the Solr document's
+# '_version_' property to ensure that we're not retrieving an older
+# version of the object from the cache. Also adds a `manifest_cache_duration`
+# attribute to set how long you want the thing sticking around.
+#
+# @example
+#   module Hyrax
+#     class CoolWorksController < ApplicationController
+#       # get that hyrax good-good
+#       include Hyrax::WorksControllerBehavior
+#       include Hyrax::BreadcrumbsForWorks
+#
+#       # cache the manifests!
+#       include Spot::CachedManifestBehavior
+#
+#       self.manifest_cache_duration = 180.days
+#     end
+#   end
+#
+# @todo remove the meta-programming (see +included+ block) once we upgrade to Hyrax@3
+module Spot
+  module CachedManifestBehavior
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :manifest_cache_duration
+      self.manifest_cache_duration = 30.days
+
+      # In Hyrax@3 the manifests generated are sanitized/cleaned-up.
+      # Meta-programming will allow us to prefer those methods and
+      # fall-back to defining them using the Hyrax@3 code.
+      unless method_defined?(:sanitize_manifest)
+        define_method(:sanitize_manifest) do |hash|
+          hash['label'] = sanitize_value(hash['label']) if hash.key?('label')
+          hash['description'] = hash['description']&.collect { |elem| sanitize_value(elem) } if hash.key?('description')
+
+          hash['sequences']&.each do |sequence|
+            sequence['canvases']&.each do |canvas|
+              canvas['label'] = sanitize_value(canvas['label'])
+            end
+          end
+          hash
+        end
+      end
+
+      unless method_defined?(:sanitize_value)
+        define_method(:sanitize_value) do |text|
+          Loofah.fragment(text.to_s).scrub!(:prune).to_s
+        end
+      end
+    end
+
+    def manifest
+      headers['Access-Control-Allow-Origin'] = '*'
+
+      # this is the only thing we're doing differently than Hyrax w/ this method
+      json = Rails.cache.fetch(manifest_cache_key, expires_in: manifest_cache_duration) do
+        sanitize_manifest(JSON.parse(manifest_builder.to_h.to_json))
+      end
+
+      respond_to do |wants|
+        wants.json { render json: json }
+        wants.html { render json: json }
+      end
+    end
+
+    private
+
+      # By adding the Solr '_version_' field to the cache key, we shouldn't
+      # run into the problem of fetching an outdated version of the manifest.
+      #
+      # @return [String]
+      def manifest_cache_key
+        "#{presenter.id}/#{presenter.solr_document['_version_']}"
+      end
+  end
+end

--- a/app/controllers/hyrax/publications_controller.rb
+++ b/app/controllers/hyrax/publications_controller.rb
@@ -5,6 +5,8 @@ module Hyrax
     include Hyrax::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
     include Spot::AdditionalFormatsForController
+    include Spot::CachedManifestBehavior
+
     self.curation_concern_type = ::Publication
 
     # Use this line if you want to use a custom presenter

--- a/spec/controllers/hyrax/publications_controller_spec.rb
+++ b/spec/controllers/hyrax/publications_controller_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe Hyrax::PublicationsController do
     let(:doc) { instance_double(ActiveFedora::Base, id: 'abc123def') }
     let(:manifest_factory) { instance_double(IIIFManifest::ManifestBuilder, to_h: { test: 'manifest' }) }
     let(:presenter) { instance_double(Hyrax::WorkShowPresenter, id: doc.id, solr_document: solr_document) }
-    let(:solr_document) { {'_version_' => 12345678 } }
-    let(:cache_key) { "#{doc.id}/12345678" }
+    let(:solr_document) { { '_version_' => 123 } }
+    let(:cache_key) { "#{doc.id}/123" }
 
     it 'adds the doc to the cache' do
       expect(Rails.cache.exist?(cache_key)).to be false

--- a/spec/controllers/hyrax/publications_controller_spec.rb
+++ b/spec/controllers/hyrax/publications_controller_spec.rb
@@ -45,4 +45,31 @@ RSpec.describe Hyrax::PublicationsController do
       expect(response.body).to start_with('id,title')
     end
   end
+
+  # test iiif manifest cache
+  context 'when requesting the iiif manifest of an item' do
+    before do
+      allow(IIIFManifest::ManifestFactory).to receive(:new)
+        .with(presenter)
+        .and_return(manifest_factory)
+
+      allow(controller).to receive(:presenter).and_return(presenter)
+
+      Rails.cache.clear
+    end
+
+    let(:doc) { instance_double(ActiveFedora::Base, id: 'abc123def') }
+    let(:manifest_factory) { instance_double(IIIFManifest::ManifestBuilder, to_h: { test: 'manifest' }) }
+    let(:presenter) { instance_double(Hyrax::WorkShowPresenter, id: doc.id, solr_document: solr_document) }
+    let(:solr_document) { {'_version_' => 12345678 } }
+    let(:cache_key) { "#{doc.id}/12345678" }
+
+    it 'adds the doc to the cache' do
+      expect(Rails.cache.exist?(cache_key)).to be false
+
+      get :manifest, params: { id: doc.id }
+
+      expect(Rails.cache.exist?(cache_key)).to be true
+    end
+  end
 end


### PR DESCRIPTION
overwrites the default hyrax behavior for generating iiif manifests on an item to save the output to a cache. this should improve subsequent load times for items. 

to use:

```ruby
module Hyrax
  class ImageController < ApplicationController
    # ... Hyrax boilerplate: be sure to include this before the mixin

    # cache the manifests!
    include Spot::CachedManifestBehavior

    # adjust how long we'll keep the docs around in the cache. default is 30.days
    self.manifest_cache_duration = 180.days
  end
end
```

(this adds the mixin to `Hyrax::PublicationsController` already)

**note:** this includes some meta-programming because my initial pass was based on the `master` branch of Hyrax, which has sanitizing methods that aren't in 2.5.1. after the upgrade, you'll want to strip this out.