### PR TITLE
add ingest task for publications

### DIFF
--- a/lib/capistrano/tasks/spot/remote_tasks.rake
+++ b/lib/capistrano/tasks/spot/remote_tasks.rake
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 #
 # capistrano wrappings around spot tasks that we might want to do remotely
-# rubocop:disable Metrics/BlockLength
 namespace :spot do
   namespace :roles do
     task :add_user_to_role do
@@ -28,4 +27,3 @@ namespace :spot do
     end
   end
 end
-# rubocop:enable Metrics/BlockLength

--- a/lib/capistrano/tasks/spot/remote_tasks.rake
+++ b/lib/capistrano/tasks/spot/remote_tasks.rake
@@ -3,26 +3,6 @@
 # capistrano wrappings around spot tasks that we might want to do remotely
 # rubocop:disable Metrics/BlockLength
 namespace :spot do
-  desc 'ingest a directory of zipped bags'
-  task :ingest do
-    # using fetch will cause the task to abort if the fields are missing
-    source = ENV.fetch('source')
-    work_class = ENV.fetch('work_class')
-    path = ENV.fetch('path')
-
-    tmp_path = File.join('/tmp', "spot-bag-ingest-#{Time.now.to_i}")
-
-    on roles(:app) do
-      upload!(path, tmp_path, recursive: true)
-
-      within current_path do
-        with rails_env: fetch(:rails_env) do
-          execute(:rails, 'spot:ingest', "source=#{source}", "work_class=#{work_class}", "path=#{tmp_path}")
-        end
-      end
-    end
-  end
-
   namespace :roles do
     task :add_user_to_role do
       role = ENV.fetch('role')

--- a/lib/tasks/spot/ingest.rake
+++ b/lib/tasks/spot/ingest.rake
@@ -16,12 +16,7 @@ namespace :spot do
   def check_for_errors!
     return true unless (msg = check_env)
 
-    common_envs = 'source=<source> work_class=<work class>'
-
-    puts msg
-    puts "Use `bundle exec rails #{t} #{common_envs} path=</path/to/bag_file.zip>"
-    puts " or `bundle exec rails #{t} #{common_envs} path=</path/to/directory_of_bags"
-    exit
+    puts msg and exit
   end
 
   def job_args_from_env

--- a/lib/tasks/spot/ingest.rake
+++ b/lib/tasks/spot/ingest.rake
@@ -16,7 +16,7 @@ namespace :spot do
   def check_for_errors!
     return true unless (msg = check_env)
 
-    puts msg and exit
+    puts msg && exit
   end
 
   def job_args_from_env

--- a/lib/tasks/spot/ingest.rake
+++ b/lib/tasks/spot/ingest.rake
@@ -30,7 +30,7 @@ namespace :spot do
       multi_value_character: ENV.fetch('multi_value_character', '|'),
       source: ENV['source'],
       work_class: ENV['work_class'],
-      working_path: ENV.fetch('working_path', Rails.root.join('tmp', 'ingest').to_s),
+      working_path: ENV.fetch('working_path', Rails.root.join('tmp', 'ingest').to_s)
     }
   end
 
@@ -48,7 +48,7 @@ namespace :spot do
   namespace :ingest do
     desc 'Ingest Publication items from zipped BagIt files'
     task publication: :environment do
-      check_for_errors! && enqueue_jobs(job_args_from_env.merge(work_class: 'Publication')
+      check_for_errors! && enqueue_jobs(job_args_from_env.merge(work_class: 'Publication'))
     end
   end
 end

--- a/lib/tasks/spot/ingest.rake
+++ b/lib/tasks/spot/ingest.rake
@@ -48,6 +48,7 @@ namespace :spot do
   namespace :ingest do
     desc 'Ingest Publication items from zipped BagIt files'
     task publication: :environment do
+      ENV['work_class'] = 'Publication'
       check_for_errors! && enqueue_jobs(job_args_from_env.merge(work_class: 'Publication'))
     end
   end

--- a/lib/tasks/spot/ingest.rake
+++ b/lib/tasks/spot/ingest.rake
@@ -1,40 +1,54 @@
 # frozen_string_literal: true
 
 namespace :spot do
-  desc 'Ingest items from zipped BagIt files'
-  task ingest: :environment do |t|
-    source = ENV['source']
-    path = ENV['path']
-    work_class = ENV['work_class']
-    collection_ids = ENV['collection_ids'].to_s.split(',')
-    multi_value_character = ENV.fetch('multi_value_character', '|')
-    working_path = ENV.fetch('working_path', Rails.root.join('tmp', 'ingest').to_s)
-
-    error_message = if    !source       then 'No `source` provided!'
-                    elsif !path         then 'No `path` provided!'
-                    elsif !work_class   then 'No `work_class` provided!'
-                    end
-
-    if error_message
-      common_envs = 'source=<source> work_class=<work class>'
-
-      puts error_message
-      puts "Use `bundle exec rails #{t} #{common_envs} path=</path/to/bag_file.zip>"
-      puts " or `bundle exec rails #{t} #{common_envs} path=</path/to/directory_of_bags"
-      exit
+  def check_env
+    if !ENV['source']
+      'No `source` provided!'
+    elsif !ENV['path']
+      'No `path` provided!'
+    elsif !File.exist?(ENV['path'])
+      'File or path does not exist'
+    elsif !ENV['work_class']
+      'No `work_class` provided!'
     end
+  end
 
-    raise ArgumentError, 'File or path does not exist' unless File.exist?(path)
+  def check_for_errors!
+    return true unless (msg = check_env)
 
-    paths = File.directory?(path) ? Dir[File.join(path, '*.zip')] : [path]
+    common_envs = 'source=<source> work_class=<work class>'
 
-    paths.each do |entry|
-      Spot::IngestZippedBagJob.perform_later(zip_path: entry,
-                                             source: source,
-                                             collection_ids: collection_ids,
-                                             multi_value_character: multi_value_character,
-                                             work_class: work_class,
-                                             working_path: working_path)
+    puts msg
+    puts "Use `bundle exec rails #{t} #{common_envs} path=</path/to/bag_file.zip>"
+    puts " or `bundle exec rails #{t} #{common_envs} path=</path/to/directory_of_bags"
+    exit
+  end
+
+  def job_args_from_env
+    {
+      collection_ids: ENV.fetch('collection_ids', '').split(','),
+      multi_value_character: ENV.fetch('multi_value_character', '|'),
+      source: ENV['source'],
+      work_class: ENV['work_class'],
+      working_path: ENV.fetch('working_path', Rails.root.join('tmp', 'ingest').to_s),
+    }
+  end
+
+  def enqueue_jobs(base_args = job_args_from_env)
+    paths = File.directory?(ENV['path']) ? Dir[File.join(ENV['path'], '*.zip')] : [ENV['path']]
+    paths.each { |e| Spot::IngestZippedBagJob.perform_later(base_args.merge(zip_path: e)) }
+    true
+  end
+
+  desc 'Ingest items from zipped BagIt files'
+  task ingest: :environment do
+    check_for_errors! && enqueue_jobs
+  end
+
+  namespace :ingest do
+    desc 'Ingest Publication items from zipped BagIt files'
+    task publication: :environment do
+      check_for_errors! && enqueue_jobs(job_args_from_env.merge(work_class: 'Publication')
     end
   end
 end


### PR DESCRIPTION
- adds a `spot:ingest:publication` task to cut down the number of ENV values needed to invoke the task
- abstacts out ENV checking so that tasks can be created for future work types
- removes capistrano ingest task since we've never actually used it