### PR TITLE
revert single_use_links keys

### DIFF
--- a/db/migrate/20200128221650_revert_single_use_links_keys.rb
+++ b/db/migrate/20200128221650_revert_single_use_links_keys.rb
@@ -1,0 +1,6 @@
+class RevertSingleUseLinksKeys < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :single_use_links, :download_key, :downloadKey
+    rename_column :single_use_links, :item_id, :itemId
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190327194742) do
+ActiveRecord::Schema.define(version: 20200128221650) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -323,9 +323,9 @@ ActiveRecord::Schema.define(version: 20190327194742) do
   end
 
   create_table "single_use_links", force: :cascade do |t|
-    t.string "download_key"
+    t.string "downloadKey"
     t.string "path"
-    t.string "item_id"
+    t.string "itemId"
     t.datetime "expires"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
reverts snake_cased keys back to camelCase for the SingleUseLinks table. this change comes with hyrax@3 and the migration was accidentally committed way back when (i'd look but i don't want to feel guilty). this reverts it back to the way hyrax@2 is expecting. we'll deal with it when hyrax@3 actually lands