### PR TITLE
ui updates

### DIFF
--- a/app/assets/stylesheets/spot.scss
+++ b/app/assets/stylesheets/spot.scss
@@ -44,6 +44,24 @@
   }
 }
 
+// collection overrides
+.hyc-banner {
+  min-height: 200px;
+
+  .hyc-title {
+    background-color: $red-light;
+    border-bottom-left-radius: inherit;
+    border-top-right-radius: inherit;
+    bottom: 0;
+    position: absolute;
+  }
+}
+
+// give some breathing room to collection items w/ thumbnails in search results
+.search-result-wrapper {
+  padding-bottom: 1rem;
+}
+
 .site-footer {
   background-color: $tan-light;
   height: 20rem;

--- a/app/assets/stylesheets/spot/_navbar.scss
+++ b/app/assets/stylesheets/spot/_navbar.scss
@@ -4,14 +4,6 @@
   background-color: $red-light;
   border-bottom: 0;
 
-  #catalog-search-form { // scss-lint:disable IdSelector
-    margin-bottom: 0;
-
-    .input-group {
-      margin-bottom: 0;
-    }
-  }
-
   @media(min-width: 768px) {
     #search-field-header { // scss-lint:disable IdSelector
       width: 50rem;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   include Hyrax::Controller
   include Hyrax::ThemedLayoutController
 
-  layout 'hyrax'
+  with_themed_layout '1_column'
 
   before_action :log_in_as_dev_user!
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -228,11 +228,16 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     # label is key, solr field is value
-    config.add_sort_field 'score desc, system_create_dtsi desc', label: :'blacklight.search.fields.sort.relevance'
-    config.add_sort_field 'date_issued_sort_dtsi asc', label: :'blacklight.search.fields.sort.date_issued.asc'
-    config.add_sort_field 'date_issued_sort_dtsi desc', label: :'blacklight.search.fields.sort.date_issued.desc'
-    config.add_sort_field 'system_create_dtsi asc', label: :'blacklight.search.fields.sort.date_added.asc'
-    config.add_sort_field 'system_create_dtsi desc', label: :'blacklight.search.fields.sort.date_added.desc'
+    #
+    # @note: not optimal, but we're using the label text here, rather than locales
+    # because the sort dropdown that appears on collection#show views doesn't run
+    # the labels through +I18n.t+ first, displaying only the symbolized translation
+    # keys we're sending here.
+    config.add_sort_field 'score desc, system_create_dtsi desc', label: "Relevance"
+    config.add_sort_field 'date_issued_sort_dtsi asc', label: "Date Added \u25B2"
+    config.add_sort_field 'date_issued_sort_dtsi desc', label: "Date Added \u25BC"
+    config.add_sort_field 'system_create_dtsi asc', label: "Issue Date \u25B2"
+    config.add_sort_field 'system_create_dtsi desc', label: "Issue Date \u25BC"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 module ApplicationHelper
+  delegate :advanced_search_path, to: :blacklight_advanced_search_engine
+
   # @return [String]
   def browse_collections_url
     'https://dss.lafayette.edu/collections'

--- a/app/helpers/spot/collection_helper.rb
+++ b/app/helpers/spot/collection_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module Spot
+  module CollectionHelper
+    # Responsible for generating the text that preceeds a collection's
+    # related_resource URLs.
+    #
+    # @param [Hyrax::CollectionPresenter] presenter
+    # @return [String]
+    def render_related_resource_language(presenter)
+      return nil if presenter.related_resource.empty?
+
+      is_multiple = presenter.related_resource.count > 1
+      translation_key = "spot.collection.show.related_resource_#{is_multiple ? 'multiple' : 'single'}"
+
+      links = presenter.related_resource.map { |url| link_to(url, url, target: '_blank').html_safe }
+      t(translation_key, link_html: links.to_sentence).html_safe
+    end
+  end
+end

--- a/app/helpers/spot/facet_helper.rb
+++ b/app/helpers/spot/facet_helper.rb
@@ -38,5 +38,18 @@ module Spot
     def general_facet_names
       facet_field_names - admin_facet_names
     end
+
+    # @return [true, false]
+    def general_facets?
+      has_facet_values?(general_facet_names)
+    end
+
+    # @return [true, false]
+    def admin_facets?
+      return false unless current_user.admin?
+      return false if admin_facet_names.empty?
+
+      facets_from_request(admin_facet_names).any? { |facet| should_render_facet?(facet) }
+    end
   end
 end

--- a/app/helpers/spot/facet_helper.rb
+++ b/app/helpers/spot/facet_helper.rb
@@ -46,7 +46,7 @@ module Spot
 
     # @return [true, false]
     def admin_facets?
-      return false unless current_user.admin?
+      return false unless current_user&.admin?
       return false if admin_facet_names.empty?
 
       facets_from_request(admin_facet_names).any? { |facet| should_render_facet?(facet) }

--- a/app/models/concerns/spot/solr_document_attributes.rb
+++ b/app/models/concerns/spot/solr_document_attributes.rb
@@ -23,6 +23,7 @@ module Spot
       attribute :academic_department,    ::Blacklight::Types::Array, 'academic_department_tesim'
       attribute :admin_set,              ::Blacklight::Types::String, 'admin_set_tesim'
       attribute :bibliographic_citation, ::Blacklight::Types::Array, 'bibliographic_citation_tesim'
+      attribute :collection_slug,        ::Blacklight::Types::String, 'collection_slug_ssi'
       attribute :contributor,            ::Blacklight::Types::Array, 'contributor_tesim'
       attribute :date_available,         ::Blacklight::Types::Array, 'date_available_ssim'
       attribute :date_modified,          ::Blacklight::Types::Date, 'date_modified_dtsi'

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -34,7 +34,7 @@ class SolrDocument
   #
   # @return [String]
   def to_param
-    return super unless collection? && collection_slug.present?
-    collection_slug
+    return collection_slug if collection? && collection_slug.present?
+    super
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -34,7 +34,7 @@ class SolrDocument
   #
   # @return [String]
   def to_param
-    return super unless collection? && (slug = identifier.find { |id| id.start_with? 'slug:' })
-    Spot::Identifier.from_string(slug).value
+    return super unless collection? && collection_slug.present?
+    collection_slug
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -28,4 +28,13 @@ class SolrDocument
 
   # Do content negotiation for AF models.
   use_extension(Hydra::ContentNegotiation)
+
+  # Overrides +Hyrax::SolrDocumentBehavior#to_param+ by preferring collection slugs
+  # (where present).
+  #
+  # @return [String]
+  def to_param
+    return super unless collection? && (slug = identifier.find { |id| id.start_with? 'slug:' })
+    Spot::Identifier.from_string(slug).value
+  end
 end

--- a/app/presenters/spot/collection_presenter.rb
+++ b/app/presenters/spot/collection_presenter.rb
@@ -4,8 +4,9 @@
 module Spot
   class CollectionPresenter < Hyrax::CollectionPresenter
     include ActionView::Helpers::AssetUrlHelper
+    include PresentsAttributes
 
-    delegate :abstract, :related_resource, to: :solr_document
+    delegate :abstract, :permalink, :related_resource, to: :solr_document
 
     # Presenter fields displayed on the #show sidebar (on the right).
     # Modify this to change what's displayed + the order.
@@ -17,7 +18,8 @@ module Spot
         :related_resource,
         :location,
         :sponsor,
-        :modified_date
+        :modified_date,
+        :permalink
       ]
     end
 

