### PR TITLE
upgrade puma again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 gem 'rails', '5.1.6.2'
 
 # use Puma as the app server (dev only, we're using passenger in production)
-gem 'puma', '3.12.3'
+gem 'puma', '3.12.4'
 
 # Use SCSS for stylesheets
 gem 'sass-rails', '5.0.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -607,7 +607,7 @@ GEM
     powerpack (0.1.2)
     public_suffix (4.0.1)
     pul_uv_rails (2.0.1)
-    puma (3.12.3)
+    puma (3.12.4)
     qa (2.2.0)
       activerecord-import
       deprecation
@@ -974,7 +974,7 @@ DEPENDENCIES
   mini_magick (= 4.9.5)
   okcomputer (= 1.17.4)
   pg (= 1.1.4)
-  puma (= 3.12.3)
+  puma (= 3.12.4)
   rails (= 5.1.6.2)
   rails-controller-testing (~> 1.0.4)
   rdf-vocab (= 3.0.8)


### PR DESCRIPTION
3.12.3 was yanked and it's causing the dependabot prs to fail because they can't find it

<img width="352" alt="Screen Shot 2020-03-03 at 1 05 30 PM" src="https://user-images.githubusercontent.com/2744987/75805379-ba712c00-5d4f-11ea-945f-3fc7884be9ff.png">

closes #421 
