### PR TITLE
update SPOT_VERSION constant creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ fits.log
 
 # Ignore collection branding items
 /public/branding
+
+# our deployed version file (shouldn't actually appear in dev,
+# but you never know i guess)
+VERSION

--- a/config/initializers/spot_constants.rb
+++ b/config/initializers/spot_constants.rb
@@ -43,10 +43,10 @@ SPOT_VERSION = begin
 
   if File.exist?(file_path)
     File.read(file_path).chomp
-  elsif gittag = `git describe --tags 2> /dev/null`.chomp
+  elsif (gittag = `git describe --tags 2> /dev/null`.chomp)
     gittag
   else
     require 'datetime'
-    "#{DateTime.now.year}-dev"
+    "#{DateTime.current.year}-dev"
   end
 end

--- a/config/initializers/spot_constants.rb
+++ b/config/initializers/spot_constants.rb
@@ -31,9 +31,22 @@ LAST_DEPLOYED =
     'Not in deployed environment'
   end
 
-# unsure of this vs creating a Spot::VERSION constant?
+# since capistrano deploys using just the files and
+# not the actual repository, we can't use git (at the
+# application root) to determine the version. instead,
+# there's now a capistrano task (`spot:write_version_file`)
+# that will generate a VERSION file at the release root
+# and we'll read from that. otherwise, assume we're
+# local + run the git command.
 SPOT_VERSION = begin
-  version = `git describe --tags 2> /dev/null`.chomp.sub('v', '')
-  version = '0.0.0' if version.blank?
-  version
+  file_path = Rails.root.join('VERSION')
+
+  if File.exist?(file_path)
+    File.read(file_path).chomp
+  elsif gittag = `git describe --tags 2> /dev/null`.chomp
+    gittag
+  else
+    require 'datetime'
+    "#{DateTime.now.year}-dev"
+  end
 end

--- a/lib/capistrano/tasks/spot/write_version_file.rake
+++ b/lib/capistrano/tasks/spot/write_version_file.rake
@@ -11,7 +11,7 @@ namespace :spot do
       next if tag == ''
 
       within release_path do
-        execute(:echo, %(#{tag}), '>', 'VERSION')
+        execute(:echo, %("#{tag}"), '>', 'VERSION')
       end
     end
   end

--- a/lib/capistrano/tasks/spot/write_version_file.rake
+++ b/lib/capistrano/tasks/spot/write_version_file.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+namespace :spot do
+  task :write_version_file do
+    on roles(:web) do
+      tag = ''
+
+      within repo_path do
+        tag = capture(:git, :describe, '--tags', '2>', '/dev/null').strip
+      end
+
+      next if tag == ''
+
+      within release_path do
+        execute(:echo, %(#{tag}), '>', 'VERSION')
+      end
+    end
+  end
+end
+
+after 'git:create_release', 'spot:write_version_file'


### PR DESCRIPTION
after deployment, we'll write a `VERSION` file to the root of the app + use that to define the `SPOT_VERSION` constant. it's convoluted, but i'd like to have a current version displayed on the site for debugging