### PR TITLE
store logs of each batch of fixity-checks

### DIFF
--- a/app/jobs/spot/repository_fixity_check_job.rb
+++ b/app/jobs/spot/repository_fixity_check_job.rb
@@ -1,47 +1,12 @@
 # frozen_string_literal: true
-#
-# NOTE: This job performs the fixity-checking synchronously (see below).
-# Be sure to run this when there is no processing needed!
-#
-# The Hyrax::RepositoryFixityCheckService enqueues all of the fixity-check
-# jobs asynchronously. We found that this results in quite a few false
-# failures. Running the service as it's defined below removes those false failures
-# (note: I'm calling them "false failures" because viewing the files in Fedora
-# shows that the fixity checks succeeded).
-#
-# Running the checks this way allows us to send a follow-up email/post
-# when the jobs are done running.
 module Spot
   class RepositoryFixityCheckJob < ApplicationJob
     queue_as :low_priority
 
-    around_perform :wrap_check
-
     # @param [true, false] :force Ignore the 'max days between check' parameter
     def perform(force: false)
-      opts = { async_jobs: false }
-      opts[:max_days_between_fixity_checks] = -1 if force
-
-      @count = 0
-
-      ::FileSet.find_each do |file_set|
-        @count += 1
-        Hyrax::FileSetFixityCheckService.new(file_set, opts).fixity_check
-      end
+      batch = Spot::FixityCheckService.perform(force: force)
+      Spot::SendFixityStatusJob.perform_now(batch)
     end
-
-    private
-
-      # Wraps our check to pass a time to the send_fixity_status_job.
-      #
-      # @yields
-      # @return [void]
-      def wrap_check
-        start = Time.zone.now
-
-        yield
-
-        SendFixityStatusJob.perform_now(item_count: @count, job_time: (Time.zone.now - start))
-      end
   end
 end

--- a/app/jobs/spot/send_fixity_status_job.rb
+++ b/app/jobs/spot/send_fixity_status_job.rb
@@ -8,15 +8,14 @@ module Spot
   class SendFixityStatusJob < ApplicationJob
     queue_as :low_priority
 
-    # @param [Number] :item_count
-    # @param [Number] :job_time
+    # @param [FixityCheckBatch] batch
     # @return [void]
-    def perform(item_count:, job_time:)
+    def perform(batch)
       return unless slack_ok?
 
-      @item_count = item_count
-      @job_time = job_time
-      @errors = ChecksumAuditLog.latest_checks.where(passed: false).count
+      @item_count = batch.checksum_audit_logs.count
+      @job_time = batch.total_time
+      @errors = batch.failed
 
       send_message_to_slack
     end

--- a/app/models/fixity_check_batch.rb
+++ b/app/models/fixity_check_batch.rb
@@ -1,15 +1,22 @@
 # frozen_string_literal: true
 class FixityCheckBatch < ApplicationRecord
+  # Class used for serializing fixity check summary info.
   class Summary
     attr_reader :success, :failed, :failed_item_ids, :total_time
 
-    def initialize(success:, failed:, failed_item_ids:, total_time:)
+    # @param [Hash] options
+    # @option [Integer] success
+    # @option [Integer] failed
+    # @option [Array<String>] failed_item_ids
+    # @option [Float] total_time
+    def initialize(success: -1, failed: -1, failed_item_ids: [], total_time: 0.0)
       @success = success
       @failed = failed
       @failed_item_ids = failed_item_ids
       @total_time = total_time
     end
 
+    # @return [Hash<Symbol => Integer, Array>]
     def to_h
       { success: success, failed: failed,
         failed_item_ids: failed_item_ids, total_time: total_time }
@@ -21,7 +28,7 @@ class FixityCheckBatch < ApplicationRecord
     # @return [FixityCheckBatch::Summary]
     def self.load(json)
       return nil if json.blank?
-      parsed = JSON.parse(json).with_indifferent_access
+      parsed = JSON.parse(json).symbolize_keys
 
       new(parsed)
     end
@@ -38,9 +45,9 @@ class FixityCheckBatch < ApplicationRecord
       when self
         JSON.dump(obj.to_h)
       when Hash
-        JSON.dump(new(obj).to_h)
+        JSON.dump(new(obj.symbolize_keys).to_h)
       else
-        raise StandardException, "Expected #{self} or Hash, got #{obj.class}"
+        raise StandardError, "Expected #{self} or Hash, got #{obj.class}"
       end
     end
   end

