### PR TITLE
fix shortcode typo + add a preventative spec

### DIFF
--- a/config/authorities/rights_statements.yml
+++ b/config/authorities/rights_statements.yml
@@ -18,7 +18,7 @@ terms:
     id: http://creativecommons.org/publicdomain/zero/1.0/
   -
     term: Creative Commons - Attribution
-    shorcode: BY
+    shortcode: BY
     id: http://creativecommons.org/licenses/by/4.0/
   -
     term: Creative Commons - Attribution, ShareAlike

--- a/spec/services/spot/rights_statement_service_spec.rb
+++ b/spec/services/spot/rights_statement_service_spec.rb
@@ -19,4 +19,10 @@ RSpec.describe Spot::RightsStatementService do
       it { is_expected.to eq fallback }
     end
   end
+
+  describe 'all values have a shortcode' do
+    it do
+      expect(service.select_all_options.map(&:last).all? { |rs| service.shortcode(rs) }).to be true
+    end
+  end
 end


### PR DESCRIPTION
love a typo bug that causes 300 items to not be facetable by rights-statement 🙃

adds a spec to ensure that all rights_statement values in our authority have shortcodes as well 