### PR TITLE
move download primary file to button; export to dropdown

### DIFF
--- a/app/presenters/hyrax/publication_presenter.rb
+++ b/app/presenters/hyrax/publication_presenter.rb
@@ -11,6 +11,11 @@ module Hyrax
              :source, :subject, :subtitle, :title_alternative,
              to: :solr_document
 
+    # @return [String]
+    def export_all_text
+      I18n.t("spot.work.export.download_work_and_metadata_#{has_multiple_members? ? 'multiple' : 'single'}")
+    end
+
     # Metadata formats we're able to export as.
     #
     # @return [Array<Symbol>]
@@ -18,28 +23,9 @@ module Hyrax
       %i[csv ttl nt jsonld]
     end
 
-    # Overrides {Hyrax::WorkShowPresenter#page_title} by only using
-    # the work's title + our product name.
-    #
-    # @return [String]
-    def page_title
-      "#{title.first} // #{I18n.t('hyrax.product_name')}"
-    end
-
-    # For now, overriding the ability to feature individual works
-    # on the homepage. This should prevent the 'Feature'/'Unfeature'
-    # button from rendering on the work edit page.
-    #
-    # @return [false]
-    def work_featurable?
-      false
-    end
-
-    # Is the document's visibility public?
-    #
     # @return [true, false]
-    def public?
-      solr_document.visibility == ::Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    def has_multiple_members?
+      list_of_item_ids_to_display.count > 1
     end
 
     # Our document's identifiers mapped to Spot::Identifier objects
@@ -65,14 +51,38 @@ module Hyrax
       solr_document.location.zip(solr_document.location_label).reject(&:empty?)
     end
 
-    # @return [Array<Spot::Identifier>]
-    def standard_identifier
-      @standard_identifier ||= identifier.select(&:standard?)
+    # Overrides {Hyrax::WorkShowPresenter#page_title} by only using
+    # the work's title + our product name.
+    #
+    # @return [String]
+    def page_title
+      "#{title.first} // #{I18n.t('hyrax.product_name')}"
+    end
+
+    # Is the document's visibility public?
+    #
+    # @return [true, false]
+    def public?
+      solr_document.visibility == ::Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
 
     # @return [Array<Array<String>>]
     def rights_statement_merged
       solr_document.rights_statement.zip(solr_document.rights_statement_label)
+    end
+
+    # @return [Array<Spot::Identifier>]
+    def standard_identifier
+      @standard_identifier ||= identifier.select(&:standard?)
+    end
+
+    # For now, overriding the ability to feature individual works
+    # on the homepage. This should prevent the 'Feature'/'Unfeature'
+    # button from rendering on the work edit page.
+    #
+    # @return [false]
+    def work_featurable?
+      false
     end
   end
 end

--- a/app/presenters/hyrax/publication_presenter.rb
+++ b/app/presenters/hyrax/publication_presenter.rb
@@ -13,7 +13,7 @@ module Hyrax
 
     # @return [String]
     def export_all_text
-      I18n.t("spot.work.export.download_work_and_metadata_#{has_multiple_members? ? 'multiple' : 'single'}")
+      I18n.t("spot.work.export.download_work_and_metadata_#{multiple_members? ? 'multiple' : 'single'}")
     end
 
     # Metadata formats we're able to export as.
@@ -21,11 +21,6 @@ module Hyrax
     # @return [Array<Symbol>]
     def export_formats
       %i[csv ttl nt jsonld]
-    end
-
-    # @return [true, false]
-    def has_multiple_members?
-      list_of_item_ids_to_display.count > 1
     end
 
     # Our document's identifiers mapped to Spot::Identifier objects
@@ -49,6 +44,11 @@ module Hyrax
     # @return [Array<Array<String>>]
     def location
       solr_document.location.zip(solr_document.location_label).reject(&:empty?)
+    end
+
+    # @return [true, false]
+    def multiple_members?
+      list_of_item_ids_to_display.count > 1
     end
 
     # Overrides {Hyrax::WorkShowPresenter#page_title} by only using

--- a/app/views/hyrax/base/_export_tools.html.erb
+++ b/app/views/hyrax/base/_export_tools.html.erb
@@ -24,7 +24,7 @@
                   main_app.export_path(presenter),
                   data: { turbolinks: false } %>
       </li>
-      <% if presenter.has_multiple_members? %>
+      <% if presenter.multiple_members? %>
         <li class="dropdown-header">
           <%= t('spot.work.export.dropdown.files_header') %>
         </li>

--- a/app/views/hyrax/base/_export_tools.html.erb
+++ b/app/views/hyrax/base/_export_tools.html.erb
@@ -1,10 +1,8 @@
 <div class="work-export-tools btn-toolbar" style="margin-bottom:1rem;">
   <div class="btn-group">
-    <%= link_to main_app.export_path(presenter),
-                class: 'btn btn-success',
-                data: { turbolinks: false } do %>
+    <%= link_to presenter.download_url, class: 'btn btn-success', data: { turbolinks: false } do %>
       <span class="fa fa-download"></span>
-      <%= t('spot.work.export.download_work') %>
+      <%= t('spot.work.export.primary_file') %>
     <% end %>
   </div>
 
@@ -19,14 +17,17 @@
     </button>
     <ul class="dropdown-menu">
       <li class="dropdown-header">
-        <%= t('spot.work.export.dropdown.file_header') %>
+        <%= t('spot.work.export.dropdown.export_header') %>
       </li>
       <li>
-        <%= link_to t('spot.work.export.primary_file'),
-                    presenter.download_url,
-                    data: { turbolinks: false } %>
+      <%= link_to presenter.export_all_text,
+                  main_app.export_path(presenter),
+                  data: { turbolinks: false } %>
       </li>
-      <% if presenter.list_of_item_ids_to_display.count > 1 %>
+      <% if presenter.has_multiple_members? %>
+        <li class="dropdown-header">
+          <%= t('spot.work.export.dropdown.files_header') %>
+        </li>
         <li>
           <%= link_to t('spot.work.export.all_files'),
                       main_app.export_path(presenter, export_type: :files),

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -84,10 +84,12 @@ en:
       export:
         additional_options: Additional options
         all_files: Download all files
-        primary_file: Download primary file
-        download_work: Download as .zip
+        primary_file: Download this item
+        download_work_and_metadata_single: Download file and all metadata formats (as .zip)
+        download_work_and_metadata_multiple: Download files and all metadata formats (as .zip)
         dropdown:
-          file_header: Files
+          export_header: Export
+          files_header: Files
           metadata_header: Metadata
         metadata:
           csv: View metadata as CSV


### PR DESCRIPTION
changes around the download/export button on the Publication show page

<img width="568" alt="Screen Shot 2019-09-30 at 4 55 54 PM" src="https://user-images.githubusercontent.com/2744987/65971543-51028f80-e436-11e9-8c98-868cef3e6527.png">

now the green button offers to download the item (traditional hyrax behavior), and the additional options include exporting as a zip as well as the metadata.

closes #281