### PR TITLE
bugfix: embargo/lease visibility changes

### DIFF
--- a/app/services/spot/embargo_lease_service.rb
+++ b/app/services/spot/embargo_lease_service.rb
@@ -31,6 +31,8 @@ module Spot
         ::Hyrax::EmbargoService.assets_with_expired_embargoes.each do |presenter|
           item = ActiveFedora::Base.find(presenter.id)
 
+          next if item.under_embargo?
+
           ::Hyrax::Actors::EmbargoActor.new(item).destroy
 
           next if item.is_a? FileSet
@@ -47,6 +49,8 @@ module Spot
       def clear_expired_leases
         ::Hyrax::LeaseService.assets_with_expired_leases.each do |presenter|
           item = ActiveFedora::Base.find(presenter.id)
+
+          next if item.active_lease?
 
           ::Hyrax::Actors::LeaseActor.new(item).destroy
 

--- a/app/services/spot/embargo_lease_service.rb
+++ b/app/services/spot/embargo_lease_service.rb
@@ -33,11 +33,11 @@ module Spot
 
           ::Hyrax::Actors::EmbargoActor.new(item).destroy
 
-          unless item.is_a? FileSet
-            item.date_available = [Time.zone.now.strftime('%Y-%m-%d')] if item.respond_to?(:date_available=)
-            item.copy_visibility_to_files
-            item.save!
-          end
+          next if item.is_a? FileSet
+
+          item.date_available = [Time.zone.now.strftime('%Y-%m-%d')] if item.respond_to?(:date_available=)
+          item.copy_visibility_to_files
+          item.save!
         end
       end
 

--- a/app/services/spot/embargo_lease_service.rb
+++ b/app/services/spot/embargo_lease_service.rb
@@ -33,14 +33,11 @@ module Spot
 
           ::Hyrax::Actors::EmbargoActor.new(item).destroy
 
-          if item.file_set?
-            item.visibility = item.visibility_after_embargo
-          else
+          unless item.is_a? FileSet
             item.date_available = [Time.zone.now.strftime('%Y-%m-%d')] if item.respond_to?(:date_available=)
             item.copy_visibility_to_files
+            item.save!
           end
-
-          item.save!
         end
       end
 
@@ -52,6 +49,8 @@ module Spot
           item = ActiveFedora::Base.find(presenter.id)
 
           ::Hyrax::Actors::LeaseActor.new(item).destroy
+
+          item.copy_visibility_to_files unless item.is_a? FileSet
         end
       end
     end

--- a/app/views/hyrax/base/_repository_metadata.html.erb
+++ b/app/views/hyrax/base/_repository_metadata.html.erb
@@ -6,15 +6,17 @@
     <tbody>
       <%= presenter.attribute_to_html(:note) %>
       <%= presenter.attribute_to_html(:admin_set, render_as: :faceted, search_field: :admin_set_sim) %>
-      <%= presenter.attribute_to_html(:depositor, render_as: :faceted, search_field: :depositor_ssim) %>
-      <%= presenter.attribute_to_html(:date_created) %>
-      <%= presenter.attribute_to_html(:date_uploaded) %>
-      <%= presenter.attribute_to_html(:date_modified) %>
-      <%= presenter.attribute_to_html(:local_identifier, render_as: :identifier, local: true) %>
       <tr>
         <th>Workflow status</th>
         <td><%= presenter.workflow.badge %></td>
       </tr>
+      <%= presenter.attribute_to_html(:embargo_release_date) %>
+      <%= presenter.attribute_to_html(:lease_expiration_date) %>
+      <%= presenter.attribute_to_html(:local_identifier, render_as: :identifier, local: true) %>
+      <%= presenter.attribute_to_html(:depositor, render_as: :faceted, search_field: :depositor_ssim) %>
+      <%= presenter.attribute_to_html(:date_created) %>
+      <%= presenter.attribute_to_html(:date_uploaded) %>
+      <%= presenter.attribute_to_html(:date_modified) %>
     </tbody>
   </table>
 </div>

--- a/config/initializers/hyrax_overrides.rb
+++ b/config/initializers/hyrax_overrides.rb
@@ -76,7 +76,13 @@ Rails.application.config.to_prepare do
   # @see https://github.com/samvera/hydra-head/blob/v10.7.0/hydra-access-controls/app/models/hydra/access_controls/embargo.rb#L13-L15
   Hydra::AccessControls::Embargo.class_eval do
     def active?
