### PR TITLE
fix hyrax overrides once and for all

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
+#
+# Provides the configuration for our searches within Solr (via Blacklight).
+#
+# @see https://github.com/projectblacklight/blacklight/wiki/Blacklight-configuration
 class CatalogController < ApplicationController
   include BlacklightRangeLimit::ControllerOverride
   include BlacklightAdvancedSearch::Controller
@@ -36,64 +40,75 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
+    #
+    # @note: when defining a field (facet, index, show, search), define the
+    #        +:label+ option as a Symbol that refers to the field _without_
+    #        the "solr jargon" (ex. "_tesim", "_ssim", etc) suffix. it _needs_
+    #        to be a Symbol in order for +I18n.translate+ to use it as
+    #        a fall-back when the lookup with the "solr jargon" ultimately fails.
+    #        this will save us from having to provide multiple locale definitions
+    #        for each attribute.
+    #
+    #        @example
+    #          config.add_index_field('keyword_ssim', label: :'blacklight.search.fields.keyword')
 
     # config.add_facet_field 'human_readable_type_sim', label: "Type", limit: 5
     config.add_facet_field 'member_of_collections_ssim',
-                           label: I18n.t('blacklight.search.fields.member_of_collection'),
+                           label: :'blacklight.search.fields.member_of_collection',
                            limit: 5
     config.add_facet_field 'resource_type_sim',
-                           label: I18n.t('blacklight.search.fields.resource_type'),
+                           label: :'blacklight.search.fields.resource_type',
                            limit: 5
     config.add_facet_field 'creator_sim',
-                           label: I18n.t('blacklight.search.fields.creator'),
+                           label: :'blacklight.search.fields.creator',
                            limit: 5
     config.add_facet_field 'publisher_sim',
-                           label: I18n.t('blacklight.search.fields.publisher'),
+                           label: :'blacklight.search.fields.publisher',
                            limit: 5
     config.add_facet_field 'organization_sim',
-                           label: I18n.t('blacklight.search.fields.organization'),
+                           label: :'blacklight.search.fields.organization',
                            limit: 5
     config.add_facet_field 'division_sim',
-                           label: I18n.t('blacklight.search.fields.division'),
+                           label: :'blacklight.search.fields.division',
                            limit: 5
     config.add_facet_field 'academic_department_sim',
-                           label: I18n.t('blacklight.search.fields.academic_department'),
+                           label: :'blacklight.search.fields.academic_department',
                            limit: 5
     config.add_facet_field 'subject_sim',
-                           label: I18n.t('blacklight.search.fields.subject'),
+                           label: :'blacklight.search.fields.subject',
                            limit: 5
     config.add_facet_field 'keyword_sim',
-                           label: I18n.t('blacklight.search.fields.keyword'),
+                           label: :'blacklight.search.fields.keyword',
                            limit: 5
     config.add_facet_field 'language_label_ssim',
-                           label: I18n.t('blacklight.search.fields.language'),
+                           label: :'blacklight.search.fields.language',
                            limit: 5
     config.add_facet_field 'location_label_ssim',
-                           label: I18n.t('blacklight.search.fields.location'),
+                           label: :'blacklight.search.fields.location',
                            limit: 5
     config.add_facet_field 'years_encompassed_iim',
                            include_in_advanced_search: false,
-                           label: I18n.t('blacklight.search.fields.years_encompassed'),
+                           label: :'blacklight.search.fields.years_encompassed',
                            range: true
 
     #
     # admin facets
     #
     config.add_facet_field 'visibility_ssi',
-                           label: I18n.t('blacklight.search.fields.visbility'),
+                           label: :'blacklight.search.fields.visibility',
                            limit: 5,
                            admin: true,
                            helper_method: :render_catalog_visibility_facet
     config.add_facet_field 'depositor_ssim',
