### PR TITLE
add redirect_controller for legacy urls

### DIFF
--- a/app/controllers/spot/redirect_controller.rb
+++ b/app/controllers/spot/redirect_controller.rb
@@ -8,8 +8,9 @@ module Spot
   # a +url:+ prefix. Redirect rules should be implemented on legacy services
   # to send the entire URL as a parameter value.
   #
-  # @example Apache redirect rules
-  #   RewriteRule ^/collections/.*$ https://ldr.lafayette.edu/redirect?url=http://%{HTTP_HOST}%{REQUEST_URI} [L,QSA]
+  # @example httpd rewrite rules
+  #   RewriteEngine on
+  #   RewriteRule ^collections\/[a-z0-9\-]+/[a-z0-9\-]+ https://ldr.lafayette.edu/redirect?url=http://digital.lafayette.edu%{REQUEST_URI} [L,QSA]
   #
   # @todo This should be abstracted out, as the {IdentifierController}
   #       (soon to be HandleController) follows (almost) the same  logic.

--- a/app/controllers/spot/redirect_controller.rb
+++ b/app/controllers/spot/redirect_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require 'uri'
+
+module Spot
+  # Controller responsible for redirecting requests from legacy services
+  # (in particular, our Islandora instance) to their migrated counterparts.
+  # For items that have a legacy URL, an identifier value is added with
+  # a +url:+ prefix. Redirect rules should be implemented on legacy services
+  # to send the entire URL as a parameter value.
+  #
+  # @example Apache redirect rules
+  #   RewriteRule ^/collections/.*$ https://ldr.lafayette.edu/redirect?url=http://%{HTTP_HOST}%{REQUEST_URI} [L,QSA]
+  #
+  # @todo This should be abstracted out, as the {IdentifierController}
+  #       (soon to be HandleController) follows (almost) the same  logic.
+  class RedirectController < ApplicationController
+    include ::Hydra::Catalog
+
+    def show
+      # all that we need for this controller are the object's ID + Hydra Model
+      query = solr_query_for_identifier.merge(fl: ['id', 'has_model_ssim'])
+      result, _documents = repository.search(query)
+
+      raise Blacklight::Exceptions::RecordNotFound if result.response['numFound'].zero?
+
+      document = result.response['docs'].first
+      controller = document['has_model_ssim'].first.downcase.pluralize
+
+      redirect_to controller: "hyrax/#{controller}", action: 'show', id: document['id']
+    end
+
+    private
+
+      # Converts the passed URI into an HTTP URI
+      # @return [String]
+      def http_uri
+        URI::HTTP.build(parse_uri_into_args).to_s
+      end
+
+      # Breaks a URI string into a Hash of URI component parts
+      #
+      # @param [String] uri_string Any kind of URI that works with +URI.parse+
+      # @return [Hash<Symbol => String, nil>]
+      def parse_uri_into_args
+        parsed = URI.parse(params[:url])
+
+        URI::Generic.component.each_with_object({}) do |component, obj|
+          obj[component.to_sym] = parsed.send(component)
+        end
+      end
+
+      def solr_query_for_identifier
+        { defType: 'lucene', q: "{!terms f=identifier_ssim}url:#{http_uri}" }
+      end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ Rails.application.routes.draw do
   end
 
   get '/handle/*id', to: 'identifier#handle', as: 'handle'
-  get '/redirect', to: 'spot/redirect#show', constraints: ->(request) {
+  get '/redirect', to: 'spot/redirect#show', constraints: lambda { |request|
     qs = Rack::Utils.parse_nested_query(request.query_string)
     qs['url'] && qs['url'].match?(URI.regexp)
   }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'sidekiq/web'
 require 'sidekiq/cron/web'
+require 'rack'
 
 Rails.application.routes.draw do
   devise_for :users
@@ -64,4 +65,8 @@ Rails.application.routes.draw do
   end
 
   get '/handle/*id', to: 'identifier#handle', as: 'handle'
+  get '/redirect', to: 'spot/redirect#show', constraints: ->(request) {
+    qs = Rack::Utils.parse_nested_query(request.query_string)
+    qs['url'] && qs['url'].match?(URI.regexp)
+  }
 end

--- a/spec/controllers/spot/redirect_controller_spec.rb
+++ b/spec/controllers/spot/redirect_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+RSpec.describe Spot::RedirectController do
+  routes { Rails.application.routes }
+
+  describe '#show' do
+    subject { get :show, params: { url: url } }
+
+    context 'when a matching URL exists' do
+      let(:url) { 'http://cool.example.com/path/to/item' }
+      let(:obj) { build(:publication, identifier: ["url:#{url}"]) }
+
+      before { obj.save! }
+
+      it { is_expected.to redirect_to hyrax_publication_path(obj.id) }
+    end
+
+    context 'when a matching url does not exist' do
+      let(:url) { 'http://nope.example.com/this/doesnt/exist' }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+  end
+end


### PR DESCRIPTION
expects a redirect rule from legacy platforms to send the full url to `/redirect?url=<full url>`

```
RewriteEngine on
RewriteRule ^collections\/[a-z0-9\-]+/[a-z0-9\-]+ https://ldr.lafayette.edu/redirect?url=http://digital.lafayette.edu%{REQUEST_URI} [L,QSA]
```

an item that contains an `:identifier` value of `url:<full url>` will match + we'll redirect to that item

closes #20 