-      (embargo_release_date.present? && DateTime.now < embargo_release_date)
+      embargo_release_date.present? && DateTime.now < embargo_release_date
+    end
+  end
+
+  Hydra::AccessControls::Lease.class_eval do
+    def active?
+      lease_expiration_date.present? && DateTime.now < lease_expiration_date
     end
   end
 end

--- a/config/initializers/hyrax_overrides.rb
+++ b/config/initializers/hyrax_overrides.rb
@@ -76,13 +76,13 @@ Rails.application.config.to_prepare do
   # @see https://github.com/samvera/hydra-head/blob/v10.7.0/hydra-access-controls/app/models/hydra/access_controls/embargo.rb#L13-L15
   Hydra::AccessControls::Embargo.class_eval do
     def active?
-      embargo_release_date.present? && DateTime.now < embargo_release_date
+      embargo_release_date.present? && DateTime.current < embargo_release_date
     end
   end
 
   Hydra::AccessControls::Lease.class_eval do
     def active?
-      lease_expiration_date.present? && DateTime.now < lease_expiration_date
+      lease_expiration_date.present? && DateTime.current < lease_expiration_date
     end
   end
 end

--- a/config/initializers/hyrax_overrides.rb
+++ b/config/initializers/hyrax_overrides.rb
@@ -61,4 +61,22 @@ Rails.application.config.to_prepare do
       @models - ['Image']
     end
   end
+
+  # By default, +Hydra::AccessControls::Embargo#active?+ compares the
+  # embargo_release_date (a DateTime) to +Date.today+ (a Date). When
+  # the release date is the same day as today, we'll get a truthy return value
+  # when it should be falsey.
+  #
+  #   Date.today < DateTime.parse(Date.today.to_s)
+  #   # => true
+  #
+  #   DateTime.parse(Date.today.to_s) < DateTime.parse(Date.today.to_s)
+  #   # => false
+  #
+  # @see https://github.com/samvera/hydra-head/blob/v10.7.0/hydra-access-controls/app/models/hydra/access_controls/embargo.rb#L13-L15
+  Hydra::AccessControls::Embargo.class_eval do
+    def active?
+      (embargo_release_date.present? && DateTime.now < embargo_release_date)
+    end
+  end
 end

--- a/spec/overrides/hydra_access_controls_embargo_spec.rb
+++ b/spec/overrides/hydra_access_controls_embargo_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+RSpec.describe Hydra::AccessControls::Embargo do
+  describe '#active?' do
+    let(:embargo) do
+      described_class.new(visibility_during_embargo: 'restricted',
+                          visibility_after_embargo: 'open',
+                          embargo_release_date: Date.today.to_s)
+    end
+
+    it 'returns false if the release date is today' do
+      expect(embargo.active?).to be false
+    end
+  end
+end

--- a/spec/overrides/hydra_access_controls_spec.rb
+++ b/spec/overrides/hydra_access_controls_spec.rb
@@ -12,3 +12,17 @@ RSpec.describe Hydra::AccessControls::Embargo do
     end
   end
 end
+
+RSpec.describe Hydra::AccessControls::Lease do
+  describe '#active?' do
+    let(:lease) do
+      described_class.new(visibility_during_lease: 'open',
+                          visibility_after_lease: 'restricted',
+                          lease_expiration_date: Date.today.to_s)
+    end
+
+    it 'returns false if the expiration date is today' do
+      expect(lease.active?).to be false
+    end
+  end
+end

--- a/spec/overrides/hydra_access_controls_spec.rb
+++ b/spec/overrides/hydra_access_controls_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
+# rubocop:disable RSpec/MultipleDescribes
 RSpec.describe Hydra::AccessControls::Embargo do
   describe '#active?' do
     let(:embargo) do
       described_class.new(visibility_during_embargo: 'restricted',
                           visibility_after_embargo: 'open',
-                          embargo_release_date: Date.today.to_s)
+                          embargo_release_date: Time.zone.today)
     end
 
     it 'returns false if the release date is today' do
@@ -18,7 +19,7 @@ RSpec.describe Hydra::AccessControls::Lease do
     let(:lease) do
       described_class.new(visibility_during_lease: 'open',
                           visibility_after_lease: 'restricted',
-                          lease_expiration_date: Date.today.to_s)
+                          lease_expiration_date: Time.zone.today)
     end
 
     it 'returns false if the expiration date is today' do
@@ -26,3 +27,4 @@ RSpec.describe Hydra::AccessControls::Lease do
     end
   end
 end
+# rubocop:enable RSpec/MultipleDescribes

