### PR TITLE
refactor ingest pipeline

### DIFF
--- a/app/actors/solr_suggest_actor.rb
+++ b/app/actors/solr_suggest_actor.rb
@@ -3,18 +3,21 @@ class SolrSuggestActor < ::Hyrax::Actors::AbstractActor
   # @param [Hyrax::Actors::Environment] env
   # @return [void]
   def create(env)
+    set_batch_flag(env)
     next_actor.create(env) && update_suggest_dictionaries(env)
   end
 
   # @param [Hyrax::Actors::Environment] env
   # @return [void]
   def update(env)
+    @part_of_batch = false
     next_actor.update(env) && update_suggest_dictionaries(env)
   end
 
   # @param [Hyrax::Actors::Environment] env
   # @return [void]
   def destroy(env)
+    @part_of_batch = false
     next_actor.destroy(env) && update_suggest_dictionaries(env)
   end
 
@@ -26,7 +29,7 @@ class SolrSuggestActor < ::Hyrax::Actors::AbstractActor
     # @param [Hyrax::Actors::Environment] env
     # @return [void]
     def update_suggest_dictionaries(env)
-      Spot::UpdateSolrSuggestDictionariesJob.perform_now unless part_of_batch_ingest?(env)
+      Spot::UpdateSolrSuggestDictionariesJob.perform_now unless part_of_batch?
     end
 
     # @return [Symbol]
@@ -34,11 +37,17 @@ class SolrSuggestActor < ::Hyrax::Actors::AbstractActor
       ::Spot::Importers::Base::RecordImporter::BATCH_INGEST_KEY
     end
 
-    # Does the environment's attributes include the BATCH_INGEST_KEY?
+    # @return [true, false]
+    def part_of_batch?
+      !!@part_of_batch
+    end
+
+    # Sets an instance variable flag if the batch_ingest_key is part of
+    # the environment's attributes.
     #
     # @param [Hyrax::Actors::Environment] env
-    # @return [true, false]
-    def part_of_batch_ingest?(env)
-      env.attributes.include?(batch_ingest_key) && env.attributes[batch_ingest_key] == true
+    # @return [void]
+    def set_batch_flag(env)
+      @part_of_batch = !!env.attributes.delete(batch_ingest_key)
     end
 end

--- a/app/actors/solr_suggest_actor.rb
+++ b/app/actors/solr_suggest_actor.rb
@@ -3,22 +3,22 @@ class SolrSuggestActor < ::Hyrax::Actors::AbstractActor
   # @param [Hyrax::Actors::Environment] env
   # @return [void]
   def create(env)
-    set_batch_flag(env)
-    next_actor.create(env) && update_suggest_dictionaries(env)
+    extract_batch_flag(env)
+    next_actor.create(env) && update_suggest_dictionaries
   end
 
   # @param [Hyrax::Actors::Environment] env
   # @return [void]
   def update(env)
-    set_batch_flag(env)
-    next_actor.update(env) && update_suggest_dictionaries(env)
+    extract_batch_flag(env)
+    next_actor.update(env) && update_suggest_dictionaries
   end
 
   # @param [Hyrax::Actors::Environment] env
   # @return [void]
   def destroy(env)
-    set_batch_flag(env)
-    next_actor.destroy(env) && update_suggest_dictionaries(env)
+    extract_batch_flag(env)
+    next_actor.destroy(env) && update_suggest_dictionaries
   end
 
   private
@@ -28,7 +28,7 @@ class SolrSuggestActor < ::Hyrax::Actors::AbstractActor
     #
     # @param [Hyrax::Actors::Environment] env
     # @return [void]
-    def update_suggest_dictionaries(env)
+    def update_suggest_dictionaries
       Spot::UpdateSolrSuggestDictionariesJob.perform_now unless part_of_batch?
     end
 
@@ -39,7 +39,7 @@ class SolrSuggestActor < ::Hyrax::Actors::AbstractActor
 
     # @return [true, false]
     def part_of_batch?
-      !!@part_of_batch
+      @part_of_batch == true
     end
 
     # Sets an instance variable flag if the batch_ingest_key is part of
@@ -47,7 +47,7 @@ class SolrSuggestActor < ::Hyrax::Actors::AbstractActor
     #
     # @param [Hyrax::Actors::Environment] env
     # @return [void]
-    def set_batch_flag(env)
-      @part_of_batch = !!env.attributes.delete(batch_ingest_key)
+    def extract_batch_flag(env)
+      @part_of_batch = env.attributes.delete(batch_ingest_key)
     end
 end

--- a/app/actors/solr_suggest_actor.rb
+++ b/app/actors/solr_suggest_actor.rb
@@ -10,14 +10,14 @@ class SolrSuggestActor < ::Hyrax::Actors::AbstractActor
   # @param [Hyrax::Actors::Environment] env
   # @return [void]
   def update(env)
-    @part_of_batch = false
+    set_batch_flag(env)
     next_actor.update(env) && update_suggest_dictionaries(env)
   end
 
   # @param [Hyrax::Actors::Environment] env
   # @return [void]
   def destroy(env)
-    @part_of_batch = false
+    set_batch_flag(env)
     next_actor.destroy(env) && update_suggest_dictionaries(env)
   end
 

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -22,8 +22,10 @@ class CharacterizeJob < ::Hyrax::ApplicationJob
     def characterize(file_set, _file_id, filepath)
       Hydra::Works::CharacterizationService.run(file_set.characterization_proxy, filepath, ch12n_tool: tool)
       Rails.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
-      file_set.characterization_proxy.alpha_channels = channels(filepath) if file_set.image? && Hyrax.config.iiif_image_server?
+
+      alpha_channels(file_set) if file_set.image? && Hyrax.config.iiif_image_server?
       file_set.characterization_proxy.save!
