### PR TITLE
update Publication#resource_type to allow {0,n} values 

### DIFF
--- a/app/assets/stylesheets/spot.scss
+++ b/app/assets/stylesheets/spot.scss
@@ -75,3 +75,7 @@
   overflow: visible !important;
   padding-bottom: 0;
 }
+
+select[multiple] {
+  min-height: 15rem;
+}

--- a/app/forms/hyrax/publication_form.rb
+++ b/app/forms/hyrax/publication_form.rb
@@ -127,7 +127,6 @@ module Hyrax
           abstract
           date_issued
           date_available
-          resource_type
           title
         ]
       end

--- a/spec/forms/hyrax/publication_form_spec.rb
+++ b/spec/forms/hyrax/publication_form_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Hyrax::PublicationForm do
 
   describe '.multiple?' do
     it 'marks singular fields as false' do
-      %w[resource_type abstract issued available date_created title].each do |f|
+      %w[abstract issued available date_created title].each do |f|
         expect(described_class.multiple?(f)).to be false
       end
     end


### PR DESCRIPTION
we were previously enforcing a `{0,1}` allowance for the field while still using the hyrax input element which provided `{0,n}` and was being missed by the form's attribute handling

closes #332 