--- a/app/models/fixity_check_batch.rb
+++ b/app/models/fixity_check_batch.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+class FixityCheckBatch < ApplicationRecord
+  class Summary < Struct.new(:success, :failed, :failed_item_ids, :total_time)
+    # Loads a Summary object from a JSON string
+    #
+    # @param [String] json
+    # @return [FixityCheckBatch::Summary]
+    def self.load(json)
+      return nil if json.blank?
+      parsed = JSON.parse(json)
+
+      new(parsed['success'], parsed['failed'], parsed['failed_item_ids'], parsed['total_time'])
+    end
+
+    # Turns a Summary into JSON.
+    #
+    # @param [Hash,FixityCheckBatch::Summary] obj
+    # @return [String]
+    # @raise [StandardException] raised when +obj+ is neither a Hash or Summary object
+    def self.dump(obj)
+      obj = obj.with_indifferent_access if obj.is_a? Hash
+
+      case obj
+      when self
+        JSON.dump(success: obj.success,
+                  failed: obj.failed,
+                  failed_item_ids: obj.failed_item_ids,
+                  total_time: obj.total_time)
+      when Hash
+        JSON.dump(success: obj[:success],
+                  failed: obj[:failed],
+                  failed_item_ids: obj[:failed_item_ids],
+                  total_time: obj[:total_time])
+      else
+        raise StandardException, "Expected #{self} or Hash, got #{obj.class}"
+      end
+    end
+  end
+
+  has_and_belongs_to_many :checksum_audit_logs
+  serialize :summary, Summary
+
+  delegate :success, :failed, :failed_item_ids, :total_time, to: :summary
+
+  # @return [ActiveRecord::AssociationRelation]
+  def failures
+    checksum_audit_logs.where(passed: false)
+  end
+
+  # @return [Integer]
+  def item_count
+    checksum_audit_logs.count
+  end
+end

--- a/app/models/fixity_check_batch.rb
+++ b/app/models/fixity_check_batch.rb
@@ -1,15 +1,29 @@
 # frozen_string_literal: true
 class FixityCheckBatch < ApplicationRecord
-  class Summary < Struct.new(:success, :failed, :failed_item_ids, :total_time)
+  class Summary
+    attr_reader :success, :failed, :failed_item_ids, :total_time
+
+    def initialize(success:, failed:, failed_item_ids:, total_time:)
+      @success = success
+      @failed = failed
+      @failed_item_ids = failed_item_ids
+      @total_time = total_time
+    end
+
+    def to_h
+      { success: success, failed: failed,
+        failed_item_ids: failed_item_ids, total_time: total_time }
+    end
+
     # Loads a Summary object from a JSON string
     #
     # @param [String] json
     # @return [FixityCheckBatch::Summary]
     def self.load(json)
       return nil if json.blank?
-      parsed = JSON.parse(json)
+      parsed = JSON.parse(json).with_indifferent_access
 
-      new(parsed['success'], parsed['failed'], parsed['failed_item_ids'], parsed['total_time'])
+      new(parsed)
     end
 
     # Turns a Summary into JSON.
@@ -22,22 +36,16 @@ class FixityCheckBatch < ApplicationRecord
 
       case obj
       when self
-        JSON.dump(success: obj.success,
-                  failed: obj.failed,
-                  failed_item_ids: obj.failed_item_ids,
-                  total_time: obj.total_time)
+        JSON.dump(obj.to_h)
       when Hash
-        JSON.dump(success: obj[:success],
-                  failed: obj[:failed],
-                  failed_item_ids: obj[:failed_item_ids],
-                  total_time: obj[:total_time])
+        JSON.dump(new(obj).to_h)
       else
         raise StandardException, "Expected #{self} or Hash, got #{obj.class}"
       end
     end
   end
 
-  has_and_belongs_to_many :checksum_audit_logs
+  has_and_belongs_to_many :checksum_audit_logs # rubocop:disable Rails/HasAndBelongsToMany
   serialize :summary, Summary
 
   delegate :success, :failed, :failed_item_ids, :total_time, to: :summary

--- a/app/services/spot/fixity_check_service.rb
+++ b/app/services/spot/fixity_check_service.rb
@@ -21,6 +21,7 @@ module Spot
       end
 
       summarize_and_save_batch!
+      @batch
     end
 
     private
@@ -50,7 +51,6 @@ module Spot
         }
 
         @batch.update!(summary: summary, completed: true)
-        @batch
       end
   end
 end

--- a/app/services/spot/fixity_check_service.rb
+++ b/app/services/spot/fixity_check_service.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+module Spot
+  class FixityCheckService
+    def self.perform(force: false)
+      new.perform(force: force)
+    end
+
+    def initialize
+      @success_count = 0
+      @failure_count = 0
+      @failed_item_ids = []
+      @batch = ::FixityCheckBatch.create(summary: nil, completed: false)
+    end
+
+    def perform(force: false)
+      opts = { async_jobs: false }
+      opts[:max_days_between_fixity_checks] = -1 if force
+
+      ::FileSet.find_each do |file_set|
+        add_check_to_batch(fixity_check_result(file_set, opts))
+      end
+
+      summarize_and_save_batch!
+    end
+
+    private
+
+      def add_check_to_batch(log_object)
+        log_object.each_pair do |key, value|
+          value.each do |log|
+            @success_count += 1 unless log.failed?
+            @failure_count += 1 if log.failed?
+            @failed_item_ids << key if log.failed?
+
+            @batch.checksum_audit_logs << log
+          end
+        end
+      end
+
+      def fixity_check_result(file_set, opts)
+        Hyrax::FileSetFixityCheckService.new(file_set, opts).fixity_check
+      end
+
+      def summarize_and_save_batch!
+        summary = {
+          success: @success_count,
+          failed: @failure_count,
+          failed_item_ids: @failed_item_ids.compact.uniq,
+          total_time: (Time.zone.now - @batch.created_at)
+        }
+
+        @batch.update!(summary: summary, completed: true)
+        @batch
+      end
+  end
+end