+
       file_set.update_index
       file_set.parent&.in_collections&.each(&:update_index)
     end
@@ -34,6 +36,12 @@ class CharacterizeJob < ::Hyrax::ApplicationJob
         cmd << filepath
       end
       [ch]
+    end
+
+    def alpha_channels(file_set)
+      return unless file_set.characterization_proxy.respond_to?(:alpha_channels=)
+
+      file_set.characterization_proxy.alpha_channels = channels(filepath)
     end
 
     def tool

--- a/app/jobs/spot/ingest_bag_job.rb
+++ b/app/jobs/spot/ingest_bag_job.rb
@@ -5,7 +5,7 @@
 #
 # @example
 #   path = '/path/to/ingestable/bag'
-#   Spot::IngestBagJob.perform_later(bag_path, source: 'newspaper', work_class: 'Publication')
+#   Spot::IngestBagJob.perform_later(bag_path, source: 'newspaper', work_klass: 'Publication')
 #
 # Note: Rails can't handle symbol arguments, so be sure to convert your
 #       source to a String! I _think_ this is fixed in Rails 6.
@@ -14,82 +14,25 @@ module Spot
   class IngestBagJob < ::ApplicationJob
     queue_as :ingest
 
-    # Validates the Bag and imports if it's okay.
-    #
-    # @param [String, Pathname] bag_path Path to the Bag directory
-    # @param [String] source Source collection / which mapper to use
-    # @param [String] work_class Work Type to use for new object
+    # @param [Hash] options
+    # @option [String, Pathname] bag_path
+    #   Path to the Bag directory
+    # @option [String] source
+    #   Source collection / which mapper to use
+    # @option [String] work_klass
+    #   Work Type to use for new object
+    # @option [Array<String>] collection_ids
+    #   Collection IDs to add the item to
     # @return [void]
     # @raise [ArgumentError] if +source:+ is not defined in {Spot::Mappers.available_mappers}
     # @raise [ArgumentError] if +work_class:+ not a valid Work type
     # @raise [ValidationError] if the file to parse is invalid
     #   (from Darlingtonia::Parser)
-    def perform(bag_path:,
-                source:,
-                work_class:,
-                collection_ids: [],
-                multi_value_character: '|')
-      @bag_path = bag_path
-      @source = source
-      @work_class = work_class.constantize
-      @collection_ids = collection_ids
-      @multi_value_character = multi_value_character
-
-      raise ArgumentError, "Unknown source: #{source}." unless source_available?
-      raise ArgumentError, "Unknown work_class: #{work_class}" unless work_class_valid?
-
-      logger.debug "Ingesting bag [#{bag_path}] using #{source} mapper"
-      importer.import if parser.validate!
+    def perform(bag_path:, source:, work_klass:, collection_ids: [])
+      mapper_klass = Spot::Mappers.get(source.to_sym)
+      service = BagIngestService.new(bag_path: bag_path, mapper_klass: mapper_klass,
+                                     work_klass: work_klass.constantize, collection_ids: collection_ids)
+      service.ingest
     end
-
-    private
-
-      attr_reader :bag_path, :source
-
-      # Is the work_class provided one of our curation_concerns?
-      #
-      # @return [TrueClass, FalseClass]
-      def work_class_valid?
-        ::Hyrax.config.curation_concerns.include?(@work_class)
-      end
-
-      # Does the provided symbol have a mapper associated with it?
-      #
-      # @return [Constant, nil]
-      def source_available?
-        Spot::Mappers.available_mappers.include?(@source.to_sym)
-      end
-
-      # The mapper to use, decided by the +:source+ parameter
-      #
-      # @return [Darlingtonia::MetadataMapper]
-      def mapper
-        @mapper ||= Spot::Mappers.get(source.to_sym).new
-      end
-
-      # @return [Spot::Importers::Bag::Parser]
-      def parser
-        @parser ||= Spot::Importers::Bag::Parser.new(directory: bag_path,
-                                                     mapper: mapper,
-                                                     multi_value_character: @multi_value_character)
-      end
-
-      # @return [Spot::Importers::Bag::RecordImporter]
-      def record_importer
-        @record_importer ||= begin
-          info = Spot::StreamLogger.new(logger, level: ::Logger::INFO)
-          error = Spot::StreamLogger.new(logger, level: ::Logger::WARN)
-          Spot::Importers::Bag::RecordImporter.new(work_class: @work_class,
-                                                   collection_ids: @collection_ids,
-                                                   info_stream: info,
-                                                   error_stream: error)
-        end
-      end
-
-      # @return [Darlingtonia::Importer]
-      def importer
-        @importer ||= Darlingtonia::Importer.new(parser: parser,
-                                                 record_importer: record_importer)
-      end
   end
 end

--- a/app/jobs/spot/ingest_bag_job.rb
+++ b/app/jobs/spot/ingest_bag_job.rb
@@ -15,7 +15,7 @@ module Spot
     queue_as :ingest
 
     # @param [Hash] options
-    # @option [String, Pathname] bag_path
+    # @option [String, Pathname] path
     #   Path to the Bag directory
     # @option [String] source
     #   Source collection / which mapper to use
@@ -28,10 +28,11 @@ module Spot
     # @raise [ArgumentError] if +work_class:+ not a valid Work type
     # @raise [ValidationError] if the file to parse is invalid
     #   (from Darlingtonia::Parser)
-    def perform(bag_path:, source:, work_klass:, collection_ids: [])
+    def perform(path:, source:, work_klass:, collection_ids: [])
       mapper_klass = Spot::Mappers.get(source.to_sym)
