### PR TITLE
map relation.ispartof to keyword for EAIC collections

### DIFF
--- a/app/services/spot/mappers/cpw_nofuko_mapper.rb
+++ b/app/services/spot/mappers/cpw_nofuko_mapper.rb
@@ -6,6 +6,7 @@ module Spot::Mappers
   class CpwNofukoMapper < BaseEaicMapper
     self.fields_map = {
       creator: 'creator.maker',
+      keyword: 'relation.ispartof',
       original_item_extent: 'format.extant',
       physical_medium: 'format.medium',
       publisher: 'creator.company',

--- a/app/services/spot/mappers/pacwar_postcards_mapper.rb
+++ b/app/services/spot/mappers/pacwar_postcards_mapper.rb
@@ -4,6 +4,7 @@ module Spot::Mappers
     self.fields_map = {
       creator: 'creator.maker',
       date_scope_note: 'description.indicia',
+      keyword: 'relation.ispartof',
       physical_medium: 'format.medium',
       publisher: 'creator.company',
       related_resource: 'description.citation',

--- a/app/services/spot/mappers/rjw_stereo_mapper.rb
+++ b/app/services/spot/mappers/rjw_stereo_mapper.rb
@@ -2,6 +2,7 @@
 module Spot::Mappers
   class RjwStereoMapper < BaseEaicMapper
     self.fields_map = {
+      keyword: 'relation.ispartof',
       physical_medium: 'format.medium',
       publisher: 'creator.company',
       related_resource: 'relation.seealso',

--- a/app/services/spot/mappers/warner_souvenirs_mapper.rb
+++ b/app/services/spot/mappers/warner_souvenirs_mapper.rb
@@ -3,6 +3,7 @@ module Spot::Mappers
   class WarnerSouvenirsMapper < BaseEaicMapper
     self.fields_map = {
       date_scope_note: 'description.indicia',
+      keyword: 'relation.ispartof',
       language: 'language',
       physical_medium: 'format.medium',
       publisher: 'creator.company',

--- a/app/services/spot/mappers/woodsworth_images_mapper.rb
+++ b/app/services/spot/mappers/woodsworth_images_mapper.rb
@@ -3,6 +3,7 @@ module Spot::Mappers
   class WoodsworthImagesMapper < BaseEaicMapper
     self.fields_map = {
       date_scope_note: 'description.indicia',
+      keyword: 'relation.ispartof',
       language: 'language',
       physical_medium: 'format.medium',
       publisher: 'creator.company',

--- a/spec/services/spot/mappers/cpw_nofuko_mapper_spec.rb
+++ b/spec/services/spot/mappers/cpw_nofuko_mapper_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe Spot::Mappers::CpwNofukoMapper do
     it { is_expected.to eq expected_values }
   end
 
+  describe '#keyword' do
+    subject { mapper.keyword }
+
+    let(:field) { 'relation.ispartof' }
+
+    it_behaves_like 'a mapped field'
+  end
+
   describe '#original_item_extent' do
     subject { mapper.original_item_extent }
 

--- a/spec/services/spot/mappers/pacwar_postcards_mapper_spec.rb
+++ b/spec/services/spot/mappers/pacwar_postcards_mapper_spec.rb
@@ -63,6 +63,14 @@ RSpec.describe Spot::Mappers::PacwarPostcardsMapper do
     it { is_expected.to eq expected_values }
   end
 
+  describe '#keyword' do
+    subject { mapper.keyword }
+
+    let(:field) { 'relation.ispartof' }
+
+    it_behaves_like 'a mapped field'
+  end
+
   describe '#physical_medium' do
     subject { mapper.physical_medium }
 

--- a/spec/services/spot/mappers/rjw_stereo_mapper_spec.rb
+++ b/spec/services/spot/mappers/rjw_stereo_mapper_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe Spot::Mappers::RjwStereoMapper do
     it { is_expected.to eq expected_results }
   end
 
+  describe '#keyword' do
+    subject { mapper.keyword }
+
+    let(:field) { 'relation.ispartof' }
+
+    it_behaves_like 'a mapped field'
+  end
+
   describe '#publisher' do
     subject { mapper.publisher }
 

--- a/spec/services/spot/mappers/warner_souvenirs_mapper_spec.rb
+++ b/spec/services/spot/mappers/warner_souvenirs_mapper_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe Spot::Mappers::WarnerSouvenirsMapper do
     it_behaves_like 'a mapped field'
   end
 
+  describe '#keyword' do
+    subject { mapper.keyword }
+
+    let(:field) { 'relation.ispartof' }
+
+    it_behaves_like 'a mapped field'
+  end
+
   describe '#language' do
     subject { mapper.language }
 

--- a/spec/services/spot/mappers/woodsworth_images_mapper_spec.rb
+++ b/spec/services/spot/mappers/woodsworth_images_mapper_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe Spot::Mappers::WoodsworthImagesMapper do
     it { is_expected.to eq expected_values }
   end
 
+  describe '#keyword' do
+    subject { mapper.keyword }
+
+    let(:field) { 'relation.ispartof' }
+
+    it_behaves_like 'a mapped field'
+  end
+
   describe '#language' do
     subject { mapper.language }
 


### PR DESCRIPTION
per discussions in chats, this maps the collections heading (which includes names/groupings that we haven't designated as official "collections") to the `keyword` field, similar to the newspaper mapper.