--- a/db/migrate/20191002150048_add_fixity_check_batches.rb
+++ b/db/migrate/20191002150048_add_fixity_check_batches.rb
@@ -1,0 +1,14 @@
+class AddFixityCheckBatches < ActiveRecord::Migration[5.1]
+  def change
+    create_table :fixity_check_batches do |t|
+      t.json :summary
+      t.boolean :completed
+      t.timestamps
+    end
+
+    create_join_table :checksum_audit_logs, :fixity_check_batches do |t|
+      t.index :checksum_audit_log_id, name: 'index_audits_checksum_audit_log_id'
+      t.index :fixity_check_batch_id, name: 'index_audits_fixity_check_batch_id'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190327194742) do
+ActiveRecord::Schema.define(version: 20191002150048) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,13 @@ ActiveRecord::Schema.define(version: 20190327194742) do
     t.boolean "passed"
     t.index ["checked_uri"], name: "index_checksum_audit_logs_on_checked_uri"
     t.index ["file_set_id", "file_id"], name: "by_file_set_id_and_file_id"
+  end
+
+  create_table "checksum_audit_logs_fixity_check_batches", id: false, force: :cascade do |t|
+    t.bigint "checksum_audit_log_id", null: false
+    t.bigint "fixity_check_batch_id", null: false
+    t.index ["checksum_audit_log_id"], name: "index_audits_checksum_audit_log_id"
+    t.index ["fixity_check_batch_id"], name: "index_audits_fixity_check_batch_id"
   end
 
   create_table "collection_branding_infos", force: :cascade do |t|
@@ -129,6 +136,13 @@ ActiveRecord::Schema.define(version: 20190327194742) do
     t.integer "user_id"
     t.index ["file_id"], name: "index_file_view_stats_on_file_id"
     t.index ["user_id"], name: "index_file_view_stats_on_user_id"
+  end
+
+  create_table "fixity_check_batches", force: :cascade do |t|
+    t.json "summary"
+    t.boolean "completed"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "hyrax_collection_types", force: :cascade do |t|

--- a/spec/models/fixity_check_batch_spec.rb
+++ b/spec/models/fixity_check_batch_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# RSpec.describe FixityCheckBatch do; end
+
+RSpec.describe FixityCheckBatch::Summary do
+  subject(:summary) { described_class.new(opts) }
+
+  let(:opts) do
+    { success: success_count, failed: failed_count,
+      failed_item_ids: failed_item_ids, total_time: total_time }
+  end
+
+  let(:success_count) { 0 }
+  let(:failed_count) { 0 }
+  let(:failed_item_ids) { [] }
+  let(:total_time) { 0.0 }
+
+  describe '.load' do
+    subject(:summary) { described_class.load(json) }
+
+    context 'with an empty object' do
+      let(:json) { '' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with values' do
+      let(:json) { '{"success": 100, "failed": 0, "failed_item_ids": [], "total_time": 0.0 }' }
+
+      it 'loads a new object with the values' do
+        expect(summary.success).to eq 100
+        expect(summary.failed).to eq 0
+        expect(summary.failed_item_ids).to eq []
+        expect(summary.total_time).to eq 0.0
+      end
+    end
+  end
+
+  describe '.dump' do
+    subject { described_class.dump(summary) }
+
+    let(:dumped) { '{"success":100,"failed":0,"failed_item_ids":[],"total_time":0.0}' }
+
+    context 'when summary is a Summary object' do
+      let(:summary) { described_class.new(success: 100, failed: 0, failed_item_ids: [], total_time: 0.0) }
+
+      it { is_expected.to eq dumped }
+    end
+
+    context 'when a summary is a Hash' do
+      let(:summary) { { 'success' => 100, 'failed' => 0, 'failed_item_ids' => [], 'total_time' => 0.0 } }
+
+      it { is_expected.to eq dumped }
+    end
+
+    context 'otherwise it raises' do
+      it do
+        expect { described_class.dump(nil) }
+          .to raise_error(StandardError, "Expected FixityCheckBatch::Summary or Hash, got NilClass")
+      end
+    end
+  end
+
+  describe '#to_h' do
+    subject(:hash) { summary.to_h }
+
+    it { is_expected.to be_a Hash }
+    it { is_expected.to include(:success, :failed, :failed_item_ids, :total_time) }
+  end
+end


### PR DESCRIPTION
creates a model of logs for fixity checks. contains:

- created/modified dates of log (created @ start, modified when completed)
- \# of successes
- \# of failures
- array of failed item ids (`<file_set_id>/files/<file id>`)

## todo

- [ ] needs specs
- [ ] add UI for logs

-------

closes #175 