-      service = BagIngestService.new(bag_path: bag_path, mapper_klass: mapper_klass,
-                                     work_klass: work_klass.constantize, collection_ids: collection_ids)
+      service = BagIngestService.new(path: path, mapper_klass: mapper_klass,
+                                     work_klass: work_klass.constantize, collection_ids: collection_ids,
+                                     logger: logger)
       service.ingest
     end
   end

--- a/app/jobs/spot/ingest_doi_job.rb
+++ b/app/jobs/spot/ingest_doi_job.rb
@@ -32,7 +32,7 @@ module Spot
         @record_importer ||= begin
           info = Spot::StreamLogger.new(logger, level: ::Logger::INFO)
           error = Spot::StreamLogger.new(logger, level: ::Logger::WARN)
-          Spot::Importers::Unpaywall::RecordImporter.new(work_class: @work_class,
+          Spot::Importers::Unpaywall::RecordImporter.new(work_klass: @work_class,
                                                          collection_ids: @collection_ids,
                                                          info_stream: info,
                                                          error_stream: error)

--- a/app/jobs/spot/ingest_zipped_bag_job.rb
+++ b/app/jobs/spot/ingest_zipped_bag_job.rb
@@ -32,8 +32,7 @@ module Spot
     # @raise [ValidationError] if the file to parse is invalid
     #   (from Darlingtonia::Parser)
     #
-    def perform(zip_path:, source:, work_class:, working_path:,
-                collection_ids: [], multi_value_character: '|')
+    def perform(zip_path:, source:, work_class:, working_path:, collection_ids: [])
       raise ArgumentError, "#{working_path} is not a directory" unless File.directory?(working_path)
 
       destination = File.join(working_path, File.basename(zip_path, '.zip'))
@@ -43,9 +42,8 @@ module Spot
 
       Spot::IngestBagJob.perform_now(bag_path: destination,
                                      source: source,
-                                     work_class: work_class,
-                                     collection_ids: collection_ids,
-                                     multi_value_character: multi_value_character)
+                                     work_klass: work_class,
+                                     collection_ids: collection_ids)
     end
   end
 end

--- a/app/jobs/spot/ingest_zipped_bag_job.rb
+++ b/app/jobs/spot/ingest_zipped_bag_job.rb
@@ -18,7 +18,7 @@ module Spot
 
     # @param [String] zip_path Path to the zip file
     # @param [String] source Source collection / which mapper to use
-    # @param [String] work_class Work Type to use for new object
+    # @param [String] work_klass Work Type to use for new object
     # @param [String] working_path Directory to unzip the object
     # @param [Array<String>] collection_ids Array of collection ids to add this item to
     # @param [String] multi_value_character The character used in the metadata to indicate multiple values
@@ -27,12 +27,12 @@ module Spot
     # @raise [ArgumentError] if +working_path:+ is not a directory
     # @raise [ArgumentError] if +source:+ is not defined in {Spot::Mappers.available_mappers}
     #   (from Spot::IngestBagJob)
-    # @raise [ArgumentError] if +work_class:+ not a valid Work type
+    # @raise [ArgumentError] if +work_klass:+ not a valid Work type
     #   (from Spot::IngestBagJob)
     # @raise [ValidationError] if the file to parse is invalid
     #   (from Darlingtonia::Parser)
     #
-    def perform(zip_path:, source:, work_class:, working_path:, collection_ids: [])
+    def perform(zip_path:, source:, work_klass:, working_path:, collection_ids: [])
       raise ArgumentError, "#{working_path} is not a directory" unless File.directory?(working_path)
 
       destination = File.join(working_path, File.basename(zip_path, '.zip'))
@@ -42,7 +42,7 @@ module Spot
 
       Spot::IngestBagJob.perform_now(bag_path: destination,
                                      source: source,
-                                     work_klass: work_class,
+                                     work_klass: work_klass,
                                      collection_ids: collection_ids)
     end
   end

--- a/app/jobs/spot/ingest_zipped_bag_job.rb
+++ b/app/jobs/spot/ingest_zipped_bag_job.rb
@@ -32,7 +32,7 @@ module Spot
     # @raise [ValidationError] if the file to parse is invalid
     #   (from Darlingtonia::Parser)
     #
-    def perform(zip_path:, source:, work_klass:, working_path:, collection_ids: [])
+    def perform(zip_path:, source:, work_klass:, working_path: Rails.root.join('tmp', 'ingest'), collection_ids: [])
       raise ArgumentError, "#{working_path} is not a directory" unless File.directory?(working_path)
 
       destination = File.join(working_path, File.basename(zip_path, '.zip'))
@@ -40,10 +40,8 @@ module Spot
 
       ZipService.new(src_path: zip_path).unzip!(dest_path: destination)
 
-      Spot::IngestBagJob.perform_now(bag_path: destination,
-                                     source: source,
-                                     work_klass: work_klass,
-                                     collection_ids: collection_ids)
+      Spot::IngestBagJob.perform_now(path: destination, source: source,
+                                     work_klass: work_klass, collection_ids: collection_ids)
     end
   end
 end

