### PR TITLE
add service/job to clear expired embargoes + leases

### DIFF
--- a/app/jobs/clear_expired_embargoes_and_leases_job.rb
+++ b/app/jobs/clear_expired_embargoes_and_leases_job.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class ClearExpiredEmbargoesAndLeasesJob < ApplicationJob
+  def perform
+    ::Spot::EmbargoLeaseService.clear_all_expired
+  end
+end

--- a/app/services/spot/embargo_lease_service.rb
+++ b/app/services/spot/embargo_lease_service.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+module Spot
+  # A service for dealing with embargoes and leases. Right now, we're just
+  # using this to clear out expired items.
+  #
+  # @example Clear out all expired values at once
+  #   Spot::EmbargoLeaseService.clear_all_expired
+  #
+  # @example Clear out expired embargoes (and update +date_available+ values)
+  #   Spot::EmbargoLeaseService.clear_expired_embargoes
+  #
+  # @example Clear out expired leases
+  #   Spot::EmbargoLeaseService.clear_expired_leases
+  #
+  class EmbargoLeaseService
+    class << self
+      # Convenience method to clear both embargoes and leases
+      #
+      # @return [void]
+      # @see {.clear_expired_embargoes}
+      # @see {.clear_expired_leases}
+      def clear_all_expired
+        clear_expired_embargoes && clear_expired_leases
+      end
+
+      # Clears out expired embargoes and sets the +date_available+ property
+      # to today's date.
+      #
+      # @return [void]
+      def clear_expired_embargoes
+        ::Hyrax::EmbargoService.assets_with_expired_embargoes.each do |presenter|
+          item = ActiveFedora::Base.find(presenter.id)
+
+          # set date available now; EmbargoActor saves the work, so we can prevent
+          # having to update the item twice
+          item.date_available = [Time.zone.now.strftime('%Y-%m-%d')]
+
+          ::Hyrax::Actors::EmbargoActor.new(item).destroy
+        end
+      end
+
+      # Clears out expired leases
+      #
+      # @return [void]
+      def clear_expired_leases
+        ::Hyrax::LeaseService.assets_with_expired_leases.each do |presenter|
+          item = ActiveFedora::Base.find(presenter.id)
+
+          ::Hyrax::Actors::LeaseActor.new(item).destroy
+        end
+      end
+    end
+  end
+end

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -4,6 +4,11 @@
 fixity_check_everything:
   # runs at midnight every Monday
   cron: '0 0 * * 1'
-  class: 'Spot::RepositoryFixityCheckJob'
+  class: Spot::RepositoryFixityCheckJob
   # @todo create a queue for fixity/cron jobs
+  queue: default
+
+clear_expired_embargoes_and_leases:
+  cron: '0 5 * * *'
+  class: ClearExpiredEmbargoesAndLeasesJob
   queue: default

--- a/spec/jobs/clear_expired_embargoes_and_leases_job_spec.rb
+++ b/spec/jobs/clear_expired_embargoes_and_leases_job_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+RSpec.describe ClearExpiredEmbargoesAndLeasesJob do
+  before do
+    allow(Spot::EmbargoLeaseService).to receive(:clear_all_expired)
+  end
+
+  it 'defers to the Spot::EmbargoLeaseService' do
+    described_class.perform_now
+
+    expect(Spot::EmbargoLeaseService).to have_received(:clear_all_expired).exactly(1).times
+  end
+end

--- a/spec/services/spot/embargo_lease_service_spec.rb
+++ b/spec/services/spot/embargo_lease_service_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+RSpec.describe Spot::EmbargoLeaseService do
+  let(:embargoed_presenter) { instance_double(Hyrax::WorkShowPresenter, id: 'abc123def') }
+  let(:leased_presenter) { instance_double(Hyrax::WorkShowPresenter, id: 'def456ghi') }
+  let(:embargoed_work) { instance_double(Publication) }
+  let(:leased_work) { instance_double(Publication) }
+  let(:embargoed_actor_double) { instance_double(Hyrax::Actors::EmbargoActor, destroy: true) }
+  let(:leased_actor_double) { instance_double(Hyrax::Actors::LeaseActor, destroy: true) }
+  let(:todays_date) { Time.zone.now.strftime('%Y-%m-%d') }
+
+  before do
+    allow(Hyrax::EmbargoService)
+      .to receive(:assets_with_expired_embargoes)
+      .and_return([embargoed_presenter])
+
+    allow(Hyrax::LeaseService)
+      .to receive(:assets_with_expired_leases)
+      .and_return([leased_presenter])
+
+    allow(ActiveFedora::Base)
+      .to receive(:find)
+      .with(embargoed_presenter.id)
+      .and_return(embargoed_work)
+
+    allow(ActiveFedora::Base)
+      .to receive(:find)
+      .with(leased_presenter.id)
+      .and_return(leased_work)
+
+    allow(Hyrax::Actors::EmbargoActor)
+      .to receive(:new)
+      .with(embargoed_work)
+      .and_return(embargoed_actor_double)
+
+    allow(Hyrax::Actors::LeaseActor)
+      .to receive(:new)
+      .with(leased_work)
+      .and_return(leased_actor_double)
+
+    allow(embargoed_work).to receive(:date_available=)
+  end
+
+  describe '.clear_all_expired' do
+    it 'calls destroy on both the embargo + lease actors' do
+      described_class.clear_all_expired
+
+      expect(embargoed_work).to have_received(:date_available=).with([todays_date])
+      expect(embargoed_actor_double).to have_received(:destroy).exactly(1).time
+      expect(leased_actor_double).to have_received(:destroy).exactly(1).time
+    end
+  end
+end


### PR DESCRIPTION
hyrax provides the ability to embargo/lease works, but doesn't have a mechanism to automatically do so, so we need to build a service to do that, rather than have staff check + remove them manually. this wraps all of the needed hyrax service invocations needed to make that happen.

also, related to #352, this updates an embargoed work's `date_available` property to be the date of the released embargo date.