### PR TITLE
update newspaper/magazine mappers

### DIFF
--- a/app/services/spot/mappers/magazine_mapper.rb
+++ b/app/services/spot/mappers/magazine_mapper.rb
@@ -38,7 +38,7 @@ module Spot::Mappers
     #
     # @return [Array<String>]
     def date_issued
-      metadata['PartDate_ISO8601'].map do |raw|
+      metadata.fetch('PartDate_ISO8601', []).map do |raw|
         short_date_to_iso(raw, century_threshold: 30)
       end
     end
@@ -47,9 +47,9 @@ module Spot::Mappers
     #
     # @return [Array<String>]
     def identifier
-      metadata['PublicationSequence']
-        .map { |num| "lafayette_magazine:#{num}" }
-        .concat(legacy_url_identifiers)
+      metadata.fetch('PublicationSequence', [])
+              .map { |num| "lafayette_magazine:#{num}" }
+              .concat(legacy_url_identifiers)
     end
 
     # @return [Array<String>]
@@ -89,7 +89,7 @@ module Spot::Mappers
     #
     # @return [Array<RDF::Literal>]
     def subtitle
-      metadata['TitleInfoSubtitle'].reject(&:blank?).map do |subtitle|
+      metadata.fetch('TitleInfoSubtitle', []).reject(&:blank?).map do |subtitle|
         RDF::Literal(subtitle, language: :en)
       end
     end
@@ -105,7 +105,7 @@ module Spot::Mappers
 
     # @return [Array<RDF::Literal>]
     def title_alternative
-      metadata['TitleInfoPartNumber'].reject(&:blank?).map do |alt|
+      metadata.fetch('TitleInfoPartNumber', []).reject(&:blank?).map do |alt|
         RDF::Literal(alt, language: :en)
       end
     end
@@ -116,7 +116,20 @@ module Spot::Mappers
       def legacy_url_identifiers
         representative_files.map do |file|
           key = File.basename(file, '.pdf').tr('_', '-')
-          "url:http://digital.lafayette.edu/collections/magazine/#{key}"
+          url = "http://digital.lafayette.edu/collections/magazine/#{key}"
+          "url:#{url}" if url_valid?(url)
+        end.compact
+      end
+
+      # We should probably be checking that the URLs we're adding are valid.
+      #
+      # @param [String]
+      # @return [true, false]
+      def url_valid?(url)
+        begin
+          Faraday::Connection.new.head(url) { |req| req.options.timeout = 5 }.success?
+        rescue
+          false
         end
       end
 

--- a/app/services/spot/mappers/magazine_mapper.rb
+++ b/app/services/spot/mappers/magazine_mapper.rb
@@ -126,11 +126,9 @@ module Spot::Mappers
       # @param [String]
       # @return [true, false]
       def url_valid?(url)
-        begin
-          Faraday::Connection.new.head(url) { |req| req.options.timeout = 5 }.success?
-        rescue
-          false
-        end
+        Faraday::Connection.new.head(url) { |req| req.options.timeout = 5 }.success?
+      rescue
+        false
       end
 
       # The display title is a combination of the `TitleInfoNonSort`,

--- a/app/services/spot/mappers/newspaper_mapper.rb
+++ b/app/services/spot/mappers/newspaper_mapper.rb
@@ -69,7 +69,7 @@ module Spot::Mappers
     def location_attributes
       nested_attributes_hash_for('dc:coverage') do |place|
         case place
-        when 'United States, Pennsylvania, Northampton County, Easton'
+        when 'United States, Pennsylvania, Northampton County, Easton', 'Easton, PA'
           'http://sws.geonames.org/5188140/'
         else
           Rails.logger.warn("No URI provided for #{place}; skipping")

--- a/app/services/spot/mappers/newspaper_mapper.rb
+++ b/app/services/spot/mappers/newspaper_mapper.rb
@@ -33,7 +33,7 @@ module Spot::Mappers
 
     # @return [Array<String>]
     def date_issued
-      metadata['date_issued'].map { |raw| Date.parse(raw).strftime('%Y-%m-%d') }
+      metadata.fetch('date_issued', []).map { |raw| Date.parse(raw).strftime('%Y-%m-%d') }
     end
 
     # @return [String, nil]
@@ -43,7 +43,7 @@ module Spot::Mappers
 
     # @return [Array<RDF::Literal>]
     def description
-      metadata['dc:description'].reject(&:blank?).map do |desc|
+      metadata.fetch('dc:description', []).reject(&:blank?).map do |desc|
         RDF::Literal(desc, language: :en)
       end
     end
@@ -85,10 +85,10 @@ module Spot::Mappers
 
     # @return [Array<RDF::Literal>]
     def title
-      metadata['dc:title']
-        .zip(date_issued)
-        .map { |(title, date)| "#{title} - #{Date.edtf(date).humanize}" }
-        .map { |title| RDF::Literal(title, language: :en) }
+      metadata.fetch('dc:title', [])
+              .zip(date_issued)
+              .map { |(title, date)| "#{title} - #{Date.edtf(date).humanize}" }
+              .map { |title| RDF::Literal(title, language: :en) }
     end
   end
 end

--- a/app/services/spot/mappers/newspaper_mapper.rb
+++ b/app/services/spot/mappers/newspaper_mapper.rb
@@ -54,9 +54,15 @@ module Spot::Mappers
     #
     # @return [Array<String>]
     def identifier
