### PR TITLE
hide fixity/file info from all but admin users

### DIFF
--- a/app/views/hyrax/file_sets/_show_details.html.erb
+++ b/app/views/hyrax/file_sets/_show_details.html.erb
@@ -4,7 +4,7 @@
   </div>
   <table class="table table-bordered">
     <tbody>
-      <% if current_user.admin? %>
+      <% if current_user&.admin? %>
       <tr>
         <th><%= t 'blacklight.search.fields.depositor' %></th>
         <td itemprop="accountablePerson" itemscope itemtype="http://schema.org/Person">
@@ -40,7 +40,7 @@
       </tr>
       <% end %>
 
-      <% if current_user.admin? %>
+      <% if current_user&.admin? %>
       <tr>
         <th><%= t 'blacklight.search.fields.original_checksum' %></th>
         <td><code><%= @presenter.original_checksum %></code></td>

--- a/app/views/hyrax/file_sets/_show_details.html.erb
+++ b/app/views/hyrax/file_sets/_show_details.html.erb
@@ -4,12 +4,14 @@
   </div>
   <table class="table table-bordered">
     <tbody>
+      <% if current_user.admin? %>
       <tr>
         <th><%= t 'blacklight.search.fields.depositor' %></th>
         <td itemprop="accountablePerson" itemscope itemtype="http://schema.org/Person">
           <span itemprop="name"><%= link_to_profile @presenter.depositor %></span>
         </td>
       </tr>
+      <% end %>
 
       <tr>
         <th><%= t 'blacklight.search.fields.date_uploaded' %></th>
@@ -38,10 +40,12 @@
       </tr>
       <% end %>
 
+      <% if current_user.admin? %>
       <tr>
         <th><%= t 'blacklight.search.fields.original_checksum' %></th>
         <td><code><%= @presenter.original_checksum %></code></td>
       </tr>
+      <% end %>
     </tbody>
   </table>
 </div>

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -28,10 +28,12 @@
       </header>
 
       <%= render 'show_actions', presenter: @presenter if @presenter.editor? %>
-
       <%= render 'show_details' %>
-      <%= render 'fixity_information', presenter: @presenter %>
-      <%= render 'activity_log', events: @presenter.events %>
+
+      <% if current_user.admin? %>
+        <%= render 'fixity_information', presenter: @presenter %>
+        <%= render 'activity_log', events: @presenter.events %>
+      <% end %>
     </div><!-- /columns second -->
   </div> <!-- /.row -->
 </div><!-- /.container-fluid -->

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -30,7 +30,7 @@
       <%= render 'show_actions', presenter: @presenter if @presenter.editor? %>
       <%= render 'show_details' %>
 
-      <% if current_user.admin? %>
+      <% if current_user&.admin? %>
         <%= render 'fixity_information', presenter: @presenter %>
         <%= render 'activity_log', events: @presenter.events %>
       <% end %>


### PR DESCRIPTION
we've decided that fixity info/checksums won't be useful for most of our users, so they're hidden to all but admins.

## general users (file_set view)

![Screen Shot 2019-10-03 at 10 06 35 AM](https://user-images.githubusercontent.com/2744987/66134049-af11ad00-e5c5-11e9-8459-ba7579379c02.png)

## admin users (file_set view)

![Screen Shot 2019-10-03 at 10 06 55 AM](https://user-images.githubusercontent.com/2744987/66134071-b5a02480-e5c5-11e9-8739-b5d157bd5828.png)

----

closes #210 