--- a/spec/services/spot/embargo_lease_service_spec.rb
+++ b/spec/services/spot/embargo_lease_service_spec.rb
@@ -1,46 +1,76 @@
 # frozen_string_literal: true
 RSpec.describe Spot::EmbargoLeaseService do
-  let(:embargoed_presenter) { instance_double(Hyrax::WorkShowPresenter, id: 'abc123def') }
-  let(:leased_presenter) { instance_double(Hyrax::WorkShowPresenter, id: 'def456ghi') }
-  let(:embargoed_work) { instance_double(Publication) }
-  let(:leased_work) { instance_double(Publication) }
-  let(:embargoed_actor_double) { instance_double(Hyrax::Actors::EmbargoActor, destroy: true) }
-  let(:leased_actor_double) { instance_double(Hyrax::Actors::LeaseActor, destroy: true) }
-  let(:todays_date) { Time.zone.now.strftime('%Y-%m-%d') }
+  describe '.clear_expired_embargoes' do
+    let(:publication) do
+      @publication ||= begin
+        build(:publication).tap do |pub|
+          pub.embargo = embargo
+          pub.admin_set_id = AdminSet.find_or_create_default_admin_set_id
+          pub.save(validate: false)
+        end
+      end
+    end
 
-  before do
-    allow(Hyrax::EmbargoService)
-      .to receive(:assets_with_expired_embargoes)
-      .and_return([embargoed_presenter])
+    let(:visibility_during_embargo) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+    let(:visibility_after_embargo) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    let(:release_date) { Date.yesterday.to_s }
 
-    allow(Hyrax::LeaseService)
-      .to receive(:assets_with_expired_leases)
-      .and_return([leased_presenter])
+    let(:embargo) do
+      Hydra::AccessControls::Embargo.create(
+        visibility_during_embargo: visibility_during_embargo,
+        visibility_after_embargo: visibility_after_embargo,
+        embargo_release_date: release_date
+      )
+    end
 
-    allow(ActiveFedora::Base)
-      .to receive(:find)
-      .with(embargoed_presenter.id)
-      .and_return(embargoed_work)
-
-    allow(ActiveFedora::Base)
-      .to receive(:find)
-      .with(leased_presenter.id)
-      .and_return(leased_work)
-
-    allow(Hyrax::Actors::EmbargoActor)
-      .to receive(:new)
-      .with(embargoed_work)
-      .and_return(embargoed_actor_double)
-
-    allow(Hyrax::Actors::LeaseActor)
-      .to receive(:new)
-      .with(leased_work)
-      .and_return(leased_actor_double)
-
-    allow(embargoed_work).to receive(:date_available=)
+    # it do
+    #   byebug
+    # end
   end
 
+  # we just want to be sure that the methods are being called, so
+  # let's just mock everything
   describe '.clear_all_expired' do
+    let(:embargoed_presenter) { instance_double(Hyrax::WorkShowPresenter, id: 'abc123def') }
+    let(:leased_presenter) { instance_double(Hyrax::WorkShowPresenter, id: 'def456ghi') }
+    let(:embargoed_work) { instance_double(Publication) }
+    let(:leased_work) { instance_double(Publication) }
+    let(:embargoed_actor_double) { instance_double(Hyrax::Actors::EmbargoActor, destroy: true) }
+    let(:leased_actor_double) { instance_double(Hyrax::Actors::LeaseActor, destroy: true) }
+    let(:todays_date) { Time.zone.now.strftime('%Y-%m-%d') }
+
+    before do
+      allow(Hyrax::EmbargoService)
+        .to receive(:assets_with_expired_embargoes)
+        .and_return([embargoed_presenter])
+
+      allow(Hyrax::LeaseService)
+        .to receive(:assets_with_expired_leases)
+        .and_return([leased_presenter])
+
+      allow(ActiveFedora::Base)
+        .to receive(:find)
+        .with(embargoed_presenter.id)
+        .and_return(embargoed_work)
+
+      allow(ActiveFedora::Base)
+        .to receive(:find)
+        .with(leased_presenter.id)
+        .and_return(leased_work)
+
+      allow(Hyrax::Actors::EmbargoActor)
+        .to receive(:new)
+        .with(embargoed_work)
+        .and_return(embargoed_actor_double)
+
+      allow(Hyrax::Actors::LeaseActor)
+        .to receive(:new)
+        .with(leased_work)
+        .and_return(leased_actor_double)
+
+      allow(embargoed_work).to receive(:date_available=)
+    end
+
     it 'calls destroy on both the embargo + lease actors' do
       described_class.clear_all_expired
 