-      metadata['dc:identifier']
-        .map { |id| id.include?('cdm.lafayette.edu') ? "url:#{id}" : "lafayette:#{id}" }
-        .push("url:#{metadata['url'].first}")
+      return [] unless metadata['dc:identifier'] || metadata['url']
+
+      ids = metadata.fetch('dc:identifier', []).map do |id|
+        id.include?('cdm.lafayette.edu') ? "url:#{id}" : "lafayette:#{id}"
+      end
+
+      return ids unless metadata['url'].present?
+
+      ids.push("url:#{metadata['url'].first}")
     end
 
     # @return [Array<RDF::URI,String>]

--- a/spec/services/spot/mappers/magazine_mapper_spec.rb
+++ b/spec/services/spot/mappers/magazine_mapper_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe Spot::Mappers::MagazineMapper do
   end
 
   describe '#identifier' do
+    subject { mapper.identifier }
+
     before do
       stub_request(:head, url)
       stub_request(:head, 'http://digital.lafayette.edu/collections/magazine/none-such-magazine')
         .to_return(status: 404)
     end
-
-    subject { mapper.identifier }
 
     let(:url) { 'http://digital.lafayette.edu/collections/magazine/lafalummag-20190800' }
     let(:metadata) do

--- a/spec/services/spot/mappers/newspaper_mapper_spec.rb
+++ b/spec/services/spot/mappers/newspaper_mapper_spec.rb
@@ -72,6 +72,24 @@ RSpec.describe Spot::Mappers::NewspaperMapper do
     it { is_expected.to include 'lafayette:islandora:37462' }
     it { is_expected.to include 'url:http://cdm.lafayette.edu/u?/newspaper,30151' }
     it { is_expected.to include 'url:http://digital.lafayette.edu/collections/newspaper/18700901' }
+
+    context 'when only dc:identifier is present' do
+      let(:metadata) { { 'dc:identifier' => ['islandora:37462'] } }
+
+      it { is_expected.to eq ['lafayette:islandora:37462'] }
+    end
+
+    context 'when only url is present' do
+      let(:metadata) { { 'url' => ['http://digital.lafayette.edu/collections/newspaper/18700901'] } }
+
+      it { is_expected.to eq ['url:http://digital.lafayette.edu/collections/newspaper/18700901'] }
+    end
+
+    context 'when no identifiers are present' do
+      let(:metadata) { {} }
+
+      it { is_expected.to eq [] }
+    end
   end
 
   describe '#keyword' do

--- a/spec/services/spot/mappers/newspaper_mapper_spec.rb
+++ b/spec/services/spot/mappers/newspaper_mapper_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Spot::Mappers::NewspaperMapper do
   let(:metadata) do
     {
       'dc:coverage' => ['United States, Pennsylvania, Northampton County, Easton'],
-      'dc:description' => ['Some informative words'],
       'dc:rights' => ['https://creativecommons.org/publicdomain/mark/1.0/']
     }
   end
@@ -37,6 +36,12 @@ RSpec.describe Spot::Mappers::NewspaperMapper do
     let(:metadata) { { 'date_issued' => ['1986-02-11T00:00:00Z'] } }
 
     it { is_expected.to eq ['1986-02-11'] }
+
+    context 'when no date_issued present' do
+      let(:metadata) { {} }
+
+      it { is_expected.to eq [] }
+    end
   end
 
   describe '#date_uploaded' do
@@ -54,9 +59,16 @@ RSpec.describe Spot::Mappers::NewspaperMapper do
   describe '#description' do
     subject { mapper.description }
 
+    let(:metadata) { { 'dc:description' => ['Some informative words'] } }
     let(:value) { [RDF::Literal('Some informative words', language: :en)] }
 
     it { is_expected.to eq value }
+
+    context 'when no description is present' do
+      let(:metadata) { {} }
+
+      it { is_expected.to eq [] }
+    end
   end
 
   describe '#identifier' do
@@ -141,5 +153,12 @@ RSpec.describe Spot::Mappers::NewspaperMapper do
     let(:value) { [RDF::Literal('A modern masterpiece', language: :en)] }
 
     it { is_expected.to eq [RDF::Literal('The Lafayette - August 14, 2019', language: :en)] }
+
+    # is this ideal?
+    context 'when no title is present' do
+      let(:metadata) { {} }
+
+      it { is_expected.to eq [] }
+    end
   end
 end

--- a/spec/services/spot/mappers/newspaper_mapper_spec.rb
+++ b/spec/services/spot/mappers/newspaper_mapper_spec.rb
@@ -15,11 +15,19 @@ RSpec.describe Spot::Mappers::NewspaperMapper do
   describe '#location_attributes' do
     subject(:location_attributes) { mapper.location_attributes }
 
+    let(:metadata) { { 'dc:coverage' => ['United States, Pennsylvania, Northampton County, Easton'] } }
+
     let(:expected_value) do
       { '0' => { 'id' => 'http://sws.geonames.org/5188140/' } }
     end
 
     it { is_expected.to eq expected_value }
+
+    context 'when "Easton, PA"' do
+      let(:metadata) { { 'dc:coverage' => ['Easton, PA'] } }
+
+      it { is_expected.to eq expected_value }
+    end
 
     context 'when location is not in our internal mapping' do
       let(:metadata) { { 'dc:coverage' => ['Coolsville, Daddy-O'] } }


### PR DESCRIPTION
in the batch of newspaper accruals, the `dc:identifier` field is not present (as those items haven't been put anywhere yet), so we need to account for that.

this also goes back and updates the newspaper + magazine mappers to be better equipped for handling missing metadata values (fails nicer)