### PR TITLE
use correct browse-collections link

### DIFF
--- a/app/views/spot/homepage/_featured_collections.html.erb
+++ b/app/views/spot/homepage/_featured_collections.html.erb
@@ -1,6 +1,7 @@
 <% if presenter.featured_collections.present? %>
 <div id="featured-collections" class="container-fluid">
-  <h2><%= t('.title') %></h2>
+  <h2><%= t(".title_#{presenter.featured_collections.size > 1 ? 'plural' : 'singular'}") %></h2>
+  <p class="lead"><%= t('.browse_html', url: browse_collections_path).html_safe %></p>
   <% presenter.featured_collections.each do |collection| %>
     <%= render 'featured_collection_item', collection: collection %>
   <% end %>

--- a/app/views/spot/homepage/_featured_collections.html.erb
+++ b/app/views/spot/homepage/_featured_collections.html.erb
@@ -1,7 +1,6 @@
 <% if presenter.featured_collections.present? %>
 <div id="featured-collections" class="container-fluid">
   <h2><%= t('.title') %></h2>
-  <p class="lead"><%= t('.browse_html').html_safe %></p>
   <% presenter.featured_collections.each do |collection| %>
     <%= render 'featured_collection_item', collection: collection %>
   <% end %>

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -49,7 +49,9 @@ en:
         page_title: Welcome to the %{name}
 
       featured_collections:
-        title: Featured Collections
+        title_singular: Featured Collection
+        title_plural: Featured Collections
+        browse_html: '<a href="%{url}">Click here</a> to browse all collections'
         collection:
           view: View Collection
           learn_more: Learn More

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -50,7 +50,6 @@ en:
 
       featured_collections:
         title: Featured Collections
-        browse_html: '<a href="https://dss.lafayette.edu/collections" target="_blank">Click here</a> to browse all collections'
         collection:
           view: View Collection
           learn_more: Learn More


### PR DESCRIPTION
nevermind that first commit 😊 this changes the link found under the "featured collections" title (now updated to be singular/plural) to point at the `browse_collections_path` url rather than the dss.lafayette.edu/collections one.

closes #322 