### PR TITLE
release 2019.1-pre.2

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -76,10 +76,3 @@ SLACK_FIXITY_CHANNEL=
 
 # Used for the database pool size.
 RAILS_MAX_THREADS=10
-
-# I found that keeping this around `RAILS_MAX_THREADS / 2` prevents
-# a slew of 'Waiting for connection' errors that occur because more
-# jobs are trying to get at the database than the database can handle.
-#
-# see: https://github.com/mperham/sidekiq/wiki/Advanced-Options#concurrency
-SIDEKIQ_CONCURRENCY=4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - update a work's `document.title` to resemble '{work title} // Lafayette Digital Repository'
 - add text content to the About page
 - add link to the Contact page in site footer
+- bugfix: don't skip single `dc:date` values when mapping to `date_issued` for magazines
 
 
 ## [2019.1-pre.1] - 2019-07-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - use the `:ingest` queue for Hyrax's "ingest-like jobs"
 - add 'spot:collections:list' task
 - bugfix: don't skip single `dc:date` values when mapping to `date_issued` for magazines
+- bugfix: add `tmp/uploads` to capistrano's shared directories
 
 ## [2019.1-pre.1] - 2019-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - add text content to the About page
 - add link to the Contact page in site footer
 - specify Sidekiq concurrency via capistrano-sidekiq configuration
+- use the `:ingest` queue for Hyrax's "ingest-like jobs"
 - bugfix: don't skip single `dc:date` values when mapping to `date_issued` for magazines
 
 ## [2019.1-pre.1] - 2019-07-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - add 'spot:collections:list' task
 - bugfix: don't skip single `dc:date` values when mapping to `date_issued` for magazines
 - bugfix: add `tmp/uploads` to capistrano's shared directories
+- bugfix: assign roles (via capistrano) on the :web server only
 
 ## [2019.1-pre.1] - 2019-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - update a work's `document.title` to resemble '{work title} // Lafayette Digital Repository'
 - add text content to the About page
 - add link to the Contact page in site footer
+- specify Sidekiq concurrency via capistrano-sidekiq configuration
 - bugfix: don't skip single `dc:date` values when mapping to `date_issued` for magazines
-
 
 ## [2019.1-pre.1] - 2019-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # changelog
 
+## Unreleased
+
+- update a work's `document.title` to resemble '{work title} // Lafayette Digital Repository'
+- add text content to the About page
+- add link to the Contact page in site footer
+
+
 ## [2019.1-pre.1] - 2019-07-24
 
 Initial pre-release (live on ldr.stage.lafayette.edu)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - add link to the Contact page in site footer
 - specify Sidekiq concurrency via capistrano-sidekiq configuration
 - use the `:ingest` queue for Hyrax's "ingest-like jobs"
+- add 'spot:collections:list' task
 - bugfix: don't skip single `dc:date` values when mapping to `date_issued` for magazines
 
 ## [2019.1-pre.1] - 2019-07-24

--- a/app/forms/hyrax/publication_form.rb
+++ b/app/forms/hyrax/publication_form.rb
@@ -98,6 +98,14 @@ module Hyrax
       self['date_issued'].first
     end
 
+    # Prevents noids (and other identifiers we don't want
+    # to be able to edit) from appearing in the form.
+    #
+    # @return [String]
+    def identifier
+      self['identifier'].reject { |id| id =~ /^noid\:/ }
+    end
+
     # @return [String, RDF::Literal]
     def title
       self['title'].first

--- a/app/presenters/hyrax/publication_presenter.rb
+++ b/app/presenters/hyrax/publication_presenter.rb
@@ -18,6 +18,14 @@ module Hyrax
       %i[csv ttl nt jsonld]
     end
 
+    # Overrides {Hyrax::WorkShowPresenter#page_title} by only using
+    # the work's title + our product name.
+    #
+    # @return [String]
+    def page_title
+      "#{title.first} // #{I18n.t('hyrax.product_name')}"
+    end
+
     # For now, overriding the ability to feature individual works
     # on the homepage. This should prevent the 'Feature'/'Unfeature'
     # button from rendering on the work edit page.

--- a/app/services/spot/mappers/newspaper_mapper.rb
+++ b/app/services/spot/mappers/newspaper_mapper.rb
@@ -46,7 +46,8 @@ module Spot::Mappers
     #
     # @return [Array<String>]
     def date_issued
