### PR TITLE
use pcdm:memberOf predicate for admin-sets

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -21,7 +21,7 @@ Hyrax.config do |config|
   # Which RDF term should be used to relate objects to an admin set?
   # If this is a new repository, you may want to set a custom predicate term here to
   # avoid clashes if you plan to use the default (dct:isPartOf) for other relations.
-  # config.admin_set_predicate = ::RDF::DC.isPartOf
+  config.admin_set_predicate = ::RDF::URI.new('http://pcdm.org/models#memberOf')
 
   # Email recipient of messages sent via the contact form
   config.contact_email = "dss@lafayette.edu"


### PR DESCRIPTION
changes the admin_set predicate from `dc:isPartOf` to `pcdm:memberOf`, allowing us to use the former for model properties