--- a/app/presenters/spot/collection_presenter.rb
+++ b/app/presenters/spot/collection_presenter.rb
@@ -15,7 +15,6 @@ module Spot
     def self.terms
       [
         :total_items,
-        :related_resource,
         :location,
         :sponsor,
         :modified_date,

--- a/app/presenters/spot/collection_presenter.rb
+++ b/app/presenters/spot/collection_presenter.rb
@@ -39,8 +39,7 @@ module Spot
 
     # @return [true,false]
     def featured?
-      @featured = FeaturedCollection.where(collection_id: solr_document.to_param).exists? if @featured.nil?
-      @featured
+      FeaturedCollection.where(collection_id: solr_document.to_param).exists?
     end
 
     # Is the document's visibility public?

--- a/app/presenters/spot/collection_presenter.rb
+++ b/app/presenters/spot/collection_presenter.rb
@@ -39,7 +39,7 @@ module Spot
 
     # @return [true,false]
     def featured?
-      @featured = FeaturedCollection.where(collection_id: solr_document.id).exists? if @featured.nil?
+      @featured = FeaturedCollection.where(collection_id: solr_document.to_param).exists? if @featured.nil?
       @featured
     end
 

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -1,0 +1,18 @@
+<nav class="navbar navbar-default navbar-static-top" role="navigation">
+  <div class="container-fluid">
+    <div class="row">
+      <ul class="nav navbar-nav col-sm-5">
+        <li <%= 'class="active"' if current_page?(hyrax.about_path) %>>
+          <%= link_to t(:'hyrax.controls.about'), hyrax.about_path, aria: current_page?(hyrax.about_path) ? {current: 'page'} : nil %></li>
+        <li <%= 'class="active"' if current_page?(hyrax.help_path) %>>
+          <%= link_to t(:'hyrax.controls.help'), hyrax.help_path, aria: current_page?(hyrax.help_path) ? {current: 'page'} : nil %></li>
+        <li <%= 'class="active"' if current_page?(hyrax.contact_path) %>>
+          <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path, aria: current_page?(hyrax.contact_path) ? {current: 'page'} : nil %></li>
+      </ul><!-- /.nav -->
+
+      <div class="searchbar-right navbar-right col-sm-7">
+        <%= render partial: 'catalog/search_form' %>
+      </div>
+    </div>
+  </div>
+</nav><!-- /.navbar -->

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -8,6 +8,8 @@
           <%= link_to t(:'hyrax.controls.help'), hyrax.help_path, aria: current_page?(hyrax.help_path) ? {current: 'page'} : nil %></li>
         <li <%= 'class="active"' if current_page?(hyrax.contact_path) %>>
           <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path, aria: current_page?(hyrax.contact_path) ? {current: 'page'} : nil %></li>
+        <li <%= 'class="active"' if current_page?(advanced_search_path) %>>
+          <%= link_to t(:'spot.controls.advanced_search'), advanced_search_path, aria: current_page?(advanced_search_path) ? {current: 'page'} : nil %></li>
       </ul><!-- /.nav -->
 
       <div class="searchbar-right navbar-right col-sm-7">

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -13,43 +13,6 @@
       </div>
 
       <div class="collapse navbar-collapse" id="top-navbar-collapse">
-        <%= form_tag search_form_action,
-                     method: :get,
-                     id: 'catalog-search-form',
-                     class: 'navbar-form navbar-left',
-                     role: 'search' do %>
-
-          <% params_to_skip = %i[q search_field qt page utf8] %>
-          <% fields = search_state.params_for_search.except(*params_to_skip) %>
-          <%= render_hash_as_hidden_fields fields %>
-
-          <input type="hidden" name="search_field" value="all_fields" />
-
-          <div class="input-group">
-            <%= text_field_tag :q,
-                               current_search_parameters,
-                               class: 'form-control',
-                               id: 'search-field-header',
-                               placeholder: t('spot.masthead.search_placeholder') %>
-            <span class="input-group-btn">
-              <button type="submit" class="btn btn-default">
-                <span class="glyphicon glyphicon-search"></span>
-                Go
-              </button>
-            </span>
-          </div>
-        <% end %>
-
-        <ul class="nav navbar-nav">
-          <%#
-            TODO: i couldn't get +advanced_search_path+ to work (was just getting 'undefined
-                  method' errors), so this is unfortunately hardcoded. let's not.
-          %>
-          <li>
-            <%= link_to t('spot.masthead.advanced_search'), '/advanced' %>
-          </li>
-        </ul>
-
         <%= render '/user_util_links' %>
       </div>
     </div>

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -1,5 +1,5 @@
 <% # main container for facets/limits menu -%>
-<% if has_facet_values? %>
+<% if general_facets? %>
 <div id="facets" class="facets sidenav">
 
   <div class="top-panel-heading panel-heading">
@@ -22,7 +22,7 @@
 <% end %>
 
 <% # display admin facets if the user is an admin + we have some configured %>
-<% if current_user&.admin? && !admin_facet_names.empty? %>
+<% if admin_facets? %>
 <div id="admin-facets" class="facets sidenav">
   <div class="top-panel-heading panel-heading">
     <button type="button" class="facets-toggle" data-toggle="collapse" data-target="#facet-panel-collapse">

--- a/app/views/catalog/_index_list_collection.html.erb
+++ b/app/views/catalog/_index_list_collection.html.erb
@@ -4,6 +4,15 @@
   <% collection_presenter.abstract.each do |abstract| %>
   <p><%= abstract %></p>
   <% end %>
+
+  <% if collection_presenter.permalink.present? %>
+  <div class="metadata">
+    <dl class="dl-horizontal">
+      <dd><%= t('blacklight.search.terms.permalink') %></dd>
+      <dt><%= collection_presenter.permalink %></dt>
+    </dl>
+  </div>
+  <% end %>
 </div>
 
 <div class="col-md-<%= col_count.zero? ? '2' : '4' %>">

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,24 +1,21 @@
-<%# search form duplicated from hyrax/catalog/_search_form.html.erb but removes the
-    'search my collections/works' dropdown and adds a 'search field' dropdown %>
-<%= form_tag search_form_action,
-             method: :get,
-             id: 'catalog-search-form',
-             class: 'form-inline search-form',
-             role: 'search' do %>
+<%= form_tag search_form_action, method: :get, class: "form-horizontal search-form", id: "search-form-header", role: "search" do %>
+  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+  <%= hidden_field_tag :search_field, 'all_fields' %>
+  <div class="form-group">
 
-  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q,
-                                                                         :search_field,
-                                                                         :qt,
-                                                                         :page,
-                                                                         :utf8)) %>
-  <input type="hidden" name="search_field" value="all_fields" />
-  <div class="input-group col-sm-12">
-    <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
+    <label class="control-label col-sm-3" for="search-field-header">
+      <%= t("hyrax.search.form.q.label", application_name: application_name) %>
+    </label>
 
