### PR TITLE
facet rights-statements using their shortcodes

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -98,6 +98,9 @@ class CatalogController < ApplicationController
                            include_in_advanced_search: false,
                            label: :'blacklight.search.fields.years_encompassed',
                            range: true
+    config.add_facet_field 'rights_statement_shortcode_ssim',
+                           label: :'blacklight.search.fields.rights_statement',
+                           limit: 5
 
     #
     # admin facets

--- a/app/services/spot/rights_statement_service.rb
+++ b/app/services/spot/rights_statement_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+module Spot
+  # Duplicates the work in +Hyrax::RightsStatementService+ and adds
+  # support for looking up a shortcode by an URI.
+  class RightsStatementService < ::Hyrax::QaSelectService
+    def initialize(_authority_name = nil)
+      super('rights_statements')
+    end
+
+    ##
+    # @param id [String]
+    #
+    # @return [String] the label for the authority
+    #
+    # @yield when no 'term' value is present for the id
+    # @yieldreturn [String] an alternate label to return
+    #
+    # @raise [KeyError] when no 'term' value is present for the id
+    def shortcode(id, &block)
+      authority.find(id).fetch('shortcode', &block)
+    end
+  end
+end

--- a/config/authorities/rights_statements.yml
+++ b/config/authorities/rights_statements.yml
@@ -1,64 +1,84 @@
 terms:
   # the Europeana 14
   -
-    term: Public Domain Mark (PDM)
+    term: Public Domain Mark
+    shortcode: PDM
     id: http://creativecommons.org/publicdomain/mark/1.0/
   -
-    term: No Copyright - non commercial re-use only (NoC-NC)
+    term: No Copyright - non commercial re-use only
+    shortcode: NoC-NC
     id: http://rightsstatements.org/vocab/NoC-NC/1.0/
   -
-    term: No Copyright - Other Known Legal Restriction (NoC-OKLR)
+    term: No Copyright - Other Known Legal Restriction
+    shortcode: NoC-OKLR
     id: http://rightsstatements.org/vocab/NoC-OKLR/1.0/
   -
-    term: Creative Commons CC0 1.0 Universal Public Domain Dedication (CC0)
+    term: Creative Commons CC0 1.0 Universal Public Domain Dedication
+    shortcode: CC0
     id: http://creativecommons.org/publicdomain/zero/1.0/
   -
-    term: Creative Commons - Attribution (BY)
+    term: Creative Commons - Attribution
+    shorcode: BY
     id: http://creativecommons.org/licenses/by/4.0/
   -
-    term: Creative Commons - Attribution, ShareAlike (BY-SA)
+    term: Creative Commons - Attribution, ShareAlike
+    shortcode: BY-SA
     id: http://creativecommons.org/licenses/by-sa/4.0/
   -
-    term: Creative Commons - Attribution, No Derivatives (BY-ND)
+    term: Creative Commons - Attribution, No Derivatives
+    shortcode: BY-ND
     id: http://creativecommons.org/licenses/by-nd/4.0/
   -
-    term: Creative Commons - Attribution, Non-Commercial (BY-NC)
+    term: Creative Commons - Attribution, Non-Commercial
+    shortcode: BY-NC
     id: http://creativecommons.org/licenses/by-nc/4.0/
   -
-    term: Creative Commons - Attribution, Non-Commercial, ShareAlike (BY-NC-SA)
+    term: Creative Commons - Attribution, Non-Commercial, ShareAlike
+    shortcode: BY-NC-SA
     id: http://creativecommons.org/licenses/by-nc-sa/4.0/
   -
-    term: Creative Commons - Attribution, Non-Commercial, No Derivatives (BY-NC-ND)
+    term: Creative Commons - Attribution, Non-Commercial, No Derivatives
+    shortcode: BY-NC-ND
     id:  http://creativecommons.org/licenses/by-nc-nd/4.0/
   -
-    term: In Copyright (InC)
+    term: In Copyright
+    shortcode: InC
     id: http://rightsstatements.org/vocab/InC/1.0/
   -
-    term: In Copyright - Educational Use Permitted (InC-EDU)
+    term: In Copyright - Educational Use Permitted
+    shortcode: InC-EDU
     id: http://rightsstatements.org/vocab/InC-EDU/1.0/
   -
-    term: In Copyright - EU Orphan Work (InC-EU-OW)
+    term: In Copyright - EU Orphan Work
+    shortcode: InC-EU-OW
     id: http://rightsstatements.org/vocab/InC-OW-EU/1.0/
   -
-    term: Copyright Not Evaluated (CNE)
+    term: Copyright Not Evaluated
+    shortcode: CNE
     id: http://rightsstatements.org/vocab/CNE/1.0/
 
   # our additional 6
   -
