### PR TITLE
add ingest user to "depositor" role

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -34,6 +34,9 @@ class Ability
 
       # can view the user dashboard
       can(:read, :dashboard)
+
+      # can add items to collections
+      can(:deposit, Collection)
     end
 
     # save some space by defining the Role abilities here

--- a/app/services/spot/importers/base/record_importer.rb
+++ b/app/services/spot/importers/base/record_importer.rb
@@ -45,6 +45,7 @@ module Spot::Importers::Base
         error_stream << empty_file_warning(attributes) if attributes[:remote_files].empty?
 
         work = work_class.new
+
         actor_env = Hyrax::Actors::Environment.new(work,
                                                    ability_for(attributes.delete(:depositor)),
                                                    attributes)
@@ -72,7 +73,8 @@ module Spot::Importers::Base
       #
       # @param [String] depositor_email
       # @return [Ability]
-      def ability_for(depositor_email = default_depositor_email)
+      def ability_for(depositor_email)
+        depositor_email ||= default_depositor_email
         Ability.new(find_or_create_depositor(email: depositor_email))
       end
 
@@ -100,15 +102,19 @@ module Spot::Importers::Base
 
       # @param [String] email
       # @return [User]
-      def find_or_create_depositor(email)
-        depositor = User.find_or_initialize_by(email: email)
+      def find_or_create_depositor(email:)
+        user = User.find_or_initialize_by(email: email)
 
-        if depositor.new_record?
-          depositor.roles << Role.find_by(name: 'depositor')
-          depositor.save(validate: false)
+        # add 'depositor' role to user if:
+        # - new record
+        # - not already a depositor
+        # - not an admin (can already deposit)
+        if user.new_record? || (!user.depositor? && !user.admin?)
+          user.roles << Role.find_by(name: 'depositor')
+          user.save(validate: false)
         end
 
-        depositor
+        user
       end
   end
 end

--- a/app/services/spot/importers/base/record_importer.rb
+++ b/app/services/spot/importers/base/record_importer.rb
@@ -72,9 +72,8 @@ module Spot::Importers::Base
       #
       # @param [String] depositor_email
       # @return [Ability]
-      def ability_for(depositor_email)
-        email = depositor_email ||= default_depositor_email
-        Ability.new(find_or_create_depositor(email: email))
+      def ability_for(depositor_email = default_depositor_email)
+        Ability.new(find_or_create_depositor(email: depositor_email))
       end
 
       # @return [Hash<String => Hash<String => String>>]

--- a/spec/support/shared_examples/record_importer.rb
+++ b/spec/support/shared_examples/record_importer.rb
@@ -15,6 +15,10 @@ RSpec.shared_examples 'a RecordImporter' do |params|
   let(:error_stream) { dev_null }
   let(:collection_id) { 'collection123' }
 
+  # ensure that the role exists
+  before(:all) { Role.find_or_create_by(name: 'depositor') }
+  after(:all) { Role.find_by(name: 'depositor')&.destroy! }
+
   describe '#import' do
     subject(:import_record!) { importer.import(record: record) }
 


### PR DESCRIPTION
- adds `Role.find_by(name: 'depositor')` to a newly-created ingest user, where applicable
- allows `"depositor"` users to add items to collections

**should** fix a bug where ingested items weren't being added to collections because they failed the `can?(:deposit, Collection)` check in [`Hyrax::Actors::CollectionsMembershipActor`]

[`Hyrax::Actors::CollectionsMembershipActor`]: https://github.com/samvera/hyrax/blob/v2.6.0/app/actors/hyrax/actors/collections_membership_actor.rb#L108