--- a/app/services/concerns/spot/mappers/language_tagged_titles.rb
+++ b/app/services/concerns/spot/mappers/language_tagged_titles.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+module Spot::Mappers
+  module LanguageTaggedTitles
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :primary_title_map, :title_alternative_map
+      self.primary_title_map = { 'title.english' => 'en' }
+      self.title_alternative_map = {
+        'title.chinese' => 'zh',
+        'title.french' => 'fr',
+        'title.german' => 'de',
+        'title.japanese' => 'ja',
+        'title.korean' => 'ko'
+      }
+    end
+
+    # @return [Array<Symbol>]
+    def field
+      super + [:title, :title_alternative]
+    end
+
+    # @return [Array<RDF::Literal>]
+    def title
+      key = primary_title_map.keys.first
+      language = primary_title_map[key]
+
+      Array.wrap(metadata.fetch(key, []))
+           .reject(&:blank?)
+           .map { |val| RDF::Literal(val, language: language.to_sym) }
+    end
+
+    # @return [Array<RDF::Literal>]
+    def title_alternative
+      title_alternative_map.keys.map do |field|
+        language = title_alternative_map[field].to_sym
+        metadata.fetch(field, []).reject(&:blank?).map do |value|
+          RDF::Literal(value, language: language)
+        end
+      end.flatten
+    end
+  end
+end

--- a/app/services/concerns/spot/mappers/language_tagged_titles.rb
+++ b/app/services/concerns/spot/mappers/language_tagged_titles.rb
@@ -1,43 +1,91 @@
 # frozen_string_literal: true
 module Spot::Mappers
+  # Mixin to add methods for extracting language-tagged literal values for
+  # +title+ and +title_alternative+ fields. To use, include this mixin and
+  # add the +:title+ and +:title_alternative+ symbols to your +#fields+ array.
+  #
+  # @example
+  #   module Spot::Mappers
+  #     class AlsaceImagesMapper < BaseMapper
+  #       include LanguageTaggedTitles
+  #
+  #       def fields
+  #         super + [:title, :title_alternative]
+  #       end
+  #     end
+  #   end
+  #
+  # Customization is available through two class attributes: +:primary_title_map+
+  # and +:title_alternative_map+. The former is expected to consist of a single
+  # key/value pair (where the key is the metadata field to target and the value
+  # is a two character symbol representing the language to tag the literal).
+  # +:title_alternative_map+ can consist of however many alt-title fields as
+  # is necessary. These have been defined at the outset to capture most of our
+  # individual collections' variations on titles. It will not raise an exception
+  # if a field does not exist in the metadata, meaning you shouldn't have to update
+  # the +:title_alternative_map+ if a collection only uses some of the fields
+  # provided.
+  #
+  # @example customizing mappings
+  #   module Spot::Mappers
+  #     class PostcardCollection < BaseMapper
+  #       include LanguageTaggedTitles
+  #
+  #       self.primary_title_map = { 'title' => :en }
+  #       self.title_alternative_map = {
+  #         'japanese_title' => :ja,
+  #         'korean_title' => :ko
+  #       }
+  #
+  #       def fields
+  #         super + [:title, :title_alternative]
+  #       end
+  #     end
+  #   end
+  #
   module LanguageTaggedTitles
     extend ActiveSupport::Concern
 
     included do
       class_attribute :primary_title_map, :title_alternative_map
-      self.primary_title_map = { 'title.english' => 'en' }
+      self.primary_title_map = { 'title.english' => :en }
       self.title_alternative_map = {
-        'title.chinese' => 'zh',
-        'title.french' => 'fr',
-        'title.german' => 'de',
-        'title.japanese' => 'ja',
-        'title.korean' => 'ko'
+        'title.chinese' => :zh,
+        'title.french' => :fr,
+        'title.german' => :de,
+        'title.japanese' => :ja,
+        'title.korean' => :ko
       }
-    end
-
-    # @return [Array<Symbol>]
-    def field
-      super + [:title, :title_alternative]
     end
 
     # @return [Array<RDF::Literal>]
     def title
-      key = primary_title_map.keys.first
-      language = primary_title_map[key]
+      field = primary_title_map.keys.first
+      language = primary_title_map[field]
 
-      Array.wrap(metadata.fetch(key, []))
-           .reject(&:blank?)
-           .map { |val| RDF::Literal(val, language: language.to_sym) }
+      field_to_tagged_literals(field, language)
     end
 
     # @return [Array<RDF::Literal>]
     def title_alternative
       title_alternative_map.keys.map do |field|
         language = title_alternative_map[field].to_sym
-        metadata.fetch(field, []).reject(&:blank?).map do |value|
-          RDF::Literal(value, language: language)
-        end
+        field_to_tagged_literals(field, language)
       end.flatten
     end
+
+    private
+
+      # Maps a field's values to RDF::Literals tagged with a language
+      #
+      # @param [String] field
+      #   Metadata field to target
+      # @param [String, Symbol] language
+      #   2 character language code (ex. :en)
+      def field_to_tagged_literals(field, language)
+        Array.wrap(metadata.fetch(field, []))
+             .reject(&:blank?)
+             .map { |v| RDF::Literal(v, language: language.to_sym) }
+      end
   end
 end

--- a/app/services/spot/bag_ingest_service.rb
+++ b/app/services/spot/bag_ingest_service.rb
@@ -1,58 +1,46 @@
 # frozen_string_literal: true
 module Spot
   class BagIngestService
-    def initialize(bag_path:, mapper_klass:, work_klass:, collection_ids: [], multi_value_character: '|')
-      @bag_path = bag_path
+    attr_reader :path, :mapper_klass, :work_klass, :collection_ids, :multi_value_character, :logger
+
+    def initialize(path:,
+                   mapper_klass:,
+                   work_klass:,
+                   collection_ids: [],
+                   multi_value_character: '|',
+                   logger: Rails.logger)
+      @path = path
       @mapper_klass = mapper_klass
       @work_klass = work_klass
       @collection_ids = collection_ids
       @multi_value_character = multi_value_character
+      @logger = logger
     end
 
     def ingest
-      validate_arguments!
+      raise ArgumentError, "Unknown work_klass: #{work_klass}" unless work_klass_valid?
+
       parser.validate!
 
