### PR TITLE
use catalog search instead of collection search

### DIFF
--- a/app/views/hyrax/collections/_search_form.html.erb
+++ b/app/views/hyrax/collections/_search_form.html.erb
@@ -1,0 +1,18 @@
+<%= form_for presenter, url: main_app.search_catalog_path, method: :get, class: "well form-search" do |f| %>
+    <label class="sr-only"><%= t('hyrax.collections.search_form.label', title: presenter.to_s) %></label>
+    <div class="input-group">
+      <%= text_field_tag :q,
+          params[:q],
+          class: 'collection-query form-control',
+          placeholder: t('hyrax.collections.search_form.placeholder',
+                         collection_name: presenter.title.first),
+          size: '30',
+          type: 'search',
+          id: 'collection_search' %>
+      <div class="input-group-btn">
+        <button type="submit" class="btn btn-primary" id="collection_submit"><i class="glyphicon glyphicon-search"></i> <%= t('hyrax.collections.search_form.button_label') %></button>
+      </div>
+    </div>
+    <%= hidden_field_tag :'f[member_of_collections_ssim][]', presenter.title.first %>
+    <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:cq, :sort, :qt, :page)) %>
+<% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -15,6 +15,10 @@ en:
       admin_set_title: Administrative Set
       default_title: User Collection
 
+    collections:
+      search_form:
+        placeholder: Search within %{collection_name}
+
     dashboard:
       collections:
         show:


### PR DESCRIPTION
instead of building out the Collection#show page to mimic the behavior of our catalog, why not redirect searches to the catalog and scope it for the collection? this lets the show page act more as a browse tool.