### PR TITLE
2019.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # changelog
 
+## [2019.4] - 2019-11-10
+
+### features
+
+- adds title_sort_si field to Publication and Collection Solr documents and adds the sort option to the catalog_controller.rb (#328)
+
+### bug fixes 🐞
+
+- use the browse_collections_link in featured collection portion of the homepage (#325)
+- use the correct hyrax layout in the contact form (previously was displaying w/o navbar) (#324)
+- update the resource_type local authority to match what's listed on the metadata application profile (#326)
+
+### notes 🗒
+
+because of the added solr field, this will require a reindexing.
+
 ## [2019.3] - 2019-11-04
 
 ### features
@@ -117,6 +133,7 @@ fixes:
 
 Initial pre-release (live on ldr.stage.lafayette.edu)
 
+[2019.4]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2019.4
 [2019.3]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2019.3
 [2019.2]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2019.2
 [2019.1]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2019.1

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -252,6 +252,8 @@ class CatalogController < ApplicationController
     config.add_sort_field 'date_issued_sort_dtsi desc', label: "Issue Date \u25BC"
     config.add_sort_field 'system_create_dtsi asc', label: "Date Added \u25B2"
     config.add_sort_field 'system_create_dtsi desc', label: "Date Added \u25BC"
+    config.add_sort_field 'title_sort_si asc', label: "Title \u25B2"
+    config.add_sort_field 'title_sort_si desc', label: "Title \u25BC"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/indexers/publication_indexer.rb
+++ b/app/indexers/publication_indexer.rb
@@ -17,6 +17,8 @@ class PublicationIndexer < Hyrax::WorkIndexer
   # @return [Hash]
   def generate_solr_document
     super.tap do |solr_doc|
+      solr_doc['title_sort_si'] = object.title.first.to_s.downcase
+
       store_license(solr_doc)
       store_years_encompassed(solr_doc)
       store_full_text_content(solr_doc)

--- a/app/indexers/spot/collection_indexer.rb
+++ b/app/indexers/spot/collection_indexer.rb
@@ -7,6 +7,8 @@ module Spot
 
     def generate_solr_document
       super.tap do |doc|
+        doc['title_sort_si'] = object.title.first.to_s.downcase
+
         if (slug_id = object.identifier.find { |id| id.start_with? 'slug:' })
           doc['collection_slug_ssi'] = Spot::Identifier.from_string(slug_id).value
         end

--- a/app/views/spot/homepage/_featured_collections.html.erb
+++ b/app/views/spot/homepage/_featured_collections.html.erb
@@ -1,7 +1,7 @@
 <% if presenter.featured_collections.present? %>
 <div id="featured-collections" class="container-fluid">
-  <h2><%= t('.title') %></h2>
-  <p class="lead"><%= t('.browse_html').html_safe %></p>
+  <h2><%= t(".title_#{presenter.featured_collections.size > 1 ? 'plural' : 'singular'}") %></h2>
+  <p class="lead"><%= t('.browse_html', url: browse_collections_path).html_safe %></p>
   <% presenter.featured_collections.each do |collection| %>
     <%= render 'featured_collection_item', collection: collection %>
   <% end %>

--- a/config/authorities/resource_types.yml
+++ b/config/authorities/resource_types.yml
@@ -1,41 +1,20 @@
 terms:
-  - id: Article
-    term: Article
-  - id: Audio
-    term: Audio
-  - id: Book
-    term: Book
-  - id: Capstone Project
-    term: Capstone Project
-  - id: Conference Proceeding
-    term: Conference Proceeding
-  - id: Dataset
-    term: Dataset
-  - id: Dissertation
-    term: Dissertation
-  - id: Image
-    term: Image
-  - id: Journal
-    term: Journal
-  - id: Map or Cartographic Material
-    term: Map or Cartographic Material
-  - id: Masters Thesis
-    term: Masters Thesis
-  - id: Part of Book
-    term: Part of Book
-  - id: Poster
-    term: Poster
-  - id: Presentation
-    term: Presentation
-  - id: Project
-    term: Project
-  - id: Report
-    term: Report
-  - id: Research Paper
-    term: Research Paper
-  - id: Software or Program Code
-    term: Software or Program Code
-  - id: Video
-    term: Video
-  - id: Other
-    term: Other
+  - Article
+  - Audio
+  - Book
+  - Conference Proceedings
+  - Dataset
+  - Image
+  - Periodicial
+  - Map or Cartographic Material
+  - Part of Book
+  - Poster
+  - Postcard
+  - Presentation
+  - Project
+  - Report
+  - Research Paper
+  - Software or Program Code
+  - Transcript
+  - Video
+  - Other

--- a/config/initializers/hyrax_overrides.rb
+++ b/config/initializers/hyrax_overrides.rb
@@ -14,7 +14,7 @@ Rails.application.config.to_prepare do
   ]
 
   # see above
-  Hyrax::ContactFormController.class_eval { layout 'hyrax' }
+  Hyrax::ContactFormController.class_eval { layout 'hyrax/1_column' }
 
   # the dashboard/my/collections (+ thus, dashboard/collections) controller defines
   # blacklight facets + uses I18n.t to provide a label. as we've found from past experience,

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -49,8 +49,9 @@ en:
         page_title: Welcome to the %{name}
 
       featured_collections:
-        title: Featured Collections
-        browse_html: '<a href="https://dss.lafayette.edu/collections" target="_blank">Click here</a> to browse all collections'
+        title_singular: Featured Collection
+        title_plural: Featured Collections
+        browse_html: '<a href="%{url}">Click here</a> to browse all collections'
         collection:
           view: View Collection
           learn_more: Learn More

--- a/spec/indexers/publication_indexer_spec.rb
+++ b/spec/indexers/publication_indexer_spec.rb
@@ -190,4 +190,10 @@ RSpec.describe PublicationIndexer do
       expect(solr_doc['extracted_text_tsimv']).to eq expected_results
     end
   end
+
+  describe 'title sort' do
+    it 'indexes the first title, downcased' do
+      expect(solr_doc['title_sort_si']).to eq work.title.first.to_s.downcase
+    end
+  end
 end

--- a/spec/indexers/spot/collection_indexer_spec.rb
+++ b/spec/indexers/spot/collection_indexer_spec.rb
@@ -9,7 +9,13 @@ RSpec.describe Spot::CollectionIndexer do
   # shared example requires that variable.
   let(:work) { Collection.new(metadata) }
   let(:indexer) { described_class.new(work) }
-  let(:metadata) { {} }
+  let(:metadata) { { title: ['A Great Collection'] } }
 
   it_behaves_like 'it indexes ISO language and label'
+
+  describe 'title sort' do
+    it 'indexes the first title, downcased' do
+      expect(solr_doc['title_sort_si']).to eq work.title.first.to_s.downcase
+    end
+  end
 end


### PR DESCRIPTION
- adds `title_sort_si` field to Publication and Collection Solr documents and adds the sort option to the `catalog_controller.rb` (#328)

## bug fixes 🐞 

- use the `browse_collections_link` in featured collection portion of the homepage (#325)
- use the correct hyrax layout in the contact form (previously was displaying w/o navbar) (#324)
- update the resource_type local authority to match what's listed on the metadata application profile (#326)

## notes 🗒 

because of the added solr field, this will require a reindexing.

---------

closes #307 
closes #322 