### PR TITLE
update lafayette_departments to match publication profile

### DIFF
--- a/config/authorities/lafayette_departments.yml
+++ b/config/authorities/lafayette_departments.yml
@@ -1,5 +1,5 @@
 terms:
-  # academic departments
+  - Administrative Content
   - Africana Studies
   - Anthropology & Sociology
   - Art
@@ -22,20 +22,6 @@ terms:
   - Music
   - Philosophy
   - Physics
-  - Policy Studies
   - Psychology
   - Religious Studies
   - Theater
-  
-  # administrative content
-  - Communication
-  - Development
-  - Facility Planning and Construction
-  - Finance and Administration
-  - Office of Institutional Research
-  - Office of Student Development
-  - Office of the Registrar
-  - Parent Relations
-  - President's Office
-  - Provost's Office
-  - Public Safety


### PR DESCRIPTION
looks like the departments authority yaml file was last updated in December 2017 (see e8de451) and never got the memo about collapsing the administrative things into a single department.