-    <div class="input-group-btn">
-      <button type="submit" class="btn btn-primary" id="search-submit-header">
-        <%= t('hyrax.search.button.html') %>
-      </button>
-    </div><!-- /.input-group-btn -->
-  </div><!-- /.input-group -->
+    <div class="input-group">
+      <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
+
+      <div class="input-group-btn">
+        <button type="submit" class="btn btn-primary" id="search-submit-header">
+          <%= t('hyrax.search.button.html') %>
+        </button>
+      </div><!-- /.input-group-btn -->
+    </div><!-- /.input-group -->
+
+  </div><!-- /.form-group -->
 <% end %>

--- a/app/views/hyrax/collections/_collection_description.html.erb
+++ b/app/views/hyrax/collections/_collection_description.html.erb
@@ -1,6 +1,6 @@
 <% if presenter.description.empty? %>
   <% presenter.abstract.each do |abstract| %>
-    <%= simple_format(auto_link(abstract)) %>
+    <%= simple_format(auto_link(abstract), class: 'lead') %>
   <% end %>
 <% else %>
   <% presenter.description.each do |description| %>

--- a/app/views/hyrax/collections/_collection_description.html.erb
+++ b/app/views/hyrax/collections/_collection_description.html.erb
@@ -1,9 +1,11 @@
-<% if presenter.description.empty? %>
-  <% presenter.abstract.each do |abstract| %>
-    <%= simple_format(auto_link(abstract), class: 'lead') %>
-  <% end %>
-<% else %>
-  <% presenter.description.each do |description| %>
-    <%= simple_format(auto_link(description)) %>
-  <% end %>
+<% presenter.abstract.each do |abstract| %>
+  <%= simple_format(auto_link(abstract), class: 'lead') %>
+<% end %>
+
+<% presenter.description.each do |description| %>
+  <%= simple_format(auto_link(description)) %>
+<% end %>
+
+<% unless presenter.related_resource.empty? %>
+  <p><%= render_related_resource_language(presenter) %></p>
 <% end %>

