### PR TITLE
index + display permalink

### DIFF
--- a/app/indexers/concerns/indexes_permalink.rb
+++ b/app/indexers/concerns/indexes_permalink.rb
@@ -6,6 +6,7 @@
 # identifier, and prefers those that contain
 # an object's NOID.
 module IndexesPermalink
+  # @todo: move the handle prefix to a configuration file
   HANDLE_PREFIX = '10385'
   PERMALINK_SOLR_FIELD = 'permalink_ss'
 

--- a/app/indexers/concerns/indexes_permalink.rb
+++ b/app/indexers/concerns/indexes_permalink.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+#
+# Mixin to fish-out a permalink + assign it to
+# a solr field. Will not assign this property
+# if an item does not have an `hdl` prefixed
+# identifier, and prefers those that contain
+# an object's NOID.
+module IndexesPermalink
+  HANDLE_PREFIX = '10385'
+  PERMALINK_SOLR_FIELD = 'permalink_ss'
+
+  def generate_solr_document
+    super.tap do |doc|
+      break doc if permalink.nil?
+      doc[PERMALINK_SOLR_FIELD] = permalink
+    end
+  end
+
+  private
+
+    # Determines the right Handle identifier to use as the permalink.
+    # - Are there any +hdl+ prefixed identifiers?
+    # - Do these identifiers include the object's NOID?
+    # - Otherwise, use the first Handle ID found
+    #
+    # @return [Spot::Identifier]
+    # @todo How to deal with multiple Handle IDs where none of them
+    #       include the object's NOID. This is a 'probably never will happen'
+    #       circumstance, but I'd like to have a fail-safe rather than
+    #       just skipping the permalink.
+    def handle_identifier
+      return nil if handle_identifiers.empty?
+      return handle_identifiers.first if handle_identifiers.size == 1
+
+      noid_handle = handle_identifiers.find do |id|
+        id.value == "#{HANDLE_PREFIX}/#{object.id}"
+      end
+
+      return noid_handle unless noid_handle.nil?
+
+      # worst case scenario?
+      handle_identifiers.first
+    end
+
+    # @return [Array<Spot::Identifier>]
+    def handle_identifiers
+      @handle_identifiers ||=
+        object.identifier
+              .select { |id| id.start_with? 'hdl' }
+              .map { |id| Spot::Identifier.from_string(id) }
+    end
+
+    # @return [String, nil]
+    def permalink
+      @permalink ||= begin
+        id = handle_identifier
+        id ? "http://hdl.handle.net/#{id.value}" : nil
+      end
+    end
+end

--- a/app/indexers/publication_indexer.rb
+++ b/app/indexers/publication_indexer.rb
@@ -4,6 +4,7 @@ class PublicationIndexer < Hyrax::WorkIndexer
   include IndexesEnglishLanguageDates
   include IndexesLanguageAndLabel
   include IndexesSortableDate
+  include IndexesPermalink
 
   # Overriding the default +Hyrax::DeepIndexingService+ for our own, which
   # doesn't require +Hyrax::BasicMetadata+

--- a/app/models/concerns/spot/solr_document_attributes.rb
+++ b/app/models/concerns/spot/solr_document_attributes.rb
@@ -45,6 +45,7 @@ module Spot
       attribute :organization,           ::Blacklight::Types::Array, 'organization_tesim'
       attribute :original_checksum,      ::Blacklight::Types::String, 'original_checksum_tesim'
       attribute :page_count,             ::Blacklight::Types::String, 'page_count_tesim'
+      attribute :permalink,              ::Blacklight::Types::String, 'permalink_ss'
       attribute :physical_medium,        ::Blacklight::Types::Array, 'physical_medium_tesim'
       attribute :related_resource,       ::Blacklight::Types::Array, 'related_resource_ssim'
       attribute :resource_type,          ::Blacklight::Types::Array, 'resource_type_tesim'

--- a/app/presenters/hyrax/publication_presenter.rb
+++ b/app/presenters/hyrax/publication_presenter.rb
@@ -7,8 +7,8 @@ module Hyrax
     delegate :abstract, :academic_department, :bibliographic_citation,
              :contributor, :creator, :date_issued, :date_available,
              :division, :editor, :keyword, :language, :language_label,
-             :organization, :publisher, :resource_type, :source, :subject,
-             :subtitle, :title_alternative,
+             :organization, :permalink, :publisher, :resource_type,
+             :source, :subject, :subtitle, :title_alternative,
              to: :solr_document
 
     # Metadata formats we're able to export as.

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -15,9 +15,11 @@
           <dd><%= doc_presenter.field_value field %></dd>
       <% end %>
     <% end %>
