### PR TITLE
add override to fix i18n labels in hyrax/my/collections_controller

### DIFF
--- a/config/initializers/hyrax_overrides.rb
+++ b/config/initializers/hyrax_overrides.rb
@@ -30,4 +30,19 @@ Rails.application.config.to_prepare do
 
   # see above
   Hyrax::ContactFormController.class_eval { layout 'hyrax' }
+
+  # the dashboard/my/collections (+ thus, dashboard/collections) controller defines
+  # blacklight facets + uses I18n.t to provide a label. as we've found from past experience,
+  # this can get called _before_ all of the locales are loaded, resulting in a
+  # "translation missing" message being provided as a fall-back label. this should
+  # prevent that error from appearing by replacing the +translate+ calls with a symbolized
+  # I18n key (see also 0717dee, + catalog_controller.rb)
+  Hyrax::My::CollectionsController.class_eval do
+    def self.update_facet_labels
+      blacklight_config.facet_fields['visibility_ssi'].label = :'hyrax.dashboard.my.heading.visibility'
+      blacklight_config.facet_fields[Collection.collection_type_gid_document_field_name].label = :'hyrax.dashboard.my.heading.collection_type'
+      blacklight_config.facet_fields['has_model_ssim'].label = :'hyrax.dashboard.my.heading.collection_type'
+    end
+    update_facet_labels
+  end
 end


### PR DESCRIPTION
similar to 0717dee, this updates how the facet labels are defined in the `Hyrax::My::CollectionsController` so that the labels aren't displaying "translation missing" errors (see below)

<img width="1155" alt="Screen Shot 2019-10-08 at 11 39 30 AM" src="https://user-images.githubusercontent.com/2744987/66410658-7c4e2700-e9c0-11e9-8806-57b08eb5c190.png">