-      logger.debug "Ingesting bag [#{bag_path}] using #{source} mapper"
+      logger.debug "Ingesting bag [#{path}] using #{mapper_klass}"
       importer.import if parser.validate!
     end
 
     private
 
-      attr_reader :bag_path, :source
-
-      def validate_arguments!
-        raise ArgumentError, "Unknown source: #{source}." unless source_available?
-        raise ArgumentError, "Unknown work_class: #{work_class}" unless work_class_valid?
-      end
-
       # Is the work_class provided one of our curation_concerns?
       #
       # @return [TrueClass, FalseClass]
-      def work_class_valid?
-        ::Hyrax.config.curation_concerns.include?(@work_class)
-      end
-
-      # Does the provided symbol have a mapper associated with it?
-      #
-      # @return [Constant, nil]
-      def source_available?
-        Spot::Mappers.available_mappers.include?(@source.to_sym)
-      end
-
-      # The mapper to use, decided by the +:source+ parameter
-      #
-      # @return [Darlingtonia::MetadataMapper]
-      def mapper
-        @mapper ||= @mapper_klass.new
+      def work_klass_valid?
+        ::Hyrax.config.curation_concerns.include?(work_klass)
       end
 
       # @return [Spot::Importers::Bag::Parser]
       def parser
         @parser ||=
-          Spot::Importers::Bag::Parser.new(directory: bag_path,
-                                           mapper: mapper,
-                                           multi_value_character: @multi_value_character)
+          Spot::Importers::Bag::Parser.new(directory: path,
+                                           mapper: mapper_klass.new,
+                                           multi_value_character: multi_value_character)
       end
 
       # @return [Spot::Importers::Bag::RecordImporter]
@@ -60,8 +48,8 @@ module Spot
         @record_importer ||= begin
           info = Spot::StreamLogger.new(logger, level: ::Logger::INFO)
           error = Spot::StreamLogger.new(logger, level: ::Logger::WARN)
