### PR TITLE
block /catalog and /downloads routes from all indexing bots

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,3 +3,9 @@
 User-agent: archive.org_bot
 Disallow: /concern
 Disallow: /downloads
+
+# Prevent indexers from crawling every facet/search option
+User-agent: *
+Disallow: /catalog
+Disallow: /catalog/*
+Disallow: /downloads


### PR DESCRIPTION
this weekend we got slammed by googlebot indexing every permutation of `/catalog` via facets which was kinda disastrous. so let's not allow that anymore.

closes #388 