### PR TITLE
upgrade nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -567,7 +567,7 @@ GEM
     noid-rails (3.0.1)
       actionpack (>= 5.0.0, < 6)
       noid (~> 0.9)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri


### PR DESCRIPTION
per [CVE-2019-5477](https://nvd.nist.gov/vuln/detail/CVE-2019-5477), bumps nokogiri to 1.10.4