### PR TITLE
redirect to current page after sign-in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,7 +65,11 @@ class ApplicationController < ActionController::Base
     # > - The request is handled by a Devise controller such as Devise::SessionsController as that could cause an
     # >    infinite redirect loop.
     # > - The request is an Ajax request as this can lead to very unexpected behaviour.
+    #
+    # Also adds a check to ignore download paths (iframe requests made by an item
+    # viewer will take precedence over the user's last visited path).
     def storable_location?
+      return false if request.path.start_with? '/downloads'
       request.get? && is_navigational_format? && !devise_controller? && !request.xhr?
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
 
   with_themed_layout '1_column'
 
+  before_action :store_user_location!, if: :storable_location?
   before_action :log_in_as_dev_user!
 
   # from Blacklight: 'Discarding flash messages on XHR requests is deprecated.'
@@ -55,5 +56,25 @@ class ApplicationController < ActionController::Base
       return unless Rails.env.development? && (current_user || ENV.key?('DEV_USER'))
       user = User.find_by(email: ENV['DEV_USER'])
       sign_in(user) unless user.nil?
+    end
+
+    # Borrowed from the Devise wiki:
+    #
+    # > Its important that the location is NOT stored if:
+    # > - The request method is not GET (non idempotent)
+    # > - The request is handled by a Devise controller such as Devise::SessionsController as that could cause an
+    # >    infinite redirect loop.
+    # > - The request is an Ajax request as this can lead to very unexpected behaviour.
+    def storable_location?
+      request.get? && is_navigational_format? && !devise_controller? && !request.xhr?
+    end
+
+    def store_user_location!
+      # :user is the scope we are authenticating
+      store_location_for(:user, request.fullpath)
+    end
+
+    def after_sign_in_path_for(resource_or_scope)
+      stored_location_for(resource_or_scope) || super
     end
 end


### PR DESCRIPTION
follows the [devise wiki](https://github.com/plataformatec/devise/wiki/How-To:-Redirect-back-to-current-page-after-sign-in,-sign-out,-sign-up,-update) guide's instructions for redirecting back to the user's current page after signing in.

closes #280 