### PR TITLE
only save collection_from_config if the attributes have changed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - solr
     stdin_open: true
     tty: true
+
   db:
     image: postgres:alpine
     volumes:
@@ -39,20 +40,24 @@ services:
       POSTGRES_DB: spot_dev
       POSTGRES_USER: spot_dev_user
     restart: always
+
   fedora:
     image: samvera/fcrepo4:4.7.5
     volumes:
       - fedora:/data
     restart: always
+
   fitsservlet:
     image: harvardlts/fitsservlet_container
     environment:
       FITSSERVLET_VERSION: '1.1.3'
+
   redis:
     image: redis:alpine
     volumes:
       - redis:/data
     restart: always
+
   solr:
     image: solr:7.5-alpine
     volumes:
@@ -60,6 +65,7 @@ services:
       - solr:/opt/solr/server/solr/mycores
     command: solr-create -c spot-development -d /spot-config
     restart: always
+
   sidekiq:
     <<: *app
     command: bundle exec sidekiq
@@ -70,4 +76,4 @@ services:
       - "4000:3000"
     restart: always
     depends_on:
-      - spot
+      - app

--- a/spec/services/spot/collection_from_config_spec.rb
+++ b/spec/services/spot/collection_from_config_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Spot::CollectionFromConfig do
   let(:visibility) { 'private' }
 
   before do
+    User.create(email: 'dss@lafayette.edu')
+
     Hyrax::CollectionTypes::CreateService.create_admin_set_type
     Hyrax::CollectionTypes::CreateService.create_user_collection_type
   end


### PR DESCRIPTION
we were getting some hanging `db:seed` calls when deploying because collections were having unnecessary `#save!` calls when there weren't changes to be made. this guards against that.

it also fixes the docker-compose.yml file bc i forgot to push those changes before checking out this branch 😊 