--- a/app/views/hyrax/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/collections/_show_descriptions.html.erb
@@ -1,3 +1,4 @@
+<%# controls the display of the metadata table that is part of the collection#show view %>
 <h2><%= t('hyrax.dashboard.collections.show.metadata_header') %></h2>
 <div class="panel panel-default">
   <table class="table table-condensed collection-show metadata-table">

--- a/app/views/hyrax/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/collections/_show_descriptions.html.erb
@@ -1,0 +1,10 @@
+<h2><%= t('hyrax.dashboard.collections.show.metadata_header') %></h2>
+<div class="panel panel-default">
+  <table class="table table-condensed collection-show metadata-table">
+    <tbody>
+      <% presenter.terms_with_values.each do |term| %>
+        <%= presenter.attribute_to_html(term.to_sym) %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -3,31 +3,16 @@
   <div class="row hyc-header">
     <div class="col-md-12">
 
-      <% unless @presenter.banner_file.blank? %>
-          <header class="hyc-banner" style="background-image:url(<%= @presenter.banner_file %>)">
-      <% else %>
-          <header class="hyc-banner" style="background-image:url(<%= image_path('default-collection-background.jpg') %>)">
-      <% end %>
+    <% unless @presenter.banner_file.blank? %>
+      <header class="hyc-banner" style="background-image:url(<%= @presenter.banner_file %>)">
+    <% else %>
+      <header class="hyc-banner" style="background-image:url(<%= image_path('default-collection-background.jpg') %>)">
+    <% end %>
 
