### PR TITLE
use | as default multi_value_character for ingest

### DIFF
--- a/app/jobs/spot/ingest_bag_job.rb
+++ b/app/jobs/spot/ingest_bag_job.rb
@@ -28,7 +28,7 @@ module Spot
                 source:,
                 work_class:,
                 collection_ids: [],
-                multi_value_character: ';')
+                multi_value_character: '|')
       @bag_path = bag_path
       @source = source
       @work_class = work_class.constantize

--- a/app/jobs/spot/ingest_zipped_bag_job.rb
+++ b/app/jobs/spot/ingest_zipped_bag_job.rb
@@ -32,12 +32,8 @@ module Spot
     # @raise [ValidationError] if the file to parse is invalid
     #   (from Darlingtonia::Parser)
     #
-    def perform(zip_path:,
-                source:,
-                work_class:,
-                working_path:,
-                collection_ids: [],
-                multi_value_character: ';')
+    def perform(zip_path:, source:, work_class:, working_path:,
+                collection_ids: [], multi_value_character: '|')
       raise ArgumentError, "#{working_path} is not a directory" unless File.directory?(working_path)
 
       destination = File.join(working_path, File.basename(zip_path, '.zip'))

--- a/lib/tasks/spot/ingest.rake
+++ b/lib/tasks/spot/ingest.rake
@@ -7,7 +7,7 @@ namespace :spot do
     path = ENV['path']
     work_class = ENV['work_class']
     collection_ids = ENV['collection_ids'].to_s.split(',')
-    multi_value_character = ENV.fetch('multi_value_character', ';')
+    multi_value_character = ENV.fetch('multi_value_character', '|')
     working_path = ENV.fetch('working_path', Rails.root.join('tmp', 'ingest').to_s)
 
     error_message = if    !source       then 'No `source` provided!'

--- a/spec/jobs/spot/ingest_zipped_bag_job_spec.rb
+++ b/spec/jobs/spot/ingest_zipped_bag_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Spot::IngestZippedBagJob do
                                 work_class: work_class,
                                 source: source,
                                 collection_ids: collection_ids,
-                                multi_value_character: '|',
+                                multi_value_character: ';',
                                 working_path: working_path)
   end
 
@@ -31,7 +31,7 @@ RSpec.describe Spot::IngestZippedBagJob do
       expect(Spot::IngestBagJob)
         .to have_received(:perform_now)
         .with(bag_path: working_path.join('bag').to_s, source: source,
-              work_class: work_class, collection_ids: collection_ids, multi_value_character: '|')
+              work_class: work_class, collection_ids: collection_ids, multi_value_character: ';')
     end
 
     context 'when working path isn\'t a directory' do


### PR DESCRIPTION
after accidentally splitting some values that contained semicolons, we've decided to switch to using a bar (`|`) as the multi-value splitting character on incoming bags