-    term: In Copyright - Non-Commercial Use Permitted (InC-NC)
+    term: In Copyright - Non-Commercial Use Permitted
+    shortcode: InC-NC
     id: http://rightsstatements.org/vocab/InC-NC/1.0/
   -
-    term: In Copyright - Rights-holder(s) Unlocatable or Unidentifiable (InC-RUU)
+    term: In Copyright - Rights-holder(s) Unlocatable or Unidentifiable
+    shortcode: InC-RUU
     id: http://rightsstatements.org/vocab/InC-RUU/1.0/
   -
-    term: No Copyright - Contractual Restrictions (NoC-CR)
+    term: No Copyright - Contractual Restrictions
+    shortcode: NoC-CR
     id: http://rightsstatements.org/vocab/NoC-CR/1.0/
   -
-    term: No Copyright - United States (NoC-US)
+    term: No Copyright - United States
+    shortcode: NoC-US
     id: http://rightsstatements.org/vocab/NoC-US/1.0/
   -
-    term: Copyright Undetermined (UND)
+    term: Copyright Undetermined
+    shortcode: UND
     id: http://rightsstatements.org/vocab/UND/1.0/
   -
-    term: No Known Copyright (NKC)
+    term: No Known Copyright
+    shortcode: NKC
     id: http://rightsstatements.org/vocab/NKC/1.0/

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -194,6 +194,9 @@ Hyrax.config do |config|
   #   @see Hyrax::LicenseService for implementation details
   # config.license_service_class = Hyrax::LicenseService
 
+  # A configuration point for changing the behavior of the rights statement service.
+  config.rights_statement_service_class = Spot::RightsStatementService
+
   # Labels for display of permission levels
   # config.permission_levels = { "View/Download" => "read", "Edit access" => "edit" }
 

--- a/spec/indexers/publication_indexer_spec.rb
+++ b/spec/indexers/publication_indexer_spec.rb
@@ -169,11 +169,6 @@ RSpec.describe PublicationIndexer do
     it_behaves_like 'simple model indexing'
   end
 
-  describe 'rights_statement' do
-    it { is_expected.to include 'rights_statement_ssim' }
-    it { is_expected.to include 'rights_statement_label_ssim' }
-  end
-
   describe 'location' do
     let(:label) { 'Easton, PA' }
     let(:uri) { 'http://sws.geonames.org/5188140/' }

--- a/spec/services/spot/rights_statement_service_spec.rb
+++ b/spec/services/spot/rights_statement_service_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+RSpec.describe Spot::RightsStatementService do
+  let(:service) { described_class.new }
+
+  describe '#shortcode' do
+    subject(:shortcode) { service.shortcode(uri) { fallback } }
+
+    let(:fallback) { 'none' }
+
+    context 'when a shortcode exists' do
+      let(:uri) { 'http://creativecommons.org/licenses/by-nc-sa/4.0/' }
+
+      it { is_expected.to eq 'BY-NC-SA' }
+    end
+
+    context 'when a shortcode does not exist' do
+      let(:uri) { 'http://no-dont-use-this.com' }
+
+      it { is_expected.to eq fallback }
+    end
+  end
+end

--- a/spec/support/shared_examples/indexing/indexes_rights_statements.rb
+++ b/spec/support/shared_examples/indexing/indexes_rights_statements.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'it indexes rights statements' do
+  subject { solr_document[key] }
+
+  let(:work_klass) { described_class.name.gsub(/Indexer$/, '').downcase.to_sym }
+  let(:work) { build(work_klass, rights_statement: rights_statement) }
+  let(:indexer) { described_class.new(work) }
+  let(:solr_document) { indexer.generate_solr_document }
+  let(:rights_statement) { ['http://creativecommons.org/publicdomain/zero/1.0/'] }
+
+  describe 'rights statement URIs' do
+    let(:key) { 'rights_statement_ssim' }
+
+    it { is_expected.to eq ['http://creativecommons.org/publicdomain/zero/1.0/'] }
+  end
+
+  describe 'rights statement labels' do
+    let(:key) { 'rights_statement_label_ssim' }
+
+    it { is_expected.to eq ['Creative Commons CC0 1.0 Universal Public Domain Dedication'] }
+  end
+
+  describe 'rights statement shortcodes' do
+    let(:key) { 'rights_statement_shortcode_ssim' }
+
+    it { is_expected.to eq ['CC0'] }
+  end
+end


### PR DESCRIPTION
adds indexing for license shortcodes (ex. "BY" for "Creative Commons - Attribution") and provides a facet field for them.