-          Spot::Importers::Bag::RecordImporter.new(work_klass: @work_klass,
-                                                   collection_ids: @collection_ids,
+          Spot::Importers::Bag::RecordImporter.new(work_klass: work_klass,
+                                                   collection_ids: collection_ids,
                                                    info_stream: info,
                                                    error_stream: error)
         end

--- a/app/services/spot/bag_ingest_service.rb
+++ b/app/services/spot/bag_ingest_service.rb
@@ -16,8 +16,6 @@ module Spot
     def ingest
       raise ArgumentError, "Unknown work_klass: #{work_klass}" unless work_klass_valid?
 
-      parser.validate!
-
       logger.debug "Ingesting bag [#{path}] using #{mapper_klass}"
       importer.import if parser.validate!
     end

--- a/app/services/spot/bag_ingest_service.rb
+++ b/app/services/spot/bag_ingest_service.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 module Spot
   class BagIngestService
-    attr_reader :path, :mapper_klass, :work_klass, :collection_ids, :multi_value_character, :logger
+    attr_reader :path, :mapper_klass, :work_klass, :collection_ids, :logger
 
-    def initialize(path:,
-                   mapper_klass:,
-                   work_klass:,
-                   collection_ids: [],
-                   multi_value_character: '|',
-                   logger: Rails.logger)
+    def initialize(path:, mapper_klass:, work_klass:,
+                   collection_ids: [], logger: Rails.logger)
       @path = path
       @mapper_klass = mapper_klass
       @work_klass = work_klass
@@ -33,6 +29,10 @@ module Spot
       # @return [TrueClass, FalseClass]
       def work_klass_valid?
         ::Hyrax.config.curation_concerns.include?(work_klass)
+      end
+
+      def multi_value_character
+        '|'
       end
 
       # @return [Spot::Importers::Bag::Parser]

--- a/app/services/spot/bag_ingest_service.rb
+++ b/app/services/spot/bag_ingest_service.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+module Spot
+  class BagIngestService
+    def initialize(bag_path:, mapper_klass:, work_klass:, collection_ids: [], multi_value_character: '|')
+      @bag_path = bag_path
+      @mapper_klass = mapper_klass
+      @work_klass = work_klass
+      @collection_ids = collection_ids
+      @multi_value_character = multi_value_character
+    end
+
+    def ingest
+      validate_arguments!
+      parser.validate!
+
+      logger.debug "Ingesting bag [#{bag_path}] using #{source} mapper"
+      importer.import if parser.validate!
+    end
+
+    private
+
+      attr_reader :bag_path, :source
+
+      def validate_arguments!
+        raise ArgumentError, "Unknown source: #{source}." unless source_available?
+        raise ArgumentError, "Unknown work_class: #{work_class}" unless work_class_valid?
+      end
+
+      # Is the work_class provided one of our curation_concerns?
+      #
+      # @return [TrueClass, FalseClass]
+      def work_class_valid?
+        ::Hyrax.config.curation_concerns.include?(@work_class)
+      end
+
+      # Does the provided symbol have a mapper associated with it?
+      #
+      # @return [Constant, nil]
+      def source_available?
+        Spot::Mappers.available_mappers.include?(@source.to_sym)
+      end
+
+      # The mapper to use, decided by the +:source+ parameter
+      #
+      # @return [Darlingtonia::MetadataMapper]
+      def mapper
+        @mapper ||= @mapper_klass.new
+      end
+
+      # @return [Spot::Importers::Bag::Parser]
+      def parser
+        @parser ||=
+          Spot::Importers::Bag::Parser.new(directory: bag_path,
+                                           mapper: mapper,
+                                           multi_value_character: @multi_value_character)
+      end
+
+      # @return [Spot::Importers::Bag::RecordImporter]
+      def record_importer
+        @record_importer ||= begin
+          info = Spot::StreamLogger.new(logger, level: ::Logger::INFO)
+          error = Spot::StreamLogger.new(logger, level: ::Logger::WARN)
+          Spot::Importers::Bag::RecordImporter.new(work_klass: @work_klass,
+                                                   collection_ids: @collection_ids,
+                                                   info_stream: info,
+                                                   error_stream: error)
+        end
+      end
+
+      # @return [Darlingtonia::Importer]
+      def importer
+        @importer ||=
+          Darlingtonia::Importer.new(parser: parser, record_importer: record_importer)
+      end
+  end
+end

--- a/app/services/spot/importers/base/record_importer.rb
+++ b/app/services/spot/importers/base/record_importer.rb
@@ -7,7 +7,7 @@ module Spot::Importers::Base
   #
   #   info_stream = Spot::StreamLogger.new(logger, level: ::Logger::INFO)
   #   error_stream = Spot::StreamLogger.new(logger, level: ::Logger::WARN)
-  #   record_importer = Spot::Importers::Base::RecordImporter.new(work_class,
+  #   record_importer = Spot::Importers::Base::RecordImporter.new(work_klass,
   #                                                               info_stream: info_stream,
   #                                                               error_stream: error_stream)
   class RecordImporter < ::Darlingtonia::RecordImporter
@@ -17,21 +17,21 @@ module Spot::Importers::Base
     self.default_depositor_email = 'dss@lafayette.edu'
     self.default_admin_set_id = AdminSet::DEFAULT_ID
 
-    attr_reader :work_class, :admin_set_id, :collection_ids
+    attr_reader :work_klass, :admin_set_id, :collection_ids
 
-    # Adds +work_class:+ and +admin_set_id:+ options to the RecordImporter initializer
+    # Adds +work_klass:+ and +admin_set_id:+ options to the RecordImporter initializer
     #
-    # @param [ActiveFedora::Base] work_class
+    # @param [ActiveFedora::Base] work_klass
     # @param [AdminSet] admin_set
     # @param [#<<] info_stream
     # @param [#<<] error_stream
-    def initialize(work_class:,
+    def initialize(work_klass:,
                    admin_set_id: default_admin_set_id,
                    collection_ids: [],
                    info_stream: STDOUT,
                    error_stream: STDOUT)
       super(info_stream: info_stream, error_stream: error_stream)
-      @work_class = work_class
+      @work_klass = work_klass
       @admin_set_id = admin_set_id
       @collection_ids = collection_ids
     end
@@ -45,15 +45,17 @@ module Spot::Importers::Base
 
         error_stream << empty_file_warning(attributes) if attributes[:remote_files].empty?
 
-        work = work_class.new
+        work = work_klass.new
 
         actor_env = Hyrax::Actors::Environment.new(work,
                                                    ability_for(attributes.delete(:depositor)),
                                                    attributes)
 
         info_stream << "Creating record: #{attributes[:title].first}\n"
-        Hyrax::CurationConcern.actor.create(actor_env) &&
-          (info_stream << "Record created: #{work.id}\n")
+
+        stack_result = Hyrax::CurationConcern.actor.create(actor_env)
+
+        info_stream << "Record created: #{work.id}\n" if stack_result
       rescue ::Ldp::Gone
         error_stream << "Ldp::Gone => [#{work.id}]\n"
       rescue => e

--- a/app/services/spot/importers/base/record_importer.rb
+++ b/app/services/spot/importers/base/record_importer.rb
@@ -50,9 +50,7 @@ module Spot::Importers::Base
 
         actor_env = Hyrax::Actors::Environment.new(work, ability, attributes)
 
-        info_stream << "Creating record: #{attributes[:title].first}\n"
-        stack_result = Hyrax::CurationConcern.actor.create(actor_env)
-        info_stream << "Record created: #{work.id}\n" if stack_result
+        kickoff_ingest(actor_env)
 
         clean_errors(work).each { |error_message| error_stream << error_message }
       rescue ::Ldp::Gone
@@ -126,6 +124,16 @@ module Spot::Importers::Base
         end
 
         user
+      end
+
+      # Logs + kicks off the ingest process with a given Environment
+      #
+      # @param [Hyrax::Actors::Environment]
+      # @return [void]
+      def kickoff_ingest(env)
+        info_stream << "Creating record: #{env.attributes[:title].first}\n"
+        stack_result = Hyrax::CurationConcern.actor.create(env)
+        info_stream << "Record created: #{env.curation_concern.id}\n" if stack_result
       end
   end
 end

--- a/app/services/spot/mappers/alsace_images_mapper.rb
+++ b/app/services/spot/mappers/alsace_images_mapper.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+module Spot::Mappers
+  class AlsaceImagesMapper < BaseMapper
+    include LanguageTaggedTitles
+
+    self.fields_map = {}
+
+    # @return [Array<Symbol>]
+    def fields
+      super + [
+        :inscription,
+        :resource_type,
+        :location,
+        :resource_type,
+        :subject_ocm,
+
+        # these come from LanguageTaggedTitles
+        :title,
+        :title_alternative
+      ]
+    end
+
+    # From Image Remediation Plan:
+    #
+    #   Map from <description.text.french> AND <description.text.german> in alsace-images.
+    #
+    # @return [Array<RDF::Literal>]
+    def inscription
+      [
+        %w[description.inscription.french fr], %w[description.inscription.german de],
+        %w[description.text.french fr], %w[description.text.german de]
+      ].collect { |(key, language)| field_to_tagged_literals(key, language) }.flatten
+    end
+
+    def location
+      # todo
+    end
+
+    # @return [Array<String>]
+    def resource_type
+      ['Image']
+    end
+
+    def subject_ocm
+      # todo
+    end
+  end
+end

--- a/app/services/spot/mappers/base_eaic_mapper.rb
+++ b/app/services/spot/mappers/base_eaic_mapper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Spot::Mappers
+  class BaseEaicMapper < BaseMapper
+    include LanguageTaggedTitles
+  end
+end

--- a/lib/tasks/spot/ingest.rake
+++ b/lib/tasks/spot/ingest.rake
@@ -8,8 +8,8 @@ namespace :spot do
       'No `path` provided!'
     elsif !File.exist?(ENV['path'])
       'File or path does not exist'
-    elsif !ENV['work_class']
-      'No `work_class` provided!'
+    elsif !ENV['work_klass']
+      'No `work_klass` provided!'
     end
   end
 
@@ -24,7 +24,7 @@ namespace :spot do
       collection_ids: ENV.fetch('collection_ids', '').split(','),
       multi_value_character: ENV.fetch('multi_value_character', '|'),
       source: ENV['source'],
-      work_class: ENV['work_class'],
+      work_klass: ENV['work_klass'],
       working_path: ENV.fetch('working_path', Rails.root.join('tmp', 'ingest').to_s)
     }
   end
@@ -43,8 +43,7 @@ namespace :spot do
   namespace :ingest do
     desc 'Ingest Publication items from zipped BagIt files'
     task publication: :environment do
-      ENV['work_class'] = 'Publication'
-      check_for_errors! && enqueue_jobs(job_args_from_env.merge(work_class: 'Publication'))
+      check_for_errors! && enqueue_jobs(job_args_from_env.merge(work_klass: 'Publication'))
     end
   end
 end

--- a/spec/jobs/spot/ingest_bag_job_spec.rb
+++ b/spec/jobs/spot/ingest_bag_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe Spot::IngestBagJob do
   let(:source) { 'ldr' }
-  let(:mapper_klass) { Spot::Mappers::get(source) }
+  let(:mapper_klass) { Spot::Mappers.get(source) }
   let(:work_klass) { 'Publication' }
   let(:fixtures_path) { Rails.root.join('spec', 'fixtures') }
   let(:bag_path) { fixtures_path.join('sample-bag') }

--- a/spec/jobs/spot/ingest_zipped_bag_job_spec.rb
+++ b/spec/jobs/spot/ingest_zipped_bag_job_spec.rb
@@ -4,16 +4,15 @@ require 'tmpdir'
 RSpec.describe Spot::IngestZippedBagJob do
   subject(:job) do
     described_class.perform_now(zip_path: zip_path,
-                                work_class: work_class,
+                                work_klass: work_klass,
                                 source: source,
                                 collection_ids: collection_ids,
-                                multi_value_character: ';',
                                 working_path: working_path)
   end
 
   let(:working_path) { Rails.root.join('tmp') }
   let(:zip_path) { '/path/to/bag.zip' }
-  let(:work_class) { 'Publication' }
+  let(:work_klass) { 'Publication' }
   let(:source) { 'ldr' }
   let(:zip_service_double) { instance_double(ZipService, unzip!: true) }
   let(:collection_ids) { ['abc123def'] }
@@ -31,7 +30,7 @@ RSpec.describe Spot::IngestZippedBagJob do
       expect(Spot::IngestBagJob)
         .to have_received(:perform_now)
         .with(bag_path: working_path.join('bag').to_s, source: source,
-              work_class: work_class, collection_ids: collection_ids, multi_value_character: ';')
+              work_klass: work_klass, collection_ids: collection_ids)
     end
 
     context 'when working path isn\'t a directory' do

