### PR TITLE
2019.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # changelog
 
+## [2019.6] - 2019-11-13
+
+### bug fixes 🐞
+
+- uses the `image-url` scss function for the hashed asset path for a spinner gif (#340)
+- updates the `lafayette_departments` local authority file to use the departments defined in the publication metadata profile (#341)
+- adds `location_attributes` to the PublicationForm's permitted parameters array (#337)
+
 ## [2019.5] - 2019-11-11
 
-## bug fixes 🐞
+### bug fixes 🐞
 
 - update `Hyrax::PublicationForm` to allow `{0,n}` values (#333)
 - have `ErrorController` handle `txt` and `json` formats in a really basic manner (#335)
@@ -140,6 +148,7 @@ fixes:
 
 Initial pre-release (live on ldr.stage.lafayette.edu)
 
+[2019.6]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2019.6
 [2019.5]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2019.5
 [2019.4]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2019.4
 [2019.3]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2019.3

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,7 +23,7 @@
 //= require blacklight_range_limit
 
 .ui-autocomplete-loading {
-  background: #fff url("/assets/spinner-24.gif") right center no-repeat;
+  background: #fff image-url("spinner-24.gif") right center no-repeat;
 }
 
 .work-show dd {

--- a/app/forms/hyrax/publication_form.rb
+++ b/app/forms/hyrax/publication_form.rb
@@ -105,6 +105,12 @@ module Hyrax
     end
 
     class << self
+      def build_permitted_params
+        super.tap do |params|
+          params << { location_attributes: [:id, :_destroy] }
+        end
+      end
+
       # samvera/hydra-editor uses both the class method (new form) and
       # instance method (edit form) versions of this method, so we need
       # to provide both (otherwise we're head-first down a rabbit hole

--- a/config/authorities/lafayette_departments.yml
+++ b/config/authorities/lafayette_departments.yml
@@ -1,5 +1,5 @@
 terms:
-  # academic departments
+  - Administrative Content
   - Africana Studies
   - Anthropology & Sociology
   - Art
@@ -22,20 +22,6 @@ terms:
   - Music
   - Philosophy
   - Physics
-  - Policy Studies
   - Psychology
   - Religious Studies
   - Theater
-  
-  # administrative content
-  - Communication
-  - Development
-  - Facility Planning and Construction
-  - Finance and Administration
-  - Office of Institutional Research
-  - Office of Student Development
-  - Office of the Registrar
-  - Parent Relations
-  - President's Office
-  - Provost's Office
-  - Public Safety

--- a/spec/forms/hyrax/publication_form_spec.rb
+++ b/spec/forms/hyrax/publication_form_spec.rb
@@ -70,12 +70,6 @@ RSpec.describe Hyrax::PublicationForm do
     end
   end
 
-  describe '.build_permitted_params' do
-    subject { described_class.build_permitted_params }
-
-    it { is_expected.to be_an Array }
-  end
-
   describe '.model_attributes' do
     subject(:attributes) { described_class.model_attributes(raw_params) }
 
@@ -130,5 +124,77 @@ RSpec.describe Hyrax::PublicationForm do
         it { is_expected.not_to be_nil, "Hint missing for Publication##{term}" }
       end
     end
+  end
+
+  describe '.build_permitted_params' do
+    subject(:params) { described_class.build_permitted_params }
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'includes permitted fields' do
+      expect(params).to include(:title)
+      expect(params).to include(subtitle: [])
+      expect(params).to include(title_alternative: [])
+      expect(params).to include(creator: [])
+      expect(params).to include(contributor: [])
+      expect(params).to include(editor: [])
+      expect(params).to include(publisher: [])
+      expect(params).to include(source: [])
+      expect(params).to include(academic_department: [])
+      expect(params).to include(division: [])
+      expect(params).to include(organization: [])
+      expect(params).to include(:abstract)
+      expect(params).to include(description: [])
+      expect(params).to include(note: [])
+      expect(params).to include(:date_issued)
+      expect(params).to include(:date_available)
+      expect(params).to include(resource_type: [])
+      expect(params).to include(physical_medium: [])
+      expect(params).to include(language: [])
+      expect(params).to include(subject: [])
+      expect(params).to include(keyword: [])
+      expect(params).to include(bibliographic_citation: [])
+      expect(params).to include(standard_identifier: [])
+      expect(params).to include(local_identifier: [])
+      expect(params).to include(related_resource: [])
+      expect(params).to include(:rights_statement)
+      expect(params).to include(:representative_id)
+      expect(params).to include(:thumbnail_id)
+      expect(params).to include(rendering_ids: [])
+      expect(params).to include(files: [])
+      expect(params).to include(:visibility_during_embargo)
+      expect(params).to include(:embargo_release_date)
+      expect(params).to include(:visibility_after_embargo)
+      expect(params).to include(:visibility_during_lease)
+      expect(params).to include(:lease_expiration_date)
+      expect(params).to include(:visibility_after_lease)
+      expect(params).to include(:visibility)
+      expect(params).to include(ordered_member_ids: [])
+      expect(params).to include(in_works_ids: [])
+      expect(params).to include(member_of_collection_ids: [])
+      expect(params).to include(:admin_set_id)
+      expect(params).to include(permissions_attributes: [:type, :name, :access, :id, :_destroy])
+      expect(params).to include(:on_behalf_of)
+      expect(params).to include(:version)
+      expect(params).to include(:add_works_to_collection)
+      expect(params).to include(
+        based_near_attributes: [:id, :_destroy],
+        member_of_collections_attributes: [:id, :_destroy],
+        work_members_attributes: [:id, :_destroy]
+      )
+      expect(params).to include(standard_identifier_prefix: [], standard_identifier_value: [])
+      expect(params).to include(local_identifier: [])
+      expect(params).to include(:title_value)
+      expect(params).to include(:title_language)
+      expect(params).to include(title_alternative_value: [], title_alternative_language: [])
+      expect(params).to include(subtitle_value: [], subtitle_language: [])
+      expect(params).to include(:abstract_value)
+      expect(params).to include(:abstract_language)
+      expect(params).to include(description_value: [], description_language: [])
+      expect(params).to include(language_attributes: [:id, :_destroy])
+      expect(params).to include(academic_department_attributes: [:id, :_destroy])
+      expect(params).to include(division_attributes: [:id, :_destroy])
+      expect(params).to include(location_attributes: [:id, :_destroy])
+    end
+    # rubocop:enable RSpec/ExampleLength
   end
 end


### PR DESCRIPTION
## bug fixes 🐞 

- uses the `image-url` scss function for the hashed asset path for a spinner gif (#340)
- updates the `lafayette_departments` local authority file to use the departments defined in the publication metadata profile (#341)
- adds `location_attributes` to the PublicationForm's permitted parameters array (#337)

----

closes #336