-                           label: I18n.t('blacklight.search.fields.depositor'),
+                           label: :'blacklight.search.fields.depositor',
                            limit: 5,
                            admin: true
     config.add_facet_field 'proxy_depositor_ssim',
-                           label: I18n.t('blacklight.search.fields.proxy_depositor'),
+                           label: :'blacklight.search.fields.proxy_depositor',
                            limit: 5,
                            admin: true
     config.add_facet_field 'admin_set_sim',
-                           label: I18n.t('blacklight.search.fields.admin_set'),
+                           label: :'blacklight.search.fields.admin_set',
                            limit: 5,
                            admin: true
 
@@ -113,55 +128,55 @@ class CatalogController < ApplicationController
                            if: false
     config.add_index_field 'resource_type_ssim',
                            itemprop: 'resourceType',
-                           label: I18n.t('blacklight.search.fields.resource_type'),
+                           label: :'blacklight.search.fields.resource_type',
                            link_to_search: 'resource_type_ssim'
     config.add_index_field 'academic_department_tesim',
                            itemprop: 'department',
-                           label: I18n.t('blacklight.search.fields.academic_department'),
+                           label: :'blacklight.search.fields.academic_department',
                            link_to_search: 'academic_department_sim'
     config.add_index_field 'keyword_tesim',
                            itemprop: 'keywords',
-                           label: I18n.t('blacklight.search.fields.keyword'),
+                           label: :'blacklight.search.fields.keyword',
                            link_to_search: 'keyword_sim'
     config.add_index_field 'subject_tesim',
                            itemprop: 'about',
-                           label: I18n.t('blacklight.search.fields.subject'),
+                           label: :'blacklight.search.fields.subject',
                            link_to_search: 'subject_sim'
     config.add_index_field 'creator_tesim',
                            itemprop: 'creator',
-                           label: I18n.t('blacklight.search.fields.creator'),
+                           label: :'blacklight.search.fields.creator',
                            link_to_search: 'creator_sim'
     config.add_index_field 'contributor_tesim',
                            itemprop: 'contributor',
-                           label: I18n.t('blacklight.search.fields.contributor'),
+                           label: :'blacklight.search.fields.contributor',
                            link_to_search: 'contributor_sim'
     config.add_index_field 'publisher_tesim',
                            itemprop: 'publisher',
-                           label: I18n.t('blacklight.search.fields.publisher'),
+                           label: :'blacklight.search.fields.publisher',
                            link_to_search: 'publisher_sim'
     config.add_index_field 'language_label_ssim',
                            itemprop: 'inLanguage',
-                           label: I18n.t('blacklight.search.fields.language'),
+                           label: :'blacklight.search.fields.language',
                            link_to_search: 'language_sim'
     config.add_index_field 'date_issued_ssim',
-                           label: I18n.t('blacklight.search.fields.date_issued')
+                           label: :'blacklight.search.fields.date_issued'
     config.add_index_field 'rights_statement_tesim',
                            helper_method: :rights_statement_links,
-                           label: I18n.t('blacklight.search.fields.rights_statement')
+                           label: :'blacklight.search.fields.rights_statement'
     config.add_index_field 'license_tesim',
                            helper_method: :license_links,
-                           label: I18n.t('blacklight.search.fields.license')
+                           label: :'blacklight.search.fields.license'
     config.add_index_field 'embargo_release_date_dtsi',
-                           label: 'Embargo release date',
+                           label: :'blacklight.search.fields.embargo_release_date',
                            helper_method: :human_readable_date
     config.add_index_field 'lease_expiration_date_dtsi',
-                           label: 'Lease expiration date',
+                           label: :'blacklight.search.fields.lease_expiration_date',
                            helper_method: :human_readable_date
 
     #
     # search field configuration
     #