-    <% if doc_presenter.permalink %>
-      <dt><%= render_index_field_label document, field: :permalink %></dt>
-      <dd><%= doc_presenter.permalink %></dd>
+    <%# there's probably a better way to do this, but we want to ensure that
+        the permalink is always at the bottom when it exists %>
+    <% if document.permalink.present? %>
+      <dt><%= t 'blacklight.search.fields.permalink' %></dt>
+      <dd><%= document.permalink %></dd>
     <% end %>
     </dl>
   </div>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -15,6 +15,10 @@
           <dd><%= doc_presenter.field_value field %></dd>
       <% end %>
     <% end %>
+    <% if doc_presenter.permalink %>
+      <dt><%= render_index_field_label document, field: :permalink %></dt>
+      <dd><%= doc_presenter.permalink %></dd>
+    <% end %>
     </dl>
   </div>
 </div>

--- a/app/views/hyrax/publications/_metadata.html.erb
+++ b/app/views/hyrax/publications/_metadata.html.erb
@@ -28,6 +28,7 @@
       <%= presenter.attribute_to_html(:bibliographic_citation) %>
       <%= presenter.attribute_to_html(:standard_identifier, render_as: :identifier) %>
       <%= presenter.attribute_to_html(:related_resource) %>
+      <%= presenter.attribute_to_html(:permalink) %>
 
       <%= render 'shared/metadata/rights_statement', presenter: presenter %>
     </tbody>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -32,6 +32,7 @@ en:
         organization: Organization
         original_checksum: Original Checksum (MD5)
         page_count: Page Count
+        permalink: Permalink
         proxy_depositor: Proxy Depositor
         publisher: Publisher
         resource_type: Type

--- a/spec/indexers/publication_indexer_spec.rb
+++ b/spec/indexers/publication_indexer_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe PublicationIndexer do
   it_behaves_like 'it indexes English-language dates'
   it_behaves_like 'it indexes ISO language and label'
   it_behaves_like 'it indexes a sortable date'
+  it_behaves_like 'it indexes a permalink'
 
   describe 'title' do
     # :stored_searchable

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe SolrDocument do
     original_checksum: { type: String, suffix: 'tesim' },
     physical_medium: { type: Array, suffix: 'tesim' },
     page_count: { type: String, suffix: 'tesim', value: '100' },
+    permalink: { type: String, suffix: 'ss', value: 'http://hdl.handle.net/10385/test' },
     related_resource: { type: Array, suffix: 'ssim' },
     resource_type: { type: Array, suffix: 'tesim' },
     rights_statement: { type: Array, suffix: 'ssim' },

--- a/spec/support/shared_examples/indexing/indexes_permalink.rb
+++ b/spec/support/shared_examples/indexing/indexes_permalink.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'it indexes a permalink' do
+  subject(:solr_doc) { indexer.generate_solr_document }
+
+  let(:indexer) { described_class.new(work) }
+  let(:work_klass) { described_class.name.gsub(/Indexer$/, '').downcase.to_sym }
+  let(:work) { build(work_klass, id: 'abc123def', identifier: identifier) }
+  let(:solr_field) { described_class::PERMALINK_SOLR_FIELD }
+
+  context 'when no identifiers present' do
+    let(:identifier) { [] }
+
+    it { is_expected.not_to include(solr_field) }
+  end
+
+  context 'when no handle identifiers present' do
+    let(:identifier) { ['issn:1234-5678'] }
+
+    it { is_expected.not_to include(solr_field) }
+  end
+
+  context 'when one handle identifier is present' do
+    let(:identifier) { %w[issn:1234-5678 hdl:10385/1234] }
+
+    it 'is a handle.net URI to the ID' do
+      expect(solr_doc[solr_field]).to eq 'http://hdl.handle.net/10385/1234'
+    end
+  end
+
+  context 'when more than one handle identifier is present' do
+    let(:identifier) { %w[hdl:10385/1234 hdl:10385/abc123def issn:1234-5678] }
+
+    it 'prefers the URI that includes the work.id value' do
+      expect(solr_doc[solr_field]).to eq "http://hdl.handle.net/10385/abc123def"
+    end
+  end
+
+  context 'when none of the identifiers contain the noid' do
+    let(:identifier) { %w[hdl:10385/1234 hdl:10385/5678 issn:1234-5678] }
+    let(:candidates) do
+      %w[http://hdl.handle.net/10385/1234 http://hdl.handle.net/10385/5678]
+    end
+
+    it 'uses the one of the handle identifiers' do
+      expect(candidates).to include(solr_doc[solr_field])
+    end
+  end
+end


### PR DESCRIPTION
split out from #269 so that we can take time to get Handle minting straightened out. this indexes a permalink when an `hdl` identifier is present + displays it on the catalog + item views.

closes #268 