-      clean_dates[0...-1].map { |raw| Date.parse(raw).strftime('%Y-%m-%d') }
+      dates = clean_dates.size > 1 ? clean_dates[0...-1] : clean_dates
+      dates.map { |raw| Date.parse(raw).strftime('%Y-%m-%d') }
     end
 
     # @return [Array<RDF::Literal>]

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,0 +1,10 @@
+<%# copied from hyrax:/app/catalog/index.html.erb solely so we can change the page title %>
+<% content_for(:page_title, t('spot.catalog.index.page_title', name: t('hyrax.product_name'))) %>
+
+<div id="content" class="col-md-9 col-md-push-3 col-sm-8 col-sm-push-4">
+    <%= render 'search_results' %>
+</div>
+
+<div id="sidebar" class="col-md-3 col-md-pull-9 col-sm-4 col-sm-pull-8">
+  <%= render 'search_sidebar' %>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -19,6 +19,7 @@
           <ul>
             <li><%= link_to 'Learn more about the repostory', about_path %></li>
             <li><%= link_to 'Get help using the repository', help_path %></li>
+            <li><%= link_to 'Contact us', hyrax.contact_path %></li>
           </ul>
         </p>
       </div>

--- a/app/views/spot/page/about.html.erb
+++ b/app/views/spot/page/about.html.erb
@@ -2,10 +2,70 @@
   About // <%= t('hyrax.product_name') %>
 <% end %>
 
-<h1>About <%= t('hyrax.product_name') %></h1>
+<h2>About <%= t('hyrax.product_name') %></h2>
 <p>
-  The Lafayette Digital Repository is an online archive designed to
-  preserve and make accessible materials from Lafayette College, including
-  administrative publications, scholarly work of Lafayette faculty, and
-  digitized materials from the college's Special Collections and Archives.
+  The Lafayette Digital Repository (LDR) is both an institutional repository and
+  an access portal to Lafayette College Library’s Digital Collections. In
+  accordance with the departmental <a href="https://dss.lafayette.edu/about/" target="_blank">mission</a>
+  of Digital Scholarship Services, the LDR supports the activities of the
+  College’s faculty, researchers, students, and community partners by preserving,
+  curating, and disseminating digital resources.  The LDR enacts the Libraries’
+  ongoing <a href="https://library.lafayette.edu/about/about-the-lafayette-libraries/" target="_blank">mission</a>
+  of providing information resources and services to help Lafayette faculty
+  and students attain their goals as teachers, scholars, and learners, through
+  the creation and maintenance of accessible digital collections, scholarly
+  output, and other digital materials that have enduring value for intellectual
+  inquiry and documentation of College activities.
+</p>
+
+<h2>Faculty Scholarship and the LDR</h2>
+<p>
+  The Lafayette College faculty passed an open access resolution in April, 2011.
+  Faculty are encouraged to share their research outputs via inclusion in the
+  Lafayette Digital Repository. Flexible access and visibility controls are
+  available for deposited content.
+</p>
+
+<h2>Why submit your content to the LDR?</h2>
+<ul>
+  <li>boost the search engine discoverability of your research</li>
+  <li>provide persistent access to your research over time (i.e. prevent “link rot” in citations to your work)</li>
+  <li>satisfy funding agency requirements for sharing and preserving research data and published findings</li>
+  <li>preserve your work for the long term in an institutional environment</li>
+</ul>
+<p>
+  Members of the faculty and administrative departments may use the LDR submission form to deposit
+  articles to the Lafayette Digital Repository.  For other content types, such as presentations,
+  research data, audiovisual materials, etc. please contact Nora Egloff, Digital Repository Librarian,
+  at egloffn@lafayette.edu for more information.
+</p>
+
+<h2>Policies</h2>
+
+<h3>Copyright and Use</h3>
+<p>
+  Please consult the <a href="https://dss.lafayette.edu/copyright-and-use/" target="_blank">Digital Scholarship Services Copyright & Use Guidelines</a>
+  for information about using and sharing content in the LDR. If you have further
+  questions, please contact us at dss@lafayette.edu.
+</p>
+
+<h3>Preservation Support Policy</h3>
+<p>
+  The Lafayette Digital Repository is committed to providing sustainable
+  and trustworthy long-term access to content according to international
+  best practices for digital preservation.
+</p>
+<p>
+  All resources in the LDR are assigned unique persistent identifiers by
+  the repository system, as well as persistent URLs through the Handle.net
+  registry. Bit-level preservation of digital objects and metadata is
+  managed through the generation of checksum hashes and performance of
+  fixity checking at regular intervals.
+</p>
+
+<p>
+  Beyond these initial preservation activities, the LDR team is developing
+  a broader preservation policy and action plan.  Details about new services
+  and preservation planning will be announced as they are approved by
+  Library and College stakeholders.
 </p>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -40,7 +40,7 @@ SSHKit.config.command_map[:solr] = '/opt/solr/bin/solr'
 
 # shared things
 append :linked_dirs, 'log'
