### PR TITLE
Publication#date_available modifications

### DIFF
--- a/app/actors/hyrax/actors/publication_actor.rb
+++ b/app/actors/hyrax/actors/publication_actor.rb
@@ -9,9 +9,42 @@ module Hyrax
         # Overrides the BaseActor method to allow us to stuff in
         # `date_uploaded` values where necessary.
         #
+        # @param [Hyrax::Actors::Environment] env
         # @return [void]
         def apply_deposit_date(env)
           env.curation_concern.date_uploaded = get_date_uploaded_value(env)
+        end
+
+        # Overrides the BaseActor method so that we can apply a +date_available+
+        # value to the item.
+        #
+        # @param [Hyrax::Actors::Environment] env
+        # @return [void]
+        # @see {#apply_date_available}
+        def apply_save_data_to_curation_concern(env)
+          super
+
+          apply_date_available(env)
+        end
+
+        # Allows us to apply a +date_available+ value to a work. The property
+        # is similar to +date_uploaded+, but accounts for embargoes where present.
+        # As the method calling this ({#apply_save_data_to_curation_concern}) is
+        # run on both +#create+ and +#update+, we'll skip this if the value has
+        # already been provided.
+        #
+        # @param [Hyrax::Actors::Environment] env
+        # @return [void]
+        def apply_date_available(env)
+          return unless env.curation_concern.date_available.empty?
+
+          embargo = env.curation_concern.embargo
+          env.curation_concern.date_available =
+            if embargo.present?
+              [embargo.embargo_release_date.strftime('%Y-%m-%d')]
+            else
+              [Time.zone.now.strftime('%Y-%m-%d')]
+            end
         end
 
         # @param [Hyrax::Actors::Environment] env

--- a/app/forms/hyrax/publication_form.rb
+++ b/app/forms/hyrax/publication_form.rb
@@ -35,7 +35,6 @@ module Hyrax
       :abstract,
       :description,
       :note,
-      :date_available,
       :physical_medium,
       :language,
       :subject,
@@ -89,11 +88,6 @@ module Hyrax
     # @return [String, RDF::Literal]
     def abstract
       self['abstract'].first
-    end
-
-    # @return [String]
-    def date_available
-      self['date_available'].first
     end
 
     # @return [String]

--- a/spec/actors/hyrax/actors/publication_actor_spec.rb
+++ b/spec/actors/hyrax/actors/publication_actor_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe Hyrax::Actors::PublicationActor do
   let(:attributes) { {} }
   let(:env) { Hyrax::Actors::Environment.new(work, ability, attributes) }
 
+  before { allow(work).to receive(:save) }
+
   describe '#apply_deposit_date' do
     before do
-      allow(work).to receive(:save)
       allow(Hyrax::TimeService).to receive(:time_in_utc).and_return(time_value)
     end
 
@@ -46,6 +47,42 @@ RSpec.describe Hyrax::Actors::PublicationActor do
           .to change { work.date_uploaded }
           .from(date_uploaded)
           .to(DateTime.parse(date_uploaded).utc)
+      end
+    end
+  end
+
+  describe '#apply_date_available' do
+    context 'when a date_available value is present' do
+      let(:attributes) { { date_available: ['2019-11-22'] } }
+
+      it 'does not update the value' do
+        expect { actor }.not_to change { work.date_available }
+      end
+    end
+
+    context 'when no date_available value is present and the work is not under embargo' do
+      let(:todays_date) { Time.zone.now.strftime('%Y-%m-%d') }
+
+      # no idea why the +expect { actor }.to change .....+ syntax keeps
+      # failing for this, but explicitly checking works?
+      it 'updates the value to today\'s date' do
+        expect(work.date_available).to eq []
+        actor
+        expect(work.date_available).to eq [todays_date]
+      end
+    end
+
+    context 'when an embargo is set for the work' do
+      before { allow(work).to receive(:embargo).and_return embargo }
+
+      let(:embargo) { instance_double(Hydra::AccessControls::Embargo, embargo_release_date: tomorrow_time) }
+      let(:tomorrow_time) { Time.zone.tomorrow }
+      let(:tomorrow) { tomorrow_time.strftime('%Y-%m-%d') }
+
+      it 'updates the value to match the embargo' do
+        expect(work.date_available).to eq []
+        actor
+        expect(work.date_available).to eq [tomorrow]
       end
     end
   end

--- a/spec/features/create_publication_spec.rb
+++ b/spec/features/create_publication_spec.rb
@@ -73,9 +73,6 @@ RSpec.feature 'Create a Publication', :clean, :js do
         fill_in 'Date issued', with: attrs[:date_issued].first
         expect(page).not_to have_css '.publication_date_issued .controls-add-text'
 
-        fill_in 'Date available', with: attrs[:date_available].first
-        expect(page).not_to have_css '.publication_date_available .controls-add-text'
-
         fill_in 'Creator', with: attrs[:creator].first
         expect(page).to have_css '.publication_creator .controls-add-text'
 

--- a/spec/forms/hyrax/publication_form_spec.rb
+++ b/spec/forms/hyrax/publication_form_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Hyrax::PublicationForm do
       it { is_expected.to include :standard_identifier }
       it { is_expected.to include :local_identifier }
       it { is_expected.to include :bibliographic_citation }
-      it { is_expected.to include :date_available }
       it { is_expected.to include :creator }
       it { is_expected.to include :contributor }
       it { is_expected.to include :editor }
@@ -143,7 +142,6 @@ RSpec.describe Hyrax::PublicationForm do
       expect(params).to include(description: [])
       expect(params).to include(note: [])
       expect(params).to include(:date_issued)
-      expect(params).to include(:date_available)
       expect(params).to include(resource_type: [])
       expect(params).to include(physical_medium: [])
       expect(params).to include(language: [])


### PR DESCRIPTION
drops `date_available` from the Publication form and instead updates it internally via `PublicationActor`

closes #352 