-      <div class="hyc-title">
-        <h1><%= @presenter.title.first %></h1>
-        <%= @presenter.permission_badge unless @presenter.public? %>
-      </div>
-
-      <% unless @presenter.logo_record.blank? %>
-          <div class="hyc-logos">
-            <% @presenter.logo_record.each_with_index  do |lr, i| %>
-
-                <% if lr[:linkurl].blank? %>
-                    <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" />
-                <% else %>
-                    <a href="<%= lr[:linkurl] %>">
-                      <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" />
-                    </a>
-                <% end %>
-            <% end %>
-          </div>
-      <% end %>
+        <div class="hyc-title">
+          <h1><%= @presenter.title.first %></h1>
+          <%= @presenter.permission_badge unless @presenter.public? %>
+        </div>
       </header>
     </div>
 
@@ -37,7 +22,7 @@
   </div>
 
   <div class="row hyc-body">
-    <div class="col-md-8 hyc-description">
+    <div class="col-md-10 hyc-description">
       <%= render 'collection_description', presenter: @presenter %>
 
       <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
@@ -51,13 +36,24 @@
           </div>
       <% end %>
 
-    </div>
-    <div class="col-md-4 hyc-metadata">
       <% unless has_collection_search_parameters? %>
-          <h2><%= t('hyrax.dashboard.collections.show.metadata_header') %></h2>
-          <%= render 'show_descriptions' %>
+        <div class="collection-metadata">
+          <%= render 'show_descriptions', presenter: @presenter %>
+        </div>
       <% end %>
     </div>
+
+    <% unless @presenter.logo_record.blank? %>
+    <div class="col-md-2">
+      <% logo = @presenter.logo_record.first %>
+      <% image_html = image_tag(logo[:file_location], class: 'img-responsive', alt: logo[:alttext]) %>
+      <% if logo[:linkurl].present? %>
+        <%= link_to(logo[:linkurl]) { image_html } %>
+      <% else %>
+        <%= image_html %>
+      <% end %>
+      </div>
+    <% end %>
   </div>
 
   <!-- Search results label -->

--- a/app/views/layouts/hyrax/1_column.html.erb
+++ b/app/views/layouts/hyrax/1_column.html.erb
@@ -1,5 +1,0 @@
-<%#
-  works_controller_behavior will render this on views that aren't the dashboard,
-  so we'll just set it to render the base layout without the navbar
-%>
-<%= render template: 'layouts/hyrax' %>

--- a/app/views/spot/homepage/_featured_collection_item.html.erb
+++ b/app/views/spot/homepage/_featured_collection_item.html.erb
@@ -12,17 +12,6 @@
       <p><%= collection.abstract.first %></p>
       <% end %>
       <%= link_to t('.collection.view'), [hyrax, collection], class: 'btn btn-primary' %>
-
-      <%#
-        TODO: this is a no-op at the moment. we may want to include a metadata property
-              that provides a URL to learn more about the collection
-      %>
-      <% if collection.related_resource.present? %>
-        <%= link_to t('.collection.learn_more'),
-                    collection.related_resource.first,
-                    class: 'btn btn-info',
-                    target: '_blank' %>
-      <% end %>
     </div>
   </div>
 </div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -44,14 +44,4 @@ en:
         visibility: Visibility
         years_encompassed: Year
 
-        search:
-          all_fields: All fields
-
-        sort:
-          date_added:
-            asc: "Date Added \u25B2"
-            desc: "Date Added \u25BC"
-          date_issued:
-            asc: "Issue Date \u25B2"
-            desc: "Issue Date \u25BC"
-          relevance: Relevance
+        all_fields: All fields

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -16,6 +16,9 @@ en:
       default_title: User Collection
 
     dashboard:
