### PR TITLE
use password for circle-ci postgres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       - image: postgres:9.4-alpine
         environment:
           POSTGRES_USER: spot_dev_user
-          POSTGRES_PASSWORD: ''
+          POSTGRES_PASSWORD: password
           POSTGRES_DB: spot_test
       - image: ualbertalib/docker-fcrepo4:4.7
         environment:
@@ -62,7 +62,7 @@ jobs:
       FCREPO_TEST_PORT: 8080/fcrepo
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
       PSQL_USER: spot_dev_user
-      PSQL_PASSWORD: ''
+      PSQL_PASSWORD: password
       PSQL_DATABASE: spot_test
       CI: true
       CAS_BASE_URL: http://localhost


### PR DESCRIPTION
should fix this error that started popping up 

```
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD for the superuser. Use
       "-e POSTGRES_PASSWORD=password" to set it in "docker run".

       You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all connections
       without a password. This is *not* recommended. See PostgreSQL
       documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html
Exited with code 1
CircleCI received exit code 1
```