-    config.add_search_field('all_fields', label: I18n.t('blacklight.search.fields.all_fields')) do |field|
+    config.add_search_field('all_fields', label: :'blacklight.search.fields.all_fields') do |field|
       fields = %w[
         all_fields_search_timv
         english_language_date_teim
@@ -175,7 +190,7 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('title', label: I18n.t('blacklight.search.fields.title')) do |field|
+    config.add_search_field('title', label: :'blacklight.search.fields.title') do |field|
       fields = %w[
         title_tesim^2
         subtitle_tesim
@@ -188,7 +203,7 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('author', label: I18n.t('blacklight.search.fields.author')) do |field|
+    config.add_search_field('author', label: :'blacklight.search.fields.author') do |field|
       fields = %w[
         creator_tesim
         contributor_tesim
@@ -201,7 +216,7 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('subject', label: I18n.t('blacklight.search.fields.subject')) do |field|
+    config.add_search_field('subject', label: :'blacklight.search.fields.subject') do |field|
       field.solr_parameters = {
         qf: 'subject_tesim',
         pf: ''
@@ -213,11 +228,11 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     # label is key, solr field is value
-    config.add_sort_field 'score desc, system_create_dtsi desc', label: I18n.t('blacklight.sort.fields.relevance')
-    config.add_sort_field 'date_issued_sort_dtsi asc', label: I18n.t('blacklight.sort.fields.date_issued.asc')
-    config.add_sort_field 'date_issued_sort_dtsi desc', label: I18n.t('blacklight.sort.fields.date_issued.desc')
-    config.add_sort_field 'system_create_dtsi asc', label: I18n.t('blacklight.sort.fields.date_added.asc')
-    config.add_sort_field 'system_create_dtsi desc', label: I18n.t('blacklight.sort.fields.date_added.desc')
+    config.add_sort_field 'score desc, system_create_dtsi desc', label: :'blacklight.search.fields.sort.relevance'
+    config.add_sort_field 'date_issued_sort_dtsi asc', label: :'blacklight.search.fields.sort.date_issued.asc'
+    config.add_sort_field 'date_issued_sort_dtsi desc', label: :'blacklight.search.fields.sort.date_issued.desc'
+    config.add_sort_field 'system_create_dtsi asc', label: :'blacklight.search.fields.sort.date_added.asc'
+    config.add_sort_field 'system_create_dtsi desc', label: :'blacklight.search.fields.sort.date_added.desc'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/config/initializers/hyrax_overrides.rb
+++ b/config/initializers/hyrax_overrides.rb
@@ -1,35 +1,7 @@
 # frozen_string_literal: true
-#
-# This may not be the best way to approach overloads, but I was running
-# into issues with a +to_prepare+ block which changed these attributes
-# causing a lot of strange locale translation misses. I did _a lot_ of
-# poking around and I think I've got it nailed down.
-#
-# Providing a +to_prepare+ block to the Configuration class adds it to
-# an array of blocks called +.to_prepare_blocks+ which is what is iterated
-# through when loading (see: https://github.com/rails/rails/blob/v5.1.7/railties/lib/rails/railtie/configuration.rb#L77-L81
-# and https://github.com/rails/rails/blob/v5.1.7/railties/lib/rails/application/finisher.rb#L52-L56).
-# (note: the code changes in later rails versions, but the concept is the same).
-#
-# Something about setting one of these class attributes throws a wrench in
-# the i18n load path, or something. When they're out, no problem, but we
-# want them in. Finding the above code, it seems like what might be happening
-# is our +to_prepare+ block is coming before one that loads I18ns from the
-# Hyrax engine (or another dependency) and hecking up something.
-#
-# SO, what this does is:
-#   a) loads the overrides in a lambda
-#   b) calls that lambda in the +after_initialize+ block
-#   c) (when in development) adds the lambda to the _end_ of the
-#      +.to_prepare_blocks+ array, so that the next time the +to_prepare+
-#      blocks are called, it'll be the last one.
-#
-# It feels like overkill, but it's the only solution
-# that's consistently worked so far.
-#
-# Please change if you can figure it out!
+Rails.application.config.to_prepare do
+  ## Spot overrides Hyrax
 
-load_overrides = lambda do
   Hyrax::Dashboard::CollectionsController.presenter_class = Spot::CollectionPresenter
   Hyrax::Dashboard::CollectionsController.form_class = Spot::Forms::CollectionForm
 
@@ -58,13 +30,4 @@ load_overrides = lambda do
 
   # see above
   Hyrax::ContactFormController.class_eval { layout 'hyrax' }
-end
-
-Rails.application.config.after_initialize do
-  # load our overrides
-  load_overrides.call
-
-  # add the lambda to the blocks run by to_prepare
-  #   if we're in development mode
-  Rails.application.config.to_prepare_blocks << load_overrides if Rails.env.development?
 end

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -6,7 +6,6 @@ en:
           title: Admin Facets
       fields:
         academic_department: Academic Department
-        all_fields: All fields
         author: Author
         bibliographic_citation: Bibliographic Citation
         contributor: Contributor
@@ -19,12 +18,13 @@ en:
         depositor: Deposited by
         description: Description
         division: Division
+        embargo_release_date: Embargo Release Date
         file_format: File Format
         file_size: File Size
         keyword: Keyword
-        keyword_sim: Keyword
         language: Language
         language_label: Language
+        lease_expiration_date: Lease Expiration Date
         license: License
         local_identifier: Local Identifier
         location: Location
@@ -37,21 +37,21 @@ en:
         publisher: Publisher
         resource_type: Type
         rights_statement: Rights Statement
+        source: Source
         standard_identifier: Standard Identifier
         subject: Subject
         title: Title
+        visibility: Visibility
         years_encompassed: Year
 
-        facet:
-          resource_type_sim: Type
-          source_sim: Source
-          visibility_ssi: Visibility
-    sort:
-      fields:
-        date_added:
-          asc: "Date Added \u25B2"
-          desc: "Date Added \u25BC"
-        date_issued:
-          asc: "Issue Date \u25B2"
-          desc: "Issue Date \u25BC"
-        relevance: Relevance
+        search:
+          all_fields: All fields
+
+        sort:
+          date_added:
+            asc: "Date Added \u25B2"
+            desc: "Date Added \u25BC"
+          date_issued:
+            asc: "Issue Date \u25B2"
+            desc: "Issue Date \u25BC"
+          relevance: Relevance


### PR DESCRIPTION
this has hounded me for... a really long time.

![](https://media.giphy.com/media/hEwkspP1OllJK/giphy.gif)

(see 29f34823c, #214)

when we override some hyrax functionality, it was causing the CatalogController to load before all of the locales are loaded (we were using calls to `I18n.t` to provide labels to field configs) which resulted in facets, index fields, and search fields receiving 'translation missing' labels. this was only really happening in the development environment (where the code is reloaded on each request), but grew to be incredibly annoying as class_attributes would get reset to their Hyrax defaults + never go back.

the fix (🤞) is sort of a blacklight hack, but solves both this problem and the problem of having to provide the same value for multiple different keys (see [config/locales/blacklight.en.yml#L24-L25](https://github.com/LafayetteCollegeLibraries/spot/blob/358d8b6/config/locales/blacklight.en.yml#L24-L25) for an example of this). when blacklight renders a label (https://github.com/projectblacklight/blacklight/blob/v6.20.0/app/helpers/blacklight/configuration_helper_behavior.rb#L136-L152), it adds the value of `field.label` to the array of defaults passed to `I18n.translate`. when this value is a Symbol, `I18n.translate` will treat it as a key within a locale file.

since our [hyrax renderer remixes] are already searching for `blacklight.search.fields.${field}`, we'll provide this field and the `.translate` call should pick it up.

[hyrax renderer remixes]: https://github.com/LafayetteCollegeLibraries/spot/tree/2019.1-pre.5/app/renderers/spot/renderers