--- a/spec/services/spot/embargo_lease_service_spec.rb
+++ b/spec/services/spot/embargo_lease_service_spec.rb
@@ -1,56 +1,86 @@
 # frozen_string_literal: true
 RSpec.describe Spot::EmbargoLeaseService do
-  describe '.clear_expired_embargoes' do
-    let(:publication) { @publication ||= Publication.new }
-    let(:ability) { Ability.new(create(:admin_user)) }
-    let(:attributes) do
-      { title: ['example item with an embargo'], date_issued: ['2020-01'],
-        rights_statement: ['http://creativecommons.org/publicdomain/mark/1.0/'],
-        resource_type: ['Other'], embargo_release_date: release_date,
-        visibility_during_embargo: visibility_during_embargo,
-        visibility_after_embargo: visibility_after_embargo }
-    end
+  let(:publication) { create(:publication) }
+  let(:attributes) do
+    { title: ['example item with an embargo'], date_issued: ['2020-01'],
+      rights_statement: ['http://creativecommons.org/publicdomain/mark/1.0/'],
+      resource_type: ['Other'], admin_set_id: AdminSet.find_or_create_default_admin_set_id }
+  end
 
+  describe '.clear_expired_embargoes' do
     let(:visibility_during_embargo) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     let(:visibility_after_embargo) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
-    let(:release_date) { Date.yesterday.to_s }
-    let(:env) { Hyrax::Actors::Environment.new(publication, ability, attributes) }
 
-    before { Hyrax::CurationConcern.actor.create(env) }
+    before do
+      publication.apply_embargo(Date.tomorrow.to_s, visibility_during_embargo, visibility_after_embargo)
+      publication.embargo_release_date = release_date
 
-    it 'clears an old embargo' do
-      expect(publication.visibility).to eq visibility_during_embargo
+      # need to skip validation so that we can back-date the embargo
+      publication.save(validate: false)
+    end
 
-      described_class.clear_expired_embargoes
+    context 'with an expired embargo' do
+      let(:release_date) { Date.yesterday.to_s }
 
-      expect(publication.visibility).to eq visibility_after_embargo
+      it "updates the item's visibility" do
+        expect(publication.visibility).to eq visibility_during_embargo
+
+        described_class.clear_expired_embargoes
+
+        # the same as +publication.reload+ but should be compatible with Wings
+        expect(Publication.find(publication.id).visibility).to eq visibility_after_embargo
+      end
+    end
+
+    context 'with an active embargo' do
+      let(:release_date) { Date.tomorrow.to_s }
+
+      it 'does nothing' do
+        expect(publication.visibility).to eq visibility_during_embargo
+
+        described_class.clear_expired_embargoes
+
+        pub = Publication.find(publication.id)
+        expect(pub.visibility).not_to eq visibility_after_embargo
+        expect(pub.visibility).to eq visibility_during_embargo
+      end
     end
   end
 
   describe '.clear_expired_leases' do
-    let(:publication) { @publication ||= Publication.new }
-    let(:ability) { Ability.new(create(:admin_user)) }
-    let(:attributes) do
-      { title: ['example item with an lease'], date_issued: ['2020-01'],
-        rights_statement: ['http://creativecommons.org/publicdomain/mark/1.0/'],
-        resource_type: ['Other'], lease_release_date: release_date,
-        visibility_during_lease: visibility_during_lease,
-        visibility_after_lease: visibility_after_lease }
-    end
-
     let(:visibility_during_lease) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     let(:visibility_after_lease) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
-    let(:release_date) { Date.yesterday.to_s }
-    let(:env) { Hyrax::Actors::Environment.new(publication, ability, attributes) }
 
-    before { Hyrax::CurationConcern.actor.create(env) }
+    before do
+      publication.apply_lease(Date.tomorrow.to_s, visibility_during_lease, visibility_after_lease)
+      publication.lease_expiration_date = release_date
+      publication.save(validate: false)
+    end
 
-    it 'clears an old lease' do
-      expect(publication.visibility).to eq visibility_during_lease
+    context 'with an expired embargo' do
+      let(:release_date) { Date.yesterday.to_s }
 
-      described_class.clear_expired_leases
+      it "updates the item's visibility" do
+        expect(publication.visibility).to eq visibility_during_lease
 