--- a/spec/jobs/spot/ingest_zipped_bag_job_spec.rb
+++ b/spec/jobs/spot/ingest_zipped_bag_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Spot::IngestZippedBagJob do
 
       expect(Spot::IngestBagJob)
         .to have_received(:perform_now)
-        .with(bag_path: working_path.join('bag').to_s, source: source,
+        .with(path: working_path.join('bag').to_s, source: source,
               work_klass: work_klass, collection_ids: collection_ids)
     end
 

--- a/spec/services/spot/bag_ingest_service_spec.rb
+++ b/spec/services/spot/bag_ingest_service_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+RSpec.describe Spot::BagIngestService do
+  subject(:service) do
+    described_class.new(path: bag_path, work_klass: work_class, mapper_klass: mapper_klass).ingest
+  end
+
+  let(:mapper_klass) { Spot::Mappers::LdrDspaceMapper }
+  let(:source) { 'ldr' }
+  let(:work_class) { Publication }
+  let(:fixtures_path) { Rails.root.join('spec', 'fixtures') }
+  let(:bag_path) { fixtures_path.join('sample-bag') }
+  let(:importer_double) { instance_double(Darlingtonia::Importer, import: true) }
+
+  before do
+    allow(Darlingtonia::Importer).to receive(:new).and_return(importer_double)
+  end
+
+  describe '#ingest' do
+    context 'when a work_class isn\'t registered' do
+      let(:work_class) { 'Spot' }
+
+      it 'raises an ArgumentError' do
+        expect { service }.to raise_error(ArgumentError, /Unknown work_klass: #{work_class}/)
+      end
+    end
+
+    context 'when the bag validates okay' do
+      it 'calls #import on the importer' do
+        service
+
+        expect(importer_double).to have_received(:import)
+      end
+    end
+
+    context 'when the bag does not validate' do
+      let(:parser_double) do
+        instance_double(Spot::Importers::Bag::Parser, validate!: false)
+      end
+
+      before do
+        allow(Spot::Importers::Bag::Parser).to receive(:new).and_return(parser_double)
+      end
+
+      it 'does nothing' do
+        service
+
+        expect(importer_double).not_to have_received(:import)
+      end
+    end
+  end
+end

--- a/spec/services/spot/mappers/alsace_images_mapper_spec.rb
+++ b/spec/services/spot/mappers/alsace_images_mapper_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+RSpec.describe Spot::Mappers::AlsaceImagesMapper do
+  let(:mapper) { described_class.new }
+  let(:metadata) { {} }
+
+  before { mapper.metadata = metadata }
+
+  it_behaves_like 'it has language-tagged titles'
+
+  describe '#inscription' do
+    subject { mapper.inscription }
+
+    let(:metadata) do
+      {
+        'description.inscription.french' => ['Partez bien bien vite vers ce midi'],
+        'description.inscription.german' => ['Lebende bad.'],
+        'description.text.french' => ['Les vandales pleure pas!'],
+        'description.text.german' => ['Volkstracht aus Allmannweier']
+      }
+    end
+
+    let(:expected_results) do
+      [
+        RDF::Literal('Partez bien bien vite vers ce midi', language: :fr),
+        RDF::Literal('Lebende bad.', language: :de),
+        RDF::Literal('Les vandales pleure pas!', language: :fr),
+        RDF::Literal('Volkstracht aus Allmannweier', language: :de)
+      ]
+    end
+
+    it { is_expected.to include(*expected_results) }
+  end
+
+  describe '#resource_type' do
+    subject { mapper.resource_type }
+
+    it { is_expected.to eq ['Image'] }
+  end
+end

--- a/spec/support/shared_examples/base_eaic_mapper.rb
+++ b/spec/support/shared_examples/base_eaic_mapper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'a base EAIC mapper' do
+  it_behaves_like 'it has language-tagged titles'
+end

--- a/spec/support/shared_examples/language_tagged_titles.rb
+++ b/spec/support/shared_examples/language_tagged_titles.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'it has language-tagged titles' do
+  let(:mapper) { described_class.new }
+  let(:metadata) { {} }
+
+  before do
+    mapper.metadata = metadata
+  end
+
+  if described_class.new.fields.include? :title
+    describe '#title' do
+      subject { mapper.title }
+
+      let(:primary_title_key) { described_class.primary_title_map.keys.first }
+      let(:metadata) { { primary_title_key => 'The Beyond' } }
+
+      it { is_expected.to eq [RDF::Literal('The Beyond', language: :en)] }
+    end
+  end
+
+  if described_class.new.fields.include? :title_alternative
+    describe '#title_alternative' do
+      subject { mapper.title_alternative }
+
+      let(:spec_title_alternative_map) do
+        { 'title.french' => :fr, 'title.german' => :de }
+      end
+
+      let(:metadata) do
+        { 'title.french' => ["L'au-delà"], 'title.german' => ['Die Geisterstadt der Zombies'] }
+      end
+
+      # rubocop:disable RSpec/InstanceVariable
+      before do
+        @previous_title_alternative_map = described_class.title_alternative_map
+        described_class.title_alternative_map = spec_title_alternative_map
+      end
+
+      after do
+        described_class.title_alternative_map = @previous_title_alternative_map
+      end
+      # rubocop:enable RSpec/InstanceVariable
+
+      it do
+        is_expected.to include(RDF::Literal("L'au-delà", language: :fr),
+                               RDF::Literal('Die Geisterstadt der Zombies', language: :de))
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/record_importer.rb
+++ b/spec/support/shared_examples/record_importer.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 RSpec.shared_examples 'a RecordImporter' do |params|
   subject(:importer) do
-    described_class.new(work_class: work_class,
+    described_class.new(work_klass: work_klass,
                         admin_set_id: admin_set_id,
                         collection_ids: [collection_id],
                         info_stream: info_stream,
                         error_stream: error_stream)
   end
 
-  let(:work_class) { class_double('ActiveFedora::Base') }
+  let(:work_klass) { class_double('ActiveFedora::Base') }
   let(:dev_null) { File.open(File::NULL, 'w') }
   let(:admin_set_id) { 'an_admin_set' }
   let(:info_stream) { dev_null }
@@ -52,7 +52,7 @@ RSpec.shared_examples 'a RecordImporter' do |params|
       }
     end
 
-    let(:work_double) { instance_double('ActiveFedora::Base', id: '') }
+    let(:work_double) { instance_double('ActiveFedora::Base', id: '', errors: []) }
     let(:depositor) do
       User.find_or_create_by(email: described_class.default_depositor_email)
     end
@@ -72,7 +72,7 @@ RSpec.shared_examples 'a RecordImporter' do |params|
         .with(depositor)
         .and_return(ability_double)
 
-      allow(work_class)
+      allow(work_klass)
         .to receive(:new)
         .and_return(work_double)
 

--- a/spec/support/shared_examples/record_importer.rb
+++ b/spec/support/shared_examples/record_importer.rb
@@ -56,7 +56,7 @@ RSpec.shared_examples 'a RecordImporter' do |params|
     let(:depositor) do
       User.find_or_create_by(email: described_class.default_depositor_email)
     end
-    let(:env_double) { instance_double('Hyrax::Actors::Environment') }
+    let(:env_double) { instance_double('Hyrax::Actors::Environment', attributes: attributes) }
     let(:ability_double) { instance_double('Ability') }
     let(:actor_stack_double) { instance_double('Hyrax::Actors::AbstractActor') }
 


### PR DESCRIPTION
- moves ingest work out of a job and into a service
- reports model errors if they exist after ingest (previously these were being ignored)
- adds some mapper functionality
  - `Spot::Mappers::LanguageTaggedLiterals` mixin
  - `Spot::Mappers::BaseEaicMapper`
  - `Spot::Mappers::AlsaceImagesMapper`
