### PR TITLE
reorder publication form fields

### DIFF
--- a/app/forms/hyrax/publication_form.rb
+++ b/app/forms/hyrax/publication_form.rb
@@ -17,33 +17,28 @@ module Hyrax
       :resource_type,
       :rights_statement,
 
-      # titles
       :subtitle,
       :title_alternative,
-
-      # provenance
       :creator,
       :contributor,
       :editor,
       :publisher,
       :source,
-      :academic_department,
-      :division,
-      :organization,
-
-      # description
-      :abstract,
-      :description,
-      :note,
-      :physical_medium,
-      :language,
-      :subject,
-      :keyword,
-      :location,
       :bibliographic_citation,
       :standard_identifier,
       :local_identifier,
+      :abstract,
+      :description,
+      :subject,
+      :keyword,
+      :language,
+      :physical_medium,
+      :location,
+      :note,
       :related_resource,
+      :academic_department,
+      :division,
+      :organization,
 
       # internal fields
       # These are Hyrax-specific fields that deal with embargoes,


### PR DESCRIPTION
now uses the following order (title through source remain the same):

> ... following Source:
> 
> Bib citn
> Std Identifier
> Local Identifier
> Abstract
> Description
> Subjects
> KWs
> Language
> Physical Medium
> Location
> Note
> Related Resource
> Academic Dept
> Division
> Organization