-      expect(publication.visibility).to eq visibility_after_lease
+        described_class.clear_expired_leases
+
+        expect(Publication.find(publication.id).visibility).to eq visibility_after_lease
+      end
+    end
+
+    context "when a lease isn't expired yet" do
+      let(:release_date) { Date.tomorrow.to_s }
+
+      it 'does nothing' do
+        expect(publication.visibility).to eq visibility_during_lease
+
+        described_class.clear_expired_leases
+
+        pub = Publication.find(publication.id)
+        expect(pub.visibility).not_to eq visibility_after_lease
+        expect(pub.visibility).to eq visibility_during_lease
+      end
     end
   end
 
@@ -59,8 +89,7 @@ RSpec.describe Spot::EmbargoLeaseService do
   describe '.clear_all_expired' do
     let(:embargoed_presenter) { instance_double(Hyrax::WorkShowPresenter, id: 'abc123def') }
     let(:leased_presenter) { instance_double(Hyrax::WorkShowPresenter, id: 'def456ghi') }
-    let(:embargoed_work) { instance_double(Publication) }
-    let(:leased_work) { instance_double(Publication) }
+    let(:publication_double) { instance_double(Publication, copy_visibility_to_files: true, save!: true) }
     let(:embargoed_actor_double) { instance_double(Hyrax::Actors::EmbargoActor, destroy: true) }
     let(:leased_actor_double) { instance_double(Hyrax::Actors::LeaseActor, destroy: true) }
     let(:todays_date) { Time.zone.now.strftime('%Y-%m-%d') }
@@ -77,30 +106,30 @@ RSpec.describe Spot::EmbargoLeaseService do
       allow(ActiveFedora::Base)
         .to receive(:find)
         .with(embargoed_presenter.id)
-        .and_return(embargoed_work)
+        .and_return(publication_double)
 
       allow(ActiveFedora::Base)
         .to receive(:find)
         .with(leased_presenter.id)
-        .and_return(leased_work)
+        .and_return(publication_double)
 
       allow(Hyrax::Actors::EmbargoActor)
         .to receive(:new)
-        .with(embargoed_work)
+        .with(publication_double)
         .and_return(embargoed_actor_double)
 
       allow(Hyrax::Actors::LeaseActor)
         .to receive(:new)
-        .with(leased_work)
+        .with(publication_double)
         .and_return(leased_actor_double)
 
-      allow(embargoed_work).to receive(:date_available=)
+      allow(publication_double).to receive(:date_available=)
     end
 
     it 'calls destroy on both the embargo + lease actors' do
       described_class.clear_all_expired
 
-      expect(embargoed_work).to have_received(:date_available=).with([todays_date])
+      expect(publication_double).to have_received(:date_available=).with([todays_date])
       expect(embargoed_actor_double).to have_received(:destroy).exactly(1).time
       expect(leased_actor_double).to have_received(:destroy).exactly(1).time
     end

--- a/spec/services/spot/embargo_lease_service_spec.rb
+++ b/spec/services/spot/embargo_lease_service_spec.rb
@@ -113,6 +113,9 @@ RSpec.describe Spot::EmbargoLeaseService do
         .with(leased_presenter.id)
         .and_return(publication_double)
 
+      allow(publication_double).to receive(:under_embargo?)
+      allow(publication_double).to receive(:active_lease?)
+
       allow(Hyrax::Actors::EmbargoActor)
         .to receive(:new)
         .with(publication_double)


### PR DESCRIPTION
monkey-patches in a fix to how `Hydra::AccessControls::Embargo` and `Hydra::AccessControls::Lease` determine if an embargo/lease is still active. looking at the code (we'll use `Embargo` but `Lease` also follows this pattern), the [`#active?`](https://github.com/samvera/hydra-head/blob/v10.7.0/hydra-access-controls/app/models/hydra/access_controls/embargo.rb#L13-L15) methods compare the stored `embargo_release_date` with `Date.today`. however, the stored `embargo_release_date` is a `DateTime`, which leads to unexpected results.

```ruby
Date.today < DateTime.parse(Date.today.to_s)
# => true

DateTime.parse(Date.today.to_s) < DateTime.parse(Date.today.to_s)
# => false
```

So what was happening was:

- `Hyrax::EmbargoService.assets_with_expired_embargoes` performs a Solr query for items with an `embargo_release_date_dtsi:[* TO NOW]`
- `Hyrax::Actors::EmbargoActor.new(item).destroy` updates the item's visibility before clearing out the Embargo. if `item.embargo.active?` is true, it clears out the Embargo + leaves the item's visibility the same (`visibility_during_embargo`)
- since `Hydra::AccessControls::Embargo#active?` compares the DateTime to Date.today, we'll get a true response and the Embargo will get cleared out but the item's visibility won't update

thus leaving us with private items that were supposed to be public. this should fix that (:tada:)

closes #379