### PR TITLE
serve iiif images using the created access derivatives

### DIFF
--- a/app/services/spot/image_server_file_resolver.rb
+++ b/app/services/spot/image_server_file_resolver.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+module Spot
+  # Service to tell Riiif about where we're storing access copies of our works
+  # to be served by the image server.
+  #
+  # @example Using in Riiif initializer
+  #   # config/initializers/riiif.rb
+  #   Riiif::Image.file_resolver = Spot::ImageServerFileResolver.new
+  #
+  class ImageServerFileResolver < ::Riiif::FileSystemFileResolver
+    def initialize(base_path: rails_derivatives_base)
+      super(base_path: base_path)
+    end
+
+    # Creates a glob pattern for an ID
+    #
+    # @example
+    #   id = "p5547r367/files/b7ccfea9-fa64-437f-87de-ab6ebcdf0cce"
+    #   Spot::ImageServerFileResolver.new.pattern(id)
+    #   # => "/path/to/rails_root/tmp/derivatives/p5/54/7r/36/7-access.{png,jpg,tif,tiff,jp2}"
+    #
+    # @param [String] id
+    # @return [String] glob pattern for asset
+    def pattern(id)
+      clean_id = id.sub(/\A([^\/]*)\/.*/, '\1')
+      return unless validate_identifier(id: clean_id)
+
+      self.base_path = Pathname.new(base_path) unless base_path.is_a? Pathname
+      base_path.join(access_copy_path(clean_id)).to_s
+    end
+
+    private
+
+      # Turns an ID into a pair-tree path to the access copy.
+      #
+      # @param [String] id
+      # @return [String] pair-tree path for ID
+      def access_copy_path(id)
+        id.scan(/\w\w?/).join('/') + "-access.{#{input_types.join(',')}}"
+      end
+
+      def identifier_regex
+        /^[\w\d]+$/
+      end
+
+      def rails_derivatives_base
+        Rails.root.join('tmp', 'derivatives')
+      end
+  end
+end

--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
-Riiif::Image.file_resolver = Riiif::HTTPFileResolver.new
-Riiif::Image.file_resolver.basic_auth_credentials = [
-  ENV.fetch('FEDORA_USER') { 'fedoraAdmin' },
-  ENV.fetch('FEDORA_PASSWORD')
-]
+Riiif::Image.file_resolver = Spot::ImageServerFileResolver.new
+
 Riiif::Image.info_service = lambda do |id, _file|
   # id will look like a path to a pcdm:file
   # (e.g. rv042t299%2Ffiles%2F6d71677a-4f80-42f1-ae58-ed1063fd79c7)
@@ -17,15 +14,9 @@ Riiif::Image.info_service = lambda do |id, _file|
   { height: doc['height_is'], width: doc['width_is'] }
 end
 
-Riiif::Image.file_resolver.id_to_uri = lambda do |id|
-  ActiveFedora::Base.id_to_uri(CGI.unescape(id)).tap do |url|
-    Rails.logger.info "Riiif resolved #{id} to #{url}"
-  end
-end
-
 Riiif::Image.authorization_service = Hyrax::IIIFAuthorizationService
 
 Riiif.not_found_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
 Riiif.unauthorized_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
 
-Riiif::Engine.config.cache_duration_in_days = 365
+Riiif::Engine.config.cache_duration = 7.days

--- a/spec/services/spot/image_server_file_resolver_spec.rb
+++ b/spec/services/spot/image_server_file_resolver_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+RSpec.describe Spot::ImageServerFileResolver do
+  describe '#pattern' do
+    subject { service.pattern(id) }
+
+    let(:service) { described_class.new }
+    let(:id) { 'abc123def' }
+    let(:path) do
+      Rails.root.join('tmp', 'derivatives', 'ab', 'c1', '23', 'de', 'f-access.{png,jpg,tif,tiff,jp2}').to_s
+    end
+
+    it { is_expected.to eq path }
+  end
+end


### PR DESCRIPTION
uses the access copies created during the derivative process (see #262) as the source for our iiif server (at the moment, riiif), rather than pulling it from fedora every time.