### PR TITLE
only use the first layer of preservation source for access copies

### DIFF
--- a/app/services/spot/derivatives/access_master_service.rb
+++ b/app/services/spot/derivatives/access_master_service.rb
@@ -21,7 +21,7 @@ module Spot
       # @return [void]
       def create_derivatives(filename)
         MiniMagick::Tool::Convert.new do |magick|
-          magick << filename
+          magick << "#{filename}[0]"
           # note: we need to use an array for each piece of this command;
           # using a string will cause an error
           magick.merge! %w[-define tiff:tile-geometry=128x128 -compress jpeg]

--- a/spec/services/spot/derivatives/access_master_service_spec.rb
+++ b/spec/services/spot/derivatives/access_master_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
 
     let(:expected_commands) do
       [
-        '/path/to/file',
+        '/path/to/file.jpg[0]',
         '-define', 'tiff:tile-geometry=128x128',
         '-compress', 'jpeg',
         'ptif:/path/to/a/fs-access.tif'
@@ -48,7 +48,7 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
     end
 
     it 'sends imagemagick commands to MiniMagick' do
-      service.create_derivatives('/path/to/file')
+      service.create_derivatives('/path/to/file.jpg')
 
       expect(magick_commands).to eq(expected_commands)
     end


### PR DESCRIPTION
some of our incoming tif source files are causing imagemagick to hang when creating access copies. it seems like tifs with multiple layers are the culprits, so we'll treat the first layer as the source.