### PR TITLE
use scss image-url function for assets

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,7 +23,7 @@
 //= require blacklight_range_limit
 
 .ui-autocomplete-loading {
-  background: #fff url("/assets/spinner-24.gif") right center no-repeat;
+  background: #fff image-url("spinner-24.gif") right center no-repeat;
 }
 
 .work-show dd {


### PR DESCRIPTION
fixes a not-found error for `/assets/spinner-24.gif` (need to add the hash suffix)