### PR TITLE
[newspaper-mapper] prevent skipping dc:dates when less than one

### DIFF
--- a/app/services/spot/mappers/newspaper_mapper.rb
+++ b/app/services/spot/mappers/newspaper_mapper.rb
@@ -46,7 +46,8 @@ module Spot::Mappers
     #
     # @return [Array<String>]
     def date_issued
-      clean_dates[0...-1].map { |raw| Date.parse(raw).strftime('%Y-%m-%d') }
+      dates = clean_dates.size > 1 ? clean_dates[0...-1] : clean_dates
+      dates.map { |raw| Date.parse(raw).strftime('%Y-%m-%d') }
     end
 
     # @return [Array<RDF::Literal>]

--- a/spec/services/spot/mappers/newspaper_mapper_spec.rb
+++ b/spec/services/spot/mappers/newspaper_mapper_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe Spot::Mappers::NewspaperMapper do
     it 'chooses the older date for date_issued' do
       expect(mapper.date_issued).to eq ['1986-02-11']
     end
+
+    context 'when only one dc:date value is present' do
+      let(:metadata) { { 'dc:date' => ['1986-02-11T00:00:00Z'] } }
+
+      it 'uses that date' do
+        expect(mapper.date_issued).to eq ['1986-02-11']
+      end
+    end
   end
 
   describe '#date_uploaded' do


### PR DESCRIPTION
fixes a bug where the newspaper mapper wasn't providing `date_issued` values when only one existed (introduced in 62f95c6 when we were trying to separate date-uploaded from date-issued).