+      collections:
+        show:
+          metadata_header: Details
       my:
         heading:
           collection_type: Collection Type

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -21,6 +21,10 @@ en:
           collection_type: Collection Type
           visibility: Visibility
 
+    footer:
+      copyright_html: "<strong>Copyright &copy; 2017 Samvera</strong> Licensed under the Apache License, Version 2.0"
+      service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
+
     directory:
       suffix:               "@example.org"
 
@@ -34,6 +38,7 @@ en:
     product_name: Lafayette Digital Repository
     product_twitter_handle: "@LafLib"
 
-    footer:
-      copyright_html: "<strong>Copyright &copy; 2017 Samvera</strong> Licensed under the Apache License, Version 2.0"
-      service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
+    search:
+      form:
+        q:
+          label: Search LDR

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -16,12 +16,16 @@ en:
       index:
         page_title: 'Search Results // %{name}'
 
+    controls:
+      advanced_search: Advanced Search
+
     dashboard:
       fixity:
         frequency: Checks are run every Monday at midnight.
         heading: The most recent round of fixity checks found %{errors}.
         sidebar: Fixity Checks
         title: Fixity Checks
+
       status:
         sidebar: System Status
         title: System Status

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -16,6 +16,11 @@ en:
       index:
         page_title: 'Search Results // %{name}'
 
+    collection:
+      show:
+        related_resource_single: "To learn more about this collection, visit %{link_html}."
+        related_resource_multiple: "To learn more about this collection, visit the following: %{link_html}."
+
     controls:
       advanced_search: Advanced Search
 

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe SolrDocument do
       let(:base_metadata) { { 'id' => 'abc123', 'has_model_ssim' => 'Collection' } }
 
       context 'when the collection has a slug' do
-        let(:metadata) { base_metadata.merge('identifier_ssim' => ['slug:a-cool-collection']) }
+        let(:metadata) { base_metadata.merge('collection_slug_ssi' => 'a-cool-collection') }
 
         it { is_expected.to eq 'a-cool-collection' }
       end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -67,4 +67,30 @@ RSpec.describe SolrDocument do
       it { is_expected.to eq expected }
     end
   end
+
+  describe '#to_param' do
+    subject { document.to_param }
+
+    context 'when the item is a collection' do
+      let(:base_metadata) { { 'id' => 'abc123', 'has_model_ssim' => 'Collection' } }
+
+      context 'when the collection has a slug' do
+        let(:metadata) { base_metadata.merge('identifier_ssim' => ['slug:a-cool-collection']) }
+
+        it { is_expected.to eq 'a-cool-collection' }
+      end
+
+      context 'when the collection does not have a slug' do
+        let(:metadata) { base_metadata }
+
+        it { is_expected.to eq 'abc123' }
+      end
+    end
+
+    context 'default behavior' do
+      let(:metadata) { { 'id' => 'abc123', 'has_model_ssim' => 'Publication' } }
+
+      it { is_expected.to eq 'abc123' }
+    end
+  end
 end

--- a/spec/presenters/spot/collection_presenter_spec.rb
+++ b/spec/presenters/spot/collection_presenter_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Spot::CollectionPresenter do
     {
       id: 'abc123',
       title_tesim: ['Cool Collection'],
-      read_access_group_ssim: ['public']
+      read_access_group_ssim: ['public'],
+      has_model_ssim: 'Collection'
     }
   end
   let(:admin_user) { create(:admin_user) }


### PR DESCRIPTION
~i kinda fast-tracked things on the view front on #273 to focus on getting collection-slugs out the door. this'll be more user-interface-focused updates~

expanding this to include some of the UI odds + ends that were out of the collections scope.

- moves collection related_resource to their own text block
- updates `SolrDocument#to_param` to prefer slugs for Collections (when they exist)
- adds the second navbar (`1_column` layout) back
- only display the admin facet block when admin facets exist (previously, the header was just floating there when no facets were available)

## todo :bug:

- [x] clicking a link to a featured collection does a redirect dance and throws an unauthorized warning? (visiting the URL doesn't send a redirect? wtf)
- [x] `collection#show` sort-by dropdown is showing untranslated keys

------

closes #283