### PR TITLE
2019-1.pre-6

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,8 @@
 .git
+/log/*
+!/log/.keep
+/tmp/*
+!/tmp/.keep
+/coverage
+.byebug_history
+fits.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # changelog
 
-## Unreleased
+## [2019.1-pre.6] - 2019-10-01
+
+- add `/redirect?url=<digital.laf url>` routing for legacy URLs (#277)
+- the hyrax 2nd navbar has returned (#278)
+- improvements in collection-slug behavior (`SolrDocument#to_param` now checks if the item is a collection) (#278)
+- Collection views now display related_resource URLs below the abstract + description blocks
+- changes the download button on a work's show page to be for the primary object download (`/downloads/<work id>`) and moves the zip-export to the dropdown (#291)
+- adds several subcollections from dspace content (#292)
+
+fixes:
+
+- use the file_watcher in development that will work with docker
+- (collections_from_config) only update when a collection has changed (#276)
+- labels in catalog_controller.rb are now symbols, rather than calls to I18n.translate which were encountering issues with engine locales not being loaded when called (#285)
+
 
 ## [2019.1-pre.5] - 2019-09-16
 

--- a/app/assets/stylesheets/spot.scss
+++ b/app/assets/stylesheets/spot.scss
@@ -44,6 +44,24 @@
   }
 }
 
+// collection overrides
+.hyc-banner {
+  min-height: 200px;
+
+  .hyc-title {
+    background-color: $red-light;
+    border-bottom-left-radius: inherit;
+    border-top-right-radius: inherit;
+    bottom: 0;
+    position: absolute;
+  }
+}
+
+// give some breathing room to collection items w/ thumbnails in search results
+.search-result-wrapper {
+  padding-bottom: 1rem;
+}
+
 .site-footer {
   background-color: $tan-light;
   height: 20rem;

--- a/app/assets/stylesheets/spot/_navbar.scss
+++ b/app/assets/stylesheets/spot/_navbar.scss
@@ -4,14 +4,6 @@
   background-color: $red-light;
   border-bottom: 0;
 
-  #catalog-search-form { // scss-lint:disable IdSelector
-    margin-bottom: 0;
-
-    .input-group {
-      margin-bottom: 0;
-    }
-  }
-
   @media(min-width: 768px) {
     #search-field-header { // scss-lint:disable IdSelector
       width: 50rem;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   include Hyrax::Controller
   include Hyrax::ThemedLayoutController
 
-  layout 'hyrax'
+  with_themed_layout '1_column'
 
   before_action :log_in_as_dev_user!
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
+#
+# Provides the configuration for our searches within Solr (via Blacklight).
+#
+# @see https://github.com/projectblacklight/blacklight/wiki/Blacklight-configuration
 class CatalogController < ApplicationController
   include BlacklightRangeLimit::ControllerOverride
   include BlacklightAdvancedSearch::Controller
@@ -36,64 +40,75 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
+    #
+    # @note: when defining a field (facet, index, show, search), define the
+    #        +:label+ option as a Symbol that refers to the field _without_
+    #        the "solr jargon" (ex. "_tesim", "_ssim", etc) suffix. it _needs_
+    #        to be a Symbol in order for +I18n.translate+ to use it as
+    #        a fall-back when the lookup with the "solr jargon" ultimately fails.
+    #        this will save us from having to provide multiple locale definitions
+    #        for each attribute.
+    #
+    #        @example
+    #          config.add_index_field('keyword_ssim', label: :'blacklight.search.fields.keyword')
 
     # config.add_facet_field 'human_readable_type_sim', label: "Type", limit: 5
     config.add_facet_field 'member_of_collections_ssim',
-                           label: I18n.t('blacklight.search.fields.member_of_collection'),
+                           label: :'blacklight.search.fields.member_of_collection',
                            limit: 5
     config.add_facet_field 'resource_type_sim',
-                           label: I18n.t('blacklight.search.fields.resource_type'),
+                           label: :'blacklight.search.fields.resource_type',
                            limit: 5
     config.add_facet_field 'creator_sim',
-                           label: I18n.t('blacklight.search.fields.creator'),
+                           label: :'blacklight.search.fields.creator',
                            limit: 5
     config.add_facet_field 'publisher_sim',
-                           label: I18n.t('blacklight.search.fields.publisher'),
+                           label: :'blacklight.search.fields.publisher',
                            limit: 5
     config.add_facet_field 'organization_sim',
-                           label: I18n.t('blacklight.search.fields.organization'),
+                           label: :'blacklight.search.fields.organization',
                            limit: 5
     config.add_facet_field 'division_sim',
-                           label: I18n.t('blacklight.search.fields.division'),
+                           label: :'blacklight.search.fields.division',
                            limit: 5
     config.add_facet_field 'academic_department_sim',
-                           label: I18n.t('blacklight.search.fields.academic_department'),
+                           label: :'blacklight.search.fields.academic_department',
                            limit: 5
     config.add_facet_field 'subject_sim',
-                           label: I18n.t('blacklight.search.fields.subject'),
+                           label: :'blacklight.search.fields.subject',
                            limit: 5
     config.add_facet_field 'keyword_sim',
-                           label: I18n.t('blacklight.search.fields.keyword'),
+                           label: :'blacklight.search.fields.keyword',
                            limit: 5
     config.add_facet_field 'language_label_ssim',
-                           label: I18n.t('blacklight.search.fields.language'),
+                           label: :'blacklight.search.fields.language',
                            limit: 5
     config.add_facet_field 'location_label_ssim',
-                           label: I18n.t('blacklight.search.fields.location'),
+                           label: :'blacklight.search.fields.location',
                            limit: 5
     config.add_facet_field 'years_encompassed_iim',
                            include_in_advanced_search: false,
-                           label: I18n.t('blacklight.search.fields.years_encompassed'),
+                           label: :'blacklight.search.fields.years_encompassed',
                            range: true
 
     #
     # admin facets
     #
     config.add_facet_field 'visibility_ssi',
-                           label: I18n.t('blacklight.search.fields.visbility'),
+                           label: :'blacklight.search.fields.visibility',
                            limit: 5,
                            admin: true,
                            helper_method: :render_catalog_visibility_facet
     config.add_facet_field 'depositor_ssim',
-                           label: I18n.t('blacklight.search.fields.depositor'),
+                           label: :'blacklight.search.fields.depositor',
                            limit: 5,
                            admin: true
     config.add_facet_field 'proxy_depositor_ssim',
-                           label: I18n.t('blacklight.search.fields.proxy_depositor'),
+                           label: :'blacklight.search.fields.proxy_depositor',
                            limit: 5,
                            admin: true
     config.add_facet_field 'admin_set_sim',
-                           label: I18n.t('blacklight.search.fields.admin_set'),
+                           label: :'blacklight.search.fields.admin_set',
                            limit: 5,
                            admin: true
 
@@ -113,55 +128,55 @@ class CatalogController < ApplicationController
                            if: false
     config.add_index_field 'resource_type_ssim',
                            itemprop: 'resourceType',
-                           label: I18n.t('blacklight.search.fields.resource_type'),
+                           label: :'blacklight.search.fields.resource_type',
                            link_to_search: 'resource_type_ssim'
     config.add_index_field 'academic_department_tesim',
                            itemprop: 'department',
-                           label: I18n.t('blacklight.search.fields.academic_department'),
+                           label: :'blacklight.search.fields.academic_department',
                            link_to_search: 'academic_department_sim'
     config.add_index_field 'keyword_tesim',
                            itemprop: 'keywords',
-                           label: I18n.t('blacklight.search.fields.keyword'),
+                           label: :'blacklight.search.fields.keyword',
                            link_to_search: 'keyword_sim'
     config.add_index_field 'subject_tesim',
                            itemprop: 'about',
-                           label: I18n.t('blacklight.search.fields.subject'),
+                           label: :'blacklight.search.fields.subject',
                            link_to_search: 'subject_sim'
     config.add_index_field 'creator_tesim',
                            itemprop: 'creator',
-                           label: I18n.t('blacklight.search.fields.creator'),
+                           label: :'blacklight.search.fields.creator',
                            link_to_search: 'creator_sim'
     config.add_index_field 'contributor_tesim',
                            itemprop: 'contributor',
-                           label: I18n.t('blacklight.search.fields.contributor'),
+                           label: :'blacklight.search.fields.contributor',
                            link_to_search: 'contributor_sim'
     config.add_index_field 'publisher_tesim',
                            itemprop: 'publisher',
-                           label: I18n.t('blacklight.search.fields.publisher'),
+                           label: :'blacklight.search.fields.publisher',
                            link_to_search: 'publisher_sim'
     config.add_index_field 'language_label_ssim',
                            itemprop: 'inLanguage',
-                           label: I18n.t('blacklight.search.fields.language'),
+                           label: :'blacklight.search.fields.language',
                            link_to_search: 'language_sim'
     config.add_index_field 'date_issued_ssim',
-                           label: I18n.t('blacklight.search.fields.date_issued')
+                           label: :'blacklight.search.fields.date_issued'
     config.add_index_field 'rights_statement_tesim',
                            helper_method: :rights_statement_links,
-                           label: I18n.t('blacklight.search.fields.rights_statement')
+                           label: :'blacklight.search.fields.rights_statement'
     config.add_index_field 'license_tesim',
                            helper_method: :license_links,
-                           label: I18n.t('blacklight.search.fields.license')
+                           label: :'blacklight.search.fields.license'
     config.add_index_field 'embargo_release_date_dtsi',
-                           label: 'Embargo release date',
+                           label: :'blacklight.search.fields.embargo_release_date',
                            helper_method: :human_readable_date
     config.add_index_field 'lease_expiration_date_dtsi',
-                           label: 'Lease expiration date',
+                           label: :'blacklight.search.fields.lease_expiration_date',
                            helper_method: :human_readable_date
 
     #
     # search field configuration
     #
-    config.add_search_field('all_fields', label: I18n.t('blacklight.search.fields.all_fields')) do |field|
+    config.add_search_field('all_fields', label: :'blacklight.search.fields.all_fields') do |field|
       fields = %w[
         all_fields_search_timv
         english_language_date_teim
@@ -175,7 +190,7 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('title', label: I18n.t('blacklight.search.fields.title')) do |field|
+    config.add_search_field('title', label: :'blacklight.search.fields.title') do |field|
       fields = %w[
         title_tesim^2
         subtitle_tesim
@@ -188,7 +203,7 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('author', label: I18n.t('blacklight.search.fields.author')) do |field|
+    config.add_search_field('author', label: :'blacklight.search.fields.author') do |field|
       fields = %w[
         creator_tesim
         contributor_tesim
@@ -201,7 +216,7 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('subject', label: I18n.t('blacklight.search.fields.subject')) do |field|
+    config.add_search_field('subject', label: :'blacklight.search.fields.subject') do |field|
       field.solr_parameters = {
         qf: 'subject_tesim',
         pf: ''
@@ -213,11 +228,11 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     # label is key, solr field is value
-    config.add_sort_field 'score desc, system_create_dtsi desc', label: I18n.t('blacklight.sort.fields.relevance')
-    config.add_sort_field 'date_issued_sort_dtsi asc', label: I18n.t('blacklight.sort.fields.date_issued.asc')
-    config.add_sort_field 'date_issued_sort_dtsi desc', label: I18n.t('blacklight.sort.fields.date_issued.desc')
-    config.add_sort_field 'system_create_dtsi asc', label: I18n.t('blacklight.sort.fields.date_added.asc')
-    config.add_sort_field 'system_create_dtsi desc', label: I18n.t('blacklight.sort.fields.date_added.desc')
+    config.add_sort_field 'score desc, system_create_dtsi desc', label: :'blacklight.search.fields.sort.relevance'
+    config.add_sort_field 'date_issued_sort_dtsi asc', label: :'blacklight.search.fields.sort.date_issued.asc'
+    config.add_sort_field 'date_issued_sort_dtsi desc', label: :'blacklight.search.fields.sort.date_issued.desc'
+    config.add_sort_field 'system_create_dtsi asc', label: :'blacklight.search.fields.sort.date_added.asc'
+    config.add_sort_field 'system_create_dtsi desc', label: :'blacklight.search.fields.sort.date_added.desc'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -228,11 +228,16 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     # label is key, solr field is value
-    config.add_sort_field 'score desc, system_create_dtsi desc', label: :'blacklight.search.fields.sort.relevance'
-    config.add_sort_field 'date_issued_sort_dtsi asc', label: :'blacklight.search.fields.sort.date_issued.asc'
-    config.add_sort_field 'date_issued_sort_dtsi desc', label: :'blacklight.search.fields.sort.date_issued.desc'
-    config.add_sort_field 'system_create_dtsi asc', label: :'blacklight.search.fields.sort.date_added.asc'
-    config.add_sort_field 'system_create_dtsi desc', label: :'blacklight.search.fields.sort.date_added.desc'
+    #
+    # @note: not optimal, but we're using the label text here, rather than locales
+    # because the sort dropdown that appears on collection#show views doesn't run
+    # the labels through +I18n.t+ first, displaying only the symbolized translation
+    # keys we're sending here.
+    config.add_sort_field 'score desc, system_create_dtsi desc', label: "Relevance"
+    config.add_sort_field 'date_issued_sort_dtsi asc', label: "Date Added \u25B2"
+    config.add_sort_field 'date_issued_sort_dtsi desc', label: "Date Added \u25BC"
+    config.add_sort_field 'system_create_dtsi asc', label: "Issue Date \u25B2"
+    config.add_sort_field 'system_create_dtsi desc', label: "Issue Date \u25BC"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/controllers/spot/redirect_controller.rb
+++ b/app/controllers/spot/redirect_controller.rb
@@ -8,8 +8,9 @@ module Spot
   # a +url:+ prefix. Redirect rules should be implemented on legacy services
   # to send the entire URL as a parameter value.
   #
-  # @example Apache redirect rules
-  #   RewriteRule ^/collections/.*$ https://ldr.lafayette.edu/redirect?url=http://%{HTTP_HOST}%{REQUEST_URI} [L,QSA]
+  # @example httpd rewrite rules
+  #   RewriteEngine on
+  #   RewriteRule ^collections\/[a-z0-9\-]+/[a-z0-9\-]+ https://ldr.lafayette.edu/redirect?url=http://digital.lafayette.edu%{REQUEST_URI} [L,QSA]
   #
   # @todo This should be abstracted out, as the {IdentifierController}
   #       (soon to be HandleController) follows (almost) the same  logic.

--- a/app/controllers/spot/redirect_controller.rb
+++ b/app/controllers/spot/redirect_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require 'uri'
+
+module Spot
+  # Controller responsible for redirecting requests from legacy services
+  # (in particular, our Islandora instance) to their migrated counterparts.
+  # For items that have a legacy URL, an identifier value is added with
+  # a +url:+ prefix. Redirect rules should be implemented on legacy services
+  # to send the entire URL as a parameter value.
+  #
+  # @example Apache redirect rules
+  #   RewriteRule ^/collections/.*$ https://ldr.lafayette.edu/redirect?url=http://%{HTTP_HOST}%{REQUEST_URI} [L,QSA]
+  #
+  # @todo This should be abstracted out, as the {IdentifierController}
+  #       (soon to be HandleController) follows (almost) the same  logic.
+  class RedirectController < ApplicationController
+    include ::Hydra::Catalog
+
+    def show
+      # all that we need for this controller are the object's ID + Hydra Model
+      query = solr_query_for_identifier.merge(fl: ['id', 'has_model_ssim'])
+      result, _documents = repository.search(query)
+
+      raise Blacklight::Exceptions::RecordNotFound if result.response['numFound'].zero?
+
+      document = result.response['docs'].first
+      controller = document['has_model_ssim'].first.downcase.pluralize
+
+      redirect_to controller: "hyrax/#{controller}", action: 'show', id: document['id']
+    end
+
+    private
+
+      # Converts the passed URI into an HTTP URI
+      # @return [String]
+      def http_uri
+        URI::HTTP.build(parse_uri_into_args).to_s
+      end
+
+      # Breaks a URI string into a Hash of URI component parts
+      #
+      # @param [String] uri_string Any kind of URI that works with +URI.parse+
+      # @return [Hash<Symbol => String, nil>]
+      def parse_uri_into_args
+        parsed = URI.parse(params[:url])
+
+        URI::Generic.component.each_with_object({}) do |component, obj|
+          obj[component.to_sym] = parsed.send(component)
+        end
+      end
+
+      def solr_query_for_identifier
+        { defType: 'lucene', q: "{!terms f=identifier_ssim}url:#{http_uri}" }
+      end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 module ApplicationHelper
+  delegate :advanced_search_path, to: :blacklight_advanced_search_engine
+
   # @return [String]
   def browse_collections_url
     'https://dss.lafayette.edu/collections'

--- a/app/helpers/spot/collection_helper.rb
+++ b/app/helpers/spot/collection_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module Spot
+  module CollectionHelper
+    # Responsible for generating the text that preceeds a collection's
+    # related_resource URLs.
+    #
+    # @param [Hyrax::CollectionPresenter] presenter
+    # @return [String]
+    def render_related_resource_language(presenter)
+      return nil if presenter.related_resource.empty?
+
+      is_multiple = presenter.related_resource.count > 1
+      translation_key = "spot.collection.show.related_resource_#{is_multiple ? 'multiple' : 'single'}"
+
+      links = presenter.related_resource.map { |url| link_to(url, url, target: '_blank').html_safe }
+      t(translation_key, link_html: links.to_sentence).html_safe
+    end
+  end
+end

--- a/app/helpers/spot/facet_helper.rb
+++ b/app/helpers/spot/facet_helper.rb
@@ -38,5 +38,18 @@ module Spot
     def general_facet_names
       facet_field_names - admin_facet_names
     end
+
+    # @return [true, false]
+    def general_facets?
+      has_facet_values?(general_facet_names)
+    end
+
+    # @return [true, false]
+    def admin_facets?
+      return false unless current_user.admin?
+      return false if admin_facet_names.empty?
+
+      facets_from_request(admin_facet_names).any? { |facet| should_render_facet?(facet) }
+    end
   end
 end

--- a/app/helpers/spot/facet_helper.rb
+++ b/app/helpers/spot/facet_helper.rb
@@ -46,7 +46,7 @@ module Spot
 
     # @return [true, false]
     def admin_facets?
-      return false unless current_user.admin?
+      return false unless current_user&.admin?
       return false if admin_facet_names.empty?
 
       facets_from_request(admin_facet_names).any? { |facet| should_render_facet?(facet) }

--- a/app/models/concerns/spot/solr_document_attributes.rb
+++ b/app/models/concerns/spot/solr_document_attributes.rb
@@ -23,6 +23,7 @@ module Spot
       attribute :academic_department,    ::Blacklight::Types::Array, 'academic_department_tesim'
       attribute :admin_set,              ::Blacklight::Types::String, 'admin_set_tesim'
       attribute :bibliographic_citation, ::Blacklight::Types::Array, 'bibliographic_citation_tesim'
+      attribute :collection_slug,        ::Blacklight::Types::String, 'collection_slug_ssi'
       attribute :contributor,            ::Blacklight::Types::Array, 'contributor_tesim'
       attribute :date_available,         ::Blacklight::Types::Array, 'date_available_ssim'
       attribute :date_modified,          ::Blacklight::Types::Date, 'date_modified_dtsi'

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -34,7 +34,7 @@ class SolrDocument
   #
   # @return [String]
   def to_param
-    return super unless collection? && collection_slug.present?
-    collection_slug
+    return collection_slug if collection? && collection_slug.present?
+    super
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -34,7 +34,7 @@ class SolrDocument
   #
   # @return [String]
   def to_param
-    return super unless collection? && (slug = identifier.find { |id| id.start_with? 'slug:' })
-    Spot::Identifier.from_string(slug).value
+    return super unless collection? && collection_slug.present?
+    collection_slug
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -28,4 +28,13 @@ class SolrDocument
 
   # Do content negotiation for AF models.
   use_extension(Hydra::ContentNegotiation)
+
+  # Overrides +Hyrax::SolrDocumentBehavior#to_param+ by preferring collection slugs
+  # (where present).
+  #
+  # @return [String]
+  def to_param
+    return super unless collection? && (slug = identifier.find { |id| id.start_with? 'slug:' })
+    Spot::Identifier.from_string(slug).value
+  end
 end

--- a/app/presenters/hyrax/publication_presenter.rb
+++ b/app/presenters/hyrax/publication_presenter.rb
@@ -11,35 +11,16 @@ module Hyrax
              :source, :subject, :subtitle, :title_alternative,
              to: :solr_document
 
+    # @return [String]
+    def export_all_text
+      I18n.t("spot.work.export.download_work_and_metadata_#{multiple_members? ? 'multiple' : 'single'}")
+    end
+
     # Metadata formats we're able to export as.
     #
     # @return [Array<Symbol>]
     def export_formats
       %i[csv ttl nt jsonld]
-    end
-
-    # Overrides {Hyrax::WorkShowPresenter#page_title} by only using
-    # the work's title + our product name.
-    #
-    # @return [String]
-    def page_title
-      "#{title.first} // #{I18n.t('hyrax.product_name')}"
-    end
-
-    # For now, overriding the ability to feature individual works
-    # on the homepage. This should prevent the 'Feature'/'Unfeature'
-    # button from rendering on the work edit page.
-    #
-    # @return [false]
-    def work_featurable?
-      false
-    end
-
-    # Is the document's visibility public?
-    #
-    # @return [true, false]
-    def public?
-      solr_document.visibility == ::Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
 
     # Our document's identifiers mapped to Spot::Identifier objects
@@ -65,14 +46,43 @@ module Hyrax
       solr_document.location.zip(solr_document.location_label).reject(&:empty?)
     end
 
-    # @return [Array<Spot::Identifier>]
-    def standard_identifier
-      @standard_identifier ||= identifier.select(&:standard?)
+    # @return [true, false]
+    def multiple_members?
+      list_of_item_ids_to_display.count > 1
+    end
+
+    # Overrides {Hyrax::WorkShowPresenter#page_title} by only using
+    # the work's title + our product name.
+    #
+    # @return [String]
+    def page_title
+      "#{title.first} // #{I18n.t('hyrax.product_name')}"
+    end
+
+    # Is the document's visibility public?
+    #
+    # @return [true, false]
+    def public?
+      solr_document.visibility == ::Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
 
     # @return [Array<Array<String>>]
     def rights_statement_merged
       solr_document.rights_statement.zip(solr_document.rights_statement_label)
+    end
+
+    # @return [Array<Spot::Identifier>]
+    def standard_identifier
+      @standard_identifier ||= identifier.select(&:standard?)
+    end
+
+    # For now, overriding the ability to feature individual works
+    # on the homepage. This should prevent the 'Feature'/'Unfeature'
+    # button from rendering on the work edit page.
+    #
+    # @return [false]
+    def work_featurable?
+      false
     end
   end
 end

--- a/app/presenters/spot/collection_presenter.rb
+++ b/app/presenters/spot/collection_presenter.rb
@@ -4,8 +4,9 @@
 module Spot
   class CollectionPresenter < Hyrax::CollectionPresenter
     include ActionView::Helpers::AssetUrlHelper
+    include PresentsAttributes
 
-    delegate :abstract, :related_resource, to: :solr_document
+    delegate :abstract, :permalink, :related_resource, to: :solr_document
 
     # Presenter fields displayed on the #show sidebar (on the right).
     # Modify this to change what's displayed + the order.
@@ -17,7 +18,8 @@ module Spot
         :related_resource,
         :location,
         :sponsor,
-        :modified_date
+        :modified_date,
+        :permalink
       ]
     end
 

--- a/app/presenters/spot/collection_presenter.rb
+++ b/app/presenters/spot/collection_presenter.rb
@@ -15,7 +15,6 @@ module Spot
     def self.terms
       [
         :total_items,
-        :related_resource,
         :location,
         :sponsor,
         :modified_date,

--- a/app/presenters/spot/collection_presenter.rb
+++ b/app/presenters/spot/collection_presenter.rb
@@ -39,8 +39,7 @@ module Spot
 
     # @return [true,false]
     def featured?
-      @featured = FeaturedCollection.where(collection_id: solr_document.to_param).exists? if @featured.nil?
-      @featured
+      FeaturedCollection.where(collection_id: solr_document.to_param).exists?
     end
 
     # Is the document's visibility public?

--- a/app/presenters/spot/collection_presenter.rb
+++ b/app/presenters/spot/collection_presenter.rb
@@ -39,7 +39,7 @@ module Spot
 
     # @return [true,false]
     def featured?
-      @featured = FeaturedCollection.where(collection_id: solr_document.id).exists? if @featured.nil?
+      @featured = FeaturedCollection.where(collection_id: solr_document.to_param).exists? if @featured.nil?
       @featured
     end
 

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -1,0 +1,18 @@
+<nav class="navbar navbar-default navbar-static-top" role="navigation">
+  <div class="container-fluid">
+    <div class="row">
+      <ul class="nav navbar-nav col-sm-5">
+        <li <%= 'class="active"' if current_page?(hyrax.about_path) %>>
+          <%= link_to t(:'hyrax.controls.about'), hyrax.about_path, aria: current_page?(hyrax.about_path) ? {current: 'page'} : nil %></li>
+        <li <%= 'class="active"' if current_page?(hyrax.help_path) %>>
+          <%= link_to t(:'hyrax.controls.help'), hyrax.help_path, aria: current_page?(hyrax.help_path) ? {current: 'page'} : nil %></li>
+        <li <%= 'class="active"' if current_page?(hyrax.contact_path) %>>
+          <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path, aria: current_page?(hyrax.contact_path) ? {current: 'page'} : nil %></li>
+      </ul><!-- /.nav -->
+
+      <div class="searchbar-right navbar-right col-sm-7">
+        <%= render partial: 'catalog/search_form' %>
+      </div>
+    </div>
+  </div>
+</nav><!-- /.navbar -->

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -8,6 +8,8 @@
           <%= link_to t(:'hyrax.controls.help'), hyrax.help_path, aria: current_page?(hyrax.help_path) ? {current: 'page'} : nil %></li>
         <li <%= 'class="active"' if current_page?(hyrax.contact_path) %>>
           <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path, aria: current_page?(hyrax.contact_path) ? {current: 'page'} : nil %></li>
+        <li <%= 'class="active"' if current_page?(advanced_search_path) %>>
+          <%= link_to t(:'spot.controls.advanced_search'), advanced_search_path, aria: current_page?(advanced_search_path) ? {current: 'page'} : nil %></li>
       </ul><!-- /.nav -->
 
       <div class="searchbar-right navbar-right col-sm-7">

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -13,43 +13,6 @@
       </div>
 
       <div class="collapse navbar-collapse" id="top-navbar-collapse">
-        <%= form_tag search_form_action,
-                     method: :get,
-                     id: 'catalog-search-form',
-                     class: 'navbar-form navbar-left',
-                     role: 'search' do %>
-
-          <% params_to_skip = %i[q search_field qt page utf8] %>
-          <% fields = search_state.params_for_search.except(*params_to_skip) %>
-          <%= render_hash_as_hidden_fields fields %>
-
-          <input type="hidden" name="search_field" value="all_fields" />
-
-          <div class="input-group">
-            <%= text_field_tag :q,
-                               current_search_parameters,
-                               class: 'form-control',
-                               id: 'search-field-header',
-                               placeholder: t('spot.masthead.search_placeholder') %>
-            <span class="input-group-btn">
-              <button type="submit" class="btn btn-default">
-                <span class="glyphicon glyphicon-search"></span>
-                Go
-              </button>
-            </span>
-          </div>
-        <% end %>
-
-        <ul class="nav navbar-nav">
-          <%#
-            TODO: i couldn't get +advanced_search_path+ to work (was just getting 'undefined
-                  method' errors), so this is unfortunately hardcoded. let's not.
-          %>
-          <li>
-            <%= link_to t('spot.masthead.advanced_search'), '/advanced' %>
-          </li>
-        </ul>
-
         <%= render '/user_util_links' %>
       </div>
     </div>

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -1,5 +1,5 @@
 <% # main container for facets/limits menu -%>
-<% if has_facet_values? %>
+<% if general_facets? %>
 <div id="facets" class="facets sidenav">
 
   <div class="top-panel-heading panel-heading">
@@ -22,7 +22,7 @@
 <% end %>
 
 <% # display admin facets if the user is an admin + we have some configured %>
-<% if current_user&.admin? && !admin_facet_names.empty? %>
+<% if admin_facets? %>
 <div id="admin-facets" class="facets sidenav">
   <div class="top-panel-heading panel-heading">
     <button type="button" class="facets-toggle" data-toggle="collapse" data-target="#facet-panel-collapse">

--- a/app/views/catalog/_index_list_collection.html.erb
+++ b/app/views/catalog/_index_list_collection.html.erb
@@ -4,6 +4,15 @@
   <% collection_presenter.abstract.each do |abstract| %>
   <p><%= abstract %></p>
   <% end %>
+
+  <% if collection_presenter.permalink.present? %>
+  <div class="metadata">
+    <dl class="dl-horizontal">
+      <dd><%= t('blacklight.search.terms.permalink') %></dd>
+      <dt><%= collection_presenter.permalink %></dt>
+    </dl>
+  </div>
+  <% end %>
 </div>
 
 <div class="col-md-<%= col_count.zero? ? '2' : '4' %>">

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,24 +1,21 @@
-<%# search form duplicated from hyrax/catalog/_search_form.html.erb but removes the
-    'search my collections/works' dropdown and adds a 'search field' dropdown %>
-<%= form_tag search_form_action,
-             method: :get,
-             id: 'catalog-search-form',
-             class: 'form-inline search-form',
-             role: 'search' do %>
+<%= form_tag search_form_action, method: :get, class: "form-horizontal search-form", id: "search-form-header", role: "search" do %>
+  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+  <%= hidden_field_tag :search_field, 'all_fields' %>
+  <div class="form-group">
 
-  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q,
-                                                                         :search_field,
-                                                                         :qt,
-                                                                         :page,
-                                                                         :utf8)) %>
-  <input type="hidden" name="search_field" value="all_fields" />
-  <div class="input-group col-sm-12">
-    <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
+    <label class="control-label col-sm-3" for="search-field-header">
+      <%= t("hyrax.search.form.q.label", application_name: application_name) %>
+    </label>
 
-    <div class="input-group-btn">
-      <button type="submit" class="btn btn-primary" id="search-submit-header">
-        <%= t('hyrax.search.button.html') %>
-      </button>
-    </div><!-- /.input-group-btn -->
-  </div><!-- /.input-group -->
+    <div class="input-group">
+      <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
+
+      <div class="input-group-btn">
+        <button type="submit" class="btn btn-primary" id="search-submit-header">
+          <%= t('hyrax.search.button.html') %>
+        </button>
+      </div><!-- /.input-group-btn -->
+    </div><!-- /.input-group -->
+
+  </div><!-- /.form-group -->
 <% end %>

--- a/app/views/hyrax/base/_export_tools.html.erb
+++ b/app/views/hyrax/base/_export_tools.html.erb
@@ -1,10 +1,8 @@
 <div class="work-export-tools btn-toolbar" style="margin-bottom:1rem;">
   <div class="btn-group">
-    <%= link_to main_app.export_path(presenter),
-                class: 'btn btn-success',
-                data: { turbolinks: false } do %>
+    <%= link_to presenter.download_url, class: 'btn btn-success', data: { turbolinks: false } do %>
       <span class="fa fa-download"></span>
-      <%= t('spot.work.export.download_work') %>
+      <%= t('spot.work.export.primary_file') %>
     <% end %>
   </div>
 
@@ -19,14 +17,17 @@
     </button>
     <ul class="dropdown-menu">
       <li class="dropdown-header">
-        <%= t('spot.work.export.dropdown.file_header') %>
+        <%= t('spot.work.export.dropdown.export_header') %>
       </li>
       <li>
-        <%= link_to t('spot.work.export.primary_file'),
-                    presenter.download_url,
-                    data: { turbolinks: false } %>
+      <%= link_to presenter.export_all_text,
+                  main_app.export_path(presenter),
+                  data: { turbolinks: false } %>
       </li>
-      <% if presenter.list_of_item_ids_to_display.count > 1 %>
+      <% if presenter.multiple_members? %>
+        <li class="dropdown-header">
+          <%= t('spot.work.export.dropdown.files_header') %>
+        </li>
         <li>
           <%= link_to t('spot.work.export.all_files'),
                       main_app.export_path(presenter, export_type: :files),

--- a/app/views/hyrax/collections/_collection_description.html.erb
+++ b/app/views/hyrax/collections/_collection_description.html.erb
@@ -1,6 +1,6 @@
 <% if presenter.description.empty? %>
   <% presenter.abstract.each do |abstract| %>
-    <%= simple_format(auto_link(abstract)) %>
+    <%= simple_format(auto_link(abstract), class: 'lead') %>
   <% end %>
 <% else %>
   <% presenter.description.each do |description| %>

--- a/app/views/hyrax/collections/_collection_description.html.erb
+++ b/app/views/hyrax/collections/_collection_description.html.erb
@@ -1,9 +1,11 @@
-<% if presenter.description.empty? %>
-  <% presenter.abstract.each do |abstract| %>
-    <%= simple_format(auto_link(abstract), class: 'lead') %>
-  <% end %>
-<% else %>
-  <% presenter.description.each do |description| %>
-    <%= simple_format(auto_link(description)) %>
-  <% end %>
+<% presenter.abstract.each do |abstract| %>
+  <%= simple_format(auto_link(abstract), class: 'lead') %>
+<% end %>
+
+<% presenter.description.each do |description| %>
+  <%= simple_format(auto_link(description)) %>
+<% end %>
+
+<% unless presenter.related_resource.empty? %>
+  <p><%= render_related_resource_language(presenter) %></p>
 <% end %>

--- a/app/views/hyrax/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/collections/_show_descriptions.html.erb
@@ -1,3 +1,4 @@
+<%# controls the display of the metadata table that is part of the collection#show view %>
 <h2><%= t('hyrax.dashboard.collections.show.metadata_header') %></h2>
 <div class="panel panel-default">
   <table class="table table-condensed collection-show metadata-table">

--- a/app/views/hyrax/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/collections/_show_descriptions.html.erb
@@ -1,0 +1,10 @@
+<h2><%= t('hyrax.dashboard.collections.show.metadata_header') %></h2>
+<div class="panel panel-default">
+  <table class="table table-condensed collection-show metadata-table">
+    <tbody>
+      <% presenter.terms_with_values.each do |term| %>
+        <%= presenter.attribute_to_html(term.to_sym) %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -3,31 +3,16 @@
   <div class="row hyc-header">
     <div class="col-md-12">
 
-      <% unless @presenter.banner_file.blank? %>
-          <header class="hyc-banner" style="background-image:url(<%= @presenter.banner_file %>)">
-      <% else %>
-          <header class="hyc-banner" style="background-image:url(<%= image_path('default-collection-background.jpg') %>)">
-      <% end %>
+    <% unless @presenter.banner_file.blank? %>
+      <header class="hyc-banner" style="background-image:url(<%= @presenter.banner_file %>)">
+    <% else %>
+      <header class="hyc-banner" style="background-image:url(<%= image_path('default-collection-background.jpg') %>)">
+    <% end %>
 
-      <div class="hyc-title">
-        <h1><%= @presenter.title.first %></h1>
-        <%= @presenter.permission_badge unless @presenter.public? %>
-      </div>
-
-      <% unless @presenter.logo_record.blank? %>
-          <div class="hyc-logos">
-            <% @presenter.logo_record.each_with_index  do |lr, i| %>
-
-                <% if lr[:linkurl].blank? %>
-                    <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" />
-                <% else %>
-                    <a href="<%= lr[:linkurl] %>">
-                      <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" />
-                    </a>
-                <% end %>
-            <% end %>
-          </div>
-      <% end %>
+        <div class="hyc-title">
+          <h1><%= @presenter.title.first %></h1>
+          <%= @presenter.permission_badge unless @presenter.public? %>
+        </div>
       </header>
     </div>
 
@@ -37,7 +22,7 @@
   </div>
 
   <div class="row hyc-body">
-    <div class="col-md-8 hyc-description">
+    <div class="col-md-10 hyc-description">
       <%= render 'collection_description', presenter: @presenter %>
 
       <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
@@ -51,13 +36,24 @@
           </div>
       <% end %>
 
-    </div>
-    <div class="col-md-4 hyc-metadata">
       <% unless has_collection_search_parameters? %>
-          <h2><%= t('hyrax.dashboard.collections.show.metadata_header') %></h2>
-          <%= render 'show_descriptions' %>
+        <div class="collection-metadata">
+          <%= render 'show_descriptions', presenter: @presenter %>
+        </div>
       <% end %>
     </div>
+
+    <% unless @presenter.logo_record.blank? %>
+    <div class="col-md-2">
+      <% logo = @presenter.logo_record.first %>
+      <% image_html = image_tag(logo[:file_location], class: 'img-responsive', alt: logo[:alttext]) %>
+      <% if logo[:linkurl].present? %>
+        <%= link_to(logo[:linkurl]) { image_html } %>
+      <% else %>
+        <%= image_html %>
+      <% end %>
+      </div>
+    <% end %>
   </div>
 
   <!-- Search results label -->

--- a/app/views/layouts/hyrax/1_column.html.erb
+++ b/app/views/layouts/hyrax/1_column.html.erb
@@ -1,5 +1,0 @@
-<%#
-  works_controller_behavior will render this on views that aren't the dashboard,
-  so we'll just set it to render the base layout without the navbar
-%>
-<%= render template: 'layouts/hyrax' %>

--- a/app/views/spot/homepage/_featured_collection_item.html.erb
+++ b/app/views/spot/homepage/_featured_collection_item.html.erb
@@ -12,17 +12,6 @@
       <p><%= collection.abstract.first %></p>
       <% end %>
       <%= link_to t('.collection.view'), [hyrax, collection], class: 'btn btn-primary' %>
-
-      <%#
-        TODO: this is a no-op at the moment. we may want to include a metadata property
-              that provides a URL to learn more about the collection
-      %>
-      <% if collection.related_resource.present? %>
-        <%= link_to t('.collection.learn_more'),
-                    collection.related_resource.first,
-                    class: 'btn btn-info',
-                    target: '_blank' %>
-      <% end %>
     </div>
   </div>
 </div>

--- a/config/collections.yml
+++ b/config/collections.yml
@@ -15,6 +15,11 @@
 #       'private' - closed to all but the depositor
 #     - Default: 'private'
 #
+#   slug
+#     - Type: String
+#     - Easier to remember URL path for a collection. Should be lower-cased
+#       and separated by hyphens (ex. "lafayette-newspaper-archive")
+#
 #   metadata
 #     - Type: Hash (or whatever yaml calls them)
 #     - Default: {}
@@ -33,6 +38,14 @@
   title: Bytes and Books
   visibility: public
   slug: bytes-and-books
+-
+  title: College Administration
+  visibility: public
+  slug: college-administration
+-
+  title: Course Catalogs
+  visibility: public
+  slug: course-catalogs
 -
   title: Faculty Publications
   visibility: public
@@ -64,6 +77,10 @@
     related_resource:
       - https://dss.lafayette.edu/collections/lafayette-newspaper-collection
 -
+  title: Public Safety
+  visibility: public
+  slug: public-safety
+-
   title: Shakespeare Bulletin Archive
   visibility: public
   slug: shakespeare-bulletin-archive
@@ -76,3 +93,7 @@
       on Film Newsletter (1976-1992).
     related_resource:
       - https://dss.lafayette.edu/collections/shakespeare-bulletin-archive
+-
+  title: Student Publications
+  visibility: public
+  slug: student-publications

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,5 +55,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end

--- a/config/initializers/hyrax_overrides.rb
+++ b/config/initializers/hyrax_overrides.rb
@@ -1,35 +1,7 @@
 # frozen_string_literal: true
-#
-# This may not be the best way to approach overloads, but I was running
-# into issues with a +to_prepare+ block which changed these attributes
-# causing a lot of strange locale translation misses. I did _a lot_ of
-# poking around and I think I've got it nailed down.
-#
-# Providing a +to_prepare+ block to the Configuration class adds it to
-# an array of blocks called +.to_prepare_blocks+ which is what is iterated
-# through when loading (see: https://github.com/rails/rails/blob/v5.1.7/railties/lib/rails/railtie/configuration.rb#L77-L81
-# and https://github.com/rails/rails/blob/v5.1.7/railties/lib/rails/application/finisher.rb#L52-L56).
-# (note: the code changes in later rails versions, but the concept is the same).
-#
-# Something about setting one of these class attributes throws a wrench in
-# the i18n load path, or something. When they're out, no problem, but we
-# want them in. Finding the above code, it seems like what might be happening
-# is our +to_prepare+ block is coming before one that loads I18ns from the
-# Hyrax engine (or another dependency) and hecking up something.
-#
-# SO, what this does is:
-#   a) loads the overrides in a lambda
-#   b) calls that lambda in the +after_initialize+ block
-#   c) (when in development) adds the lambda to the _end_ of the
-#      +.to_prepare_blocks+ array, so that the next time the +to_prepare+
-#      blocks are called, it'll be the last one.
-#
-# It feels like overkill, but it's the only solution
-# that's consistently worked so far.
-#
-# Please change if you can figure it out!
+Rails.application.config.to_prepare do
+  ## Spot overrides Hyrax
 
-load_overrides = lambda do
   Hyrax::Dashboard::CollectionsController.presenter_class = Spot::CollectionPresenter
   Hyrax::Dashboard::CollectionsController.form_class = Spot::Forms::CollectionForm
 
@@ -58,13 +30,4 @@ load_overrides = lambda do
 
   # see above
   Hyrax::ContactFormController.class_eval { layout 'hyrax' }
-end
-
-Rails.application.config.after_initialize do
-  # load our overrides
-  load_overrides.call
-
-  # add the lambda to the blocks run by to_prepare
-  #   if we're in development mode
-  Rails.application.config.to_prepare_blocks << load_overrides if Rails.env.development?
 end

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -6,7 +6,6 @@ en:
           title: Admin Facets
       fields:
         academic_department: Academic Department
-        all_fields: All fields
         author: Author
         bibliographic_citation: Bibliographic Citation
         contributor: Contributor
@@ -19,12 +18,13 @@ en:
         depositor: Deposited by
         description: Description
         division: Division
+        embargo_release_date: Embargo Release Date
         file_format: File Format
         file_size: File Size
         keyword: Keyword
-        keyword_sim: Keyword
         language: Language
         language_label: Language
+        lease_expiration_date: Lease Expiration Date
         license: License
         local_identifier: Local Identifier
         location: Location
@@ -37,21 +37,21 @@ en:
         publisher: Publisher
         resource_type: Type
         rights_statement: Rights Statement
+        source: Source
         standard_identifier: Standard Identifier
         subject: Subject
         title: Title
+        visibility: Visibility
         years_encompassed: Year
 
-        facet:
-          resource_type_sim: Type
-          source_sim: Source
-          visibility_ssi: Visibility
-    sort:
-      fields:
-        date_added:
-          asc: "Date Added \u25B2"
-          desc: "Date Added \u25BC"
-        date_issued:
-          asc: "Issue Date \u25B2"
-          desc: "Issue Date \u25BC"
-        relevance: Relevance
+        search:
+          all_fields: All fields
+
+        sort:
+          date_added:
+            asc: "Date Added \u25B2"
+            desc: "Date Added \u25BC"
+          date_issued:
+            asc: "Issue Date \u25B2"
+            desc: "Issue Date \u25BC"
+          relevance: Relevance

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -44,14 +44,4 @@ en:
         visibility: Visibility
         years_encompassed: Year
 
-        search:
-          all_fields: All fields
-
-        sort:
-          date_added:
-            asc: "Date Added \u25B2"
-            desc: "Date Added \u25BC"
-          date_issued:
-            asc: "Issue Date \u25B2"
-            desc: "Issue Date \u25BC"
-          relevance: Relevance
+        all_fields: All fields

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -16,6 +16,9 @@ en:
       default_title: User Collection
 
     dashboard:
+      collections:
+        show:
+          metadata_header: Details
       my:
         heading:
           collection_type: Collection Type

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -21,6 +21,10 @@ en:
           collection_type: Collection Type
           visibility: Visibility
 
+    footer:
+      copyright_html: "<strong>Copyright &copy; 2017 Samvera</strong> Licensed under the Apache License, Version 2.0"
+      service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
+
     directory:
       suffix:               "@example.org"
 
@@ -34,6 +38,7 @@ en:
     product_name: Lafayette Digital Repository
     product_twitter_handle: "@LafLib"
 
-    footer:
-      copyright_html: "<strong>Copyright &copy; 2017 Samvera</strong> Licensed under the Apache License, Version 2.0"
-      service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
+    search:
+      form:
+        q:
+          label: Search LDR

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -16,12 +16,16 @@ en:
       index:
         page_title: 'Search Results // %{name}'
 
+    controls:
+      advanced_search: Advanced Search
+
     dashboard:
       fixity:
         frequency: Checks are run every Monday at midnight.
         heading: The most recent round of fixity checks found %{errors}.
         sidebar: Fixity Checks
         title: Fixity Checks
+
       status:
         sidebar: System Status
         title: System Status

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -84,10 +84,12 @@ en:
       export:
         additional_options: Additional options
         all_files: Download all files
-        primary_file: Download primary file
-        download_work: Download as .zip
+        primary_file: Download this item
+        download_work_and_metadata_single: Download file and all metadata formats (as .zip)
+        download_work_and_metadata_multiple: Download files and all metadata formats (as .zip)
         dropdown:
-          file_header: Files
+          export_header: Export
+          files_header: Files
           metadata_header: Metadata
         metadata:
           csv: View metadata as CSV

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -16,6 +16,11 @@ en:
       index:
         page_title: 'Search Results // %{name}'
 
+    collection:
+      show:
+        related_resource_single: "To learn more about this collection, visit %{link_html}."
+        related_resource_multiple: "To learn more about this collection, visit the following: %{link_html}."
+
     controls:
       advanced_search: Advanced Search
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ Rails.application.routes.draw do
   end
 
   get '/handle/*id', to: 'identifier#handle', as: 'handle'
-  get '/redirect', to: 'spot/redirect#show', constraints: ->(request) {
+  get '/redirect', to: 'spot/redirect#show', constraints: lambda { |request|
     qs = Rack::Utils.parse_nested_query(request.query_string)
     qs['url'] && qs['url'].match?(URI.regexp)
   }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'sidekiq/web'
 require 'sidekiq/cron/web'
+require 'rack'
 
 Rails.application.routes.draw do
   devise_for :users
@@ -64,4 +65,8 @@ Rails.application.routes.draw do
   end
 
   get '/handle/*id', to: 'identifier#handle', as: 'handle'
+  get '/redirect', to: 'spot/redirect#show', constraints: ->(request) {
+    qs = Rack::Utils.parse_nested_query(request.query_string)
+    qs['url'] && qs['url'].match?(URI.regexp)
+  }
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
     image: solr:7.5-alpine
     volumes:
       - ./solr/config:/spot-config
-      - solr:/opt/solr/server/solr/mycores
+      - solr:/opt/solr/server/solr
     command: solr-create -c spot-development -d /spot-config
     restart: always
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - solr
     stdin_open: true
     tty: true
+
   db:
     image: postgres:alpine
     volumes:
@@ -39,20 +40,24 @@ services:
       POSTGRES_DB: spot_dev
       POSTGRES_USER: spot_dev_user
     restart: always
+
   fedora:
     image: samvera/fcrepo4:4.7.5
     volumes:
       - fedora:/data
     restart: always
+
   fitsservlet:
     image: harvardlts/fitsservlet_container
     environment:
       FITSSERVLET_VERSION: '1.1.3'
+
   redis:
     image: redis:alpine
     volumes:
       - redis:/data
     restart: always
+
   solr:
     image: solr:7.5-alpine
     volumes:
@@ -60,6 +65,7 @@ services:
       - solr:/opt/solr/server/solr/mycores
     command: solr-create -c spot-development -d /spot-config
     restart: always
+
   sidekiq:
     <<: *app
     command: bundle exec sidekiq
@@ -70,4 +76,4 @@ services:
       - "4000:3000"
     restart: always
     depends_on:
-      - spot
+      - app

--- a/spec/controllers/spot/redirect_controller_spec.rb
+++ b/spec/controllers/spot/redirect_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+RSpec.describe Spot::RedirectController do
+  routes { Rails.application.routes }
+
+  describe '#show' do
+    subject { get :show, params: { url: url } }
+
+    context 'when a matching URL exists' do
+      let(:url) { 'http://cool.example.com/path/to/item' }
+      let(:obj) { build(:publication, identifier: ["url:#{url}"]) }
+
+      before { obj.save! }
+
+      it { is_expected.to redirect_to hyrax_publication_path(obj.id) }
+    end
+
+    context 'when a matching url does not exist' do
+      let(:url) { 'http://nope.example.com/this/doesnt/exist' }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe SolrDocument do
       let(:base_metadata) { { 'id' => 'abc123', 'has_model_ssim' => 'Collection' } }
 
       context 'when the collection has a slug' do
-        let(:metadata) { base_metadata.merge('identifier_ssim' => ['slug:a-cool-collection']) }
+        let(:metadata) { base_metadata.merge('collection_slug_ssi' => 'a-cool-collection') }
 
         it { is_expected.to eq 'a-cool-collection' }
       end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -67,4 +67,30 @@ RSpec.describe SolrDocument do
       it { is_expected.to eq expected }
     end
   end
+
+  describe '#to_param' do
+    subject { document.to_param }
+
+    context 'when the item is a collection' do
+      let(:base_metadata) { { 'id' => 'abc123', 'has_model_ssim' => 'Collection' } }
+
+      context 'when the collection has a slug' do
+        let(:metadata) { base_metadata.merge('identifier_ssim' => ['slug:a-cool-collection']) }
+
+        it { is_expected.to eq 'a-cool-collection' }
+      end
+
+      context 'when the collection does not have a slug' do
+        let(:metadata) { base_metadata }
+
+        it { is_expected.to eq 'abc123' }
+      end
+    end
+
+    context 'default behavior' do
+      let(:metadata) { { 'id' => 'abc123', 'has_model_ssim' => 'Publication' } }
+
+      it { is_expected.to eq 'abc123' }
+    end
+  end
 end

--- a/spec/presenters/spot/collection_presenter_spec.rb
+++ b/spec/presenters/spot/collection_presenter_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Spot::CollectionPresenter do
     {
       id: 'abc123',
       title_tesim: ['Cool Collection'],
-      read_access_group_ssim: ['public']
+      read_access_group_ssim: ['public'],
+      has_model_ssim: 'Collection'
     }
   end
   let(:admin_user) { create(:admin_user) }

--- a/spec/services/spot/collection_from_config_spec.rb
+++ b/spec/services/spot/collection_from_config_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Spot::CollectionFromConfig do
   let(:visibility) { 'private' }
 
   before do
+    User.create(email: 'dss@lafayette.edu')
+
     Hyrax::CollectionTypes::CreateService.create_admin_set_type
     Hyrax::CollectionTypes::CreateService.create_user_collection_type
   end


### PR DESCRIPTION
a lot of commits here because i rebased + merged (rather than squashed + merged) a few of these PRs (maybe all four?)

- add `/redirect?url=<digital.laf url>` routing for legacy URLs (#277)
- the hyrax 2nd navbar has returned (#278)
- improvements in collection-slug behavior (`SolrDocument#to_param` now checks if the item is a collection) (#278)
- Collection views now display related_resource URLs below the abstract + description blocks
- changes the download button on a work's show page to be for the primary object download (`/downloads/<work id>`) and moves the zip-export to the dropdown (#291)
- adds several subcollections from dspace content (#292)

fixes:
- use the `file_watcher` in development that will work with docker
- (collections_from_config) only update when a collection has changed (#276)
- labels in `catalog_controller.rb` are now symbols, rather than calls to `I18n.translate` which were encountering issues with engine locales not being loaded when called (#285)

closes #20
closes #200
closes #281
closes #283 