-append :linked_dirs, 'tmp/cache', 'tmp/derivatives', 'tmp/export', 'tmp/ingest', 'tmp/pids', 'tmp/sockets'
+append :linked_dirs, 'tmp/cache', 'tmp/derivatives', 'tmp/export', 'tmp/ingest', 'tmp/pids', 'tmp/sockets', 'tmp/uploads'
 append :linked_dirs, 'vendor/bundle'
 append :linked_dirs, 'public/assets', 'public/branding', 'public/system', 'public/uploads'
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -21,9 +21,14 @@ set :rails_env, 'production'
 set :assets_roles, :app
 
 # capistrano-sidekiq
+#
+# note: it's probably best to specify concurrency per-environment.
+# the default we're using here is the minimum working amount that
+# worked on our single-server development instance.
 set :sidekiq_config, release_path.join('config', 'sidekiq.yml')
 set :sidekiq_env, fetch(:rails_env)
 set :sidekiq_processes, 1
+set :sidekiq_concurrency, 4
 set :sidekiq_role, :jobs
 
 # remapping commands

--- a/config/deploy/development.rb
+++ b/config/deploy/development.rb
@@ -3,4 +3,7 @@
 # Our development server. Everything lives here as an attempt to
 # prove that all of the pieces work together more than trying to
 # host a lot of objects.
+
+set :sidekiq_concurrency, 4
+
 server 'nostromo0-0.dev.lafayette.edu', user: 'deploy', roles: %w[app db solr jobs web]

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -4,6 +4,8 @@
 # the stage application will most likely be from our `develop` branch
 set :branch, ENV.fetch('BRANCH') { 'develop' }
 
+set :sidekiq_concurrency, 10
+
 server 'nostromo0-0.stage.lafayette.edu',
        user: 'deploy',
        roles: %w[app db web]

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
-#
-# Stage mirrors Production pretty closely (if not exactly).
+
+# we're releasing off of `master`, so anything going on to
+# the stage application will most likely be from our `develop` branch
+set :branch, ENV.fetch('BRANCH') { 'develop' }
+
 server 'nostromo0-0.stage.lafayette.edu',
        user: 'deploy',
        roles: %w[app db web]

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -173,7 +173,7 @@ Hyrax.config do |config|
 
   # Location on local file system where derivatives will be stored
   # If you use a multi-server architecture, this MUST be a shared volume
-  # config.derivatives_path = Rails.root.join('tmp', 'derivatives')
+  config.derivatives_path = ENV.fetch('DERIVATIVES_PATH') { Rails.root.join('tmp', 'derivatives') }
 
   # Should schema.org microdata be displayed?
   # config.display_microdata = true

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -210,7 +210,7 @@ Hyrax.config do |config|
   # config.fits_message_length = 5
 
   # ActiveJob queue to handle ingest-like jobs
-  config.ingest_queue_name = :default
+  config.ingest_queue_name = :ingest
 
   ## Attributes for the lock manager which ensures a single process/thread is mutating a ore:Aggregation at once.
   # How many times to retry to acquire the lock before raising UnableToAcquireLockError

--- a/config/initializers/hyrax_overrides.rb
+++ b/config/initializers/hyrax_overrides.rb
@@ -51,6 +51,9 @@ load_overrides = lambda do
         action_name == 'show' ? 'hyrax' : 'hyrax/dashboard'
       end
   end
+
+  # see above
+  Hyrax::ContactFormController.class_eval { layout 'hyrax' }
 end
 
 Rails.application.config.after_initialize do

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -40,6 +40,10 @@ en:
         subject: Subject
         title: Title
         years_encompassed: Year
+
+        facet:
+          resource_type_sim: Type
+          source_sim: Source
     sort:
       fields:
         date_added:

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -12,6 +12,10 @@ en:
 
     log_in: Library staff log-in
 
+    catalog:
+      index:
+        page_title: 'Search Results // %{name}'
+
     dashboard:
       fixity:
         frequency: Checks are run every Monday at midnight.

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,11 +1,11 @@
 # Config file for Sidekiq
 #
-# NOTE: this config is run through ERB when being read, so feel free
-# to do some dynamic stuff where necessary.
+# See the capistrano-sidekiq section of `config/deploy.rb`
+# for more detailed configuration (eg concurrency, # of processes).
+# This lets us vary the settings per environment.
 ---
 :verbose: false
 :timeout: 30
-:concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY') { 2 } %>
 :queues:
   - default
   - ingest

--- a/lib/capistrano/tasks/spot/remote_tasks.rake
+++ b/lib/capistrano/tasks/spot/remote_tasks.rake
@@ -28,7 +28,7 @@ namespace :spot do
       role = ENV.fetch('role')
       user = ENV.fetch('user')
 
-      on roles(:app) do
+      on roles(:web) do
         within current_path do
           with rails_env: fetch(:rails_env) do
             execute(:rails, 'spot:roles:add_user_to_role', "user=#{user}", "role=#{role}")

--- a/lib/tasks/spot/collections.rake
+++ b/lib/tasks/spot/collections.rake
@@ -11,5 +11,13 @@ namespace :spot do
         Spot::CollectionFromConfig.from_yaml(config).create
       end
     end
+
+    desc 'List Collection ids and titles (useful when ingesting items)'
+    task list: [:environment] do
+      list = Collection.all.map { |c| [c.id, c.title.first] }
+      puts " ID       || TITLE"
+      puts "==========||=========="
+      list.each { |(id, title)| puts "#{id} || #{title}" }
+    end
   end
 end

--- a/spec/features/show_publication_spec.rb
+++ b/spec/features/show_publication_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature 'Show Publication page', js: false do
 
   scenario 'metadata fields are present' do
     expect(page).to have_content pub.title.first
+    expect(page.title).to eq "#{pub.title.first} // Lafayette Digital Repository"
 
     # descriptions are treated differently
     # expect(page.all('.work_description').map(&:text))

--- a/spec/forms/hyrax/publication_form_spec.rb
+++ b/spec/forms/hyrax/publication_form_spec.rb
@@ -154,4 +154,14 @@ RSpec.describe Hyrax::PublicationForm do
       end
     end
   end
+
+  describe 'identifier field' do
+    subject { form.identifier }
+
+    let(:form) { described_class.new(pub, nil, nil) }
+    let(:pub) { Publication.new(identifier: ['noid:abc123def', 'issn:1234-5678']) }
+
+    it { is_expected.not_to include 'noid:abc123def' }
+    it { is_expected.to include 'issn:1234-5678' }
+  end
 end

--- a/spec/presenters/hyrax/publication_presenter_spec.rb
+++ b/spec/presenters/hyrax/publication_presenter_spec.rb
@@ -75,6 +75,13 @@ RSpec.describe Hyrax::PublicationPresenter do
     it { is_expected.to eq [[uri, label]] }
   end
 
+  describe '#page_title' do
+    subject { presenter.page_title }
+
+    it { is_expected.to include presenter.title.first }
+    it { is_expected.to include 'Lafayette Digital Repository' }
+  end
+
   describe '#rights_statement_merged' do
     subject { presenter.rights_statement_merged }
 

--- a/spec/services/spot/mappers/newspaper_mapper_spec.rb
+++ b/spec/services/spot/mappers/newspaper_mapper_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe Spot::Mappers::NewspaperMapper do
     it 'chooses the older date for date_issued' do
       expect(mapper.date_issued).to eq ['1986-02-11']
     end
+
+    context 'when only one dc:date value is present' do
+      let(:metadata) { { 'dc:date' => ['1986-02-11T00:00:00Z'] } }
+
+      it 'uses that date' do
+        expect(mapper.date_issued).to eq ['1986-02-11']
+      end
+    end
   end
 
   describe '#date_uploaded' do


### PR DESCRIPTION
- update a work's `document.title` to resemble '{work title} // Lafayette Digital Repository'
- add text content to the About page
- add link to the Contact page in site footer
- specify Sidekiq concurrency via capistrano-sidekiq configuration
- use the `:ingest` queue for Hyrax's "ingest-like jobs"
- add 'spot:collections:list' task
- bugfix: don't skip single `dc:date` values when mapping to `date_issued` for magazines
- bugfix: add `tmp/uploads` to capistrano's shared directories
- bugfix: assign roles (via capistrano) on the :web server only