### PR TITLE
add visibility facet for admin

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -79,6 +79,11 @@ class CatalogController < ApplicationController
     #
     # admin facets
     #
+    config.add_facet_field 'visibility_ssi',
+                           label: I18n.t('blacklight.search.fields.visbility'),
+                           limit: 5,
+                           admin: true,
+                           helper_method: :render_catalog_visibility_facet
     config.add_facet_field 'depositor_ssim',
                            label: I18n.t('blacklight.search.fields.depositor'),
                            limit: 5,

--- a/app/helpers/spot/facet_helper.rb
+++ b/app/helpers/spot/facet_helper.rb
@@ -3,18 +3,25 @@
 # Helpers to split out facets useful to admins from the regular ("general") ones
 module Spot
   module FacetHelper
-    # render partials for the majority of our partials
-    #
-    # @return [String]
-    def render_general_facet_partials
-      render_facet_partials(general_facet_names)
-    end
-
     # render only the admin facet partials
     #
     # @return [String]
     def render_admin_facet_partials
       render_facet_partials(admin_facet_names)
+    end
+
+    # Wraps our visibility facets in the Hyrax::PermissionBadge HTML
+    #
+    # @return [String]
+    def render_catalog_visibility_facet(visibility)
+      Hyrax::PermissionBadge.new(visibility).render
+    end
+
+    # render partials for the majority of our partials
+    #
+    # @return [String]
+    def render_general_facet_partials
+      render_facet_partials(general_facet_names)
     end
 
     # Returns only the facets where the option +:admin+ is truthy

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -44,6 +44,7 @@ en:
         facet:
           resource_type_sim: Type
           source_sim: Source
+          visibility_ssi: Visibility
     sort:
       fields:
         date_added:

--- a/spec/helpers/spot/facet_helper_spec.rb
+++ b/spec/helpers/spot/facet_helper_spec.rb
@@ -50,4 +50,12 @@ RSpec.describe Spot::FacetHelper, type: :helper do
         .with(helper.admin_facet_names)
     end
   end
+
+  describe '.render_catalog_visibility_facet' do
+    subject { helper.render_catalog_visibility_facet(visibility) }
+
+    let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+
+    it { is_expected.to eq '<span class="label label-success">Public</span>' }
+  end
 end


### PR DESCRIPTION
adds a visibility facet (for admins only at the moment) that uses `Hyrax::PermissionBadge` for rendering

closes #247 