### PR TITLE
add multiple-authority input

### DIFF
--- a/app/assets/javascripts/multi-authority-source.js
+++ b/app/assets/javascripts/multi-authority-source.js
@@ -1,0 +1,17 @@
+var Autocomplete = require('hyrax/autocomplete')
+var autocomplete = new Autocomplete()
+
+$(document).ready(function () {
+  $('.form-control.authority-select').on('change', function () {
+    var $this = $(this)
+    var authorityPath = $this.val()
+    var $input = $this.parent().parent().find('input.form-control')
+
+    $input.data('autocompleteUrl', authorityPath)
+    $input.attr('readonly', false)
+
+    autocomplete.setup($input,
+                       $input.data('autocomplete'),
+                       $input.data('autocompleteUrl'))
+  })
+})

--- a/app/inputs/multi_authority_controlled_vocabulary_input.rb
+++ b/app/inputs/multi_authority_controlled_vocabulary_input.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+#
+# @todo There's probably a world/future where the work of this input and
+#       {StandardIdentifierInputGroupInput} could be extracted as a common-
+#       denominator for providing the skeleton of multi-values that render
+#       a dropdown and an input.
+class MultiAuthorityControlledVocabularyInput < ControlledVocabularyInput
+  def input_type
+    'multi_value multi_authority'
+  end
+
+  private
+
+    def build_field(raw_value, index)
+      authorities = authority_select_options
+      return if authorities.empty?
+
+      <<-HTML
+      <div class="row">
+        <!-- authority-select dropdown -->
+        <div class="col-sm-4">
+          #{build_authority_dropdown(raw_value, index, authorities)}
+        </div>
+
+        <!-- field input -->
+        <div class="col-sm-8">
+          #{build_input(raw_value, index)}
+        </div>
+      </div>
+      HTML
+    end
+
+    # @return [Array<#to_s>]
+    def authority_select_options
+      return [] unless options.include?(:authorities)
+      options[:authorities].dup
+    end
+
+    # @return [String]
+    def build_authority_dropdown(value, index, authorities)
+      <<-HTML
+      <select class="form-control authority-select">
+        <option value="" selected>pick an authority</option>
+        #{authority_option_html(authorities)}
+      </select>
+      HTML
+    end
+
+    # @return [String]
+    def build_input(raw_value, index)
+      options = {
+        class: 'form-control',
+        data: { autocomplete: attribute_name },
+        readonly: true,
+        value: raw_value
+      }
+
+      @builder.text_field(attribute_name, options)
+    end
+
+    # @return [Spot::AuthoritySelectService]
+    def select_service
+      @select_service ||= Spot::AuthoritySelectService.new
+    end
+
+    # @param [Array<Symbol,String>]
+    # @return [String]
+    def authority_option_html(authorities)
+      select_service.select_options_for(*authorities).map do |auth|
+        %(<option value="#{auth[:search]}">#{auth[:label]}</option>)
+      end.join.html_safe
+    end
+end

--- a/app/services/spot/authority_select_service.rb
+++ b/app/services/spot/authority_select_service.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Spot
+  class AuthoritySelectService < ::Hyrax::QaSelectService
+    def initialize
+      super('remote_authorities')
+    end
+
+    def select_options_for(*ids)
+      ids.map { |id| authority.find(id.to_s).reject { |k, _v| k == 'id' } }
+    end
+  end
+end

--- a/app/views/images/edit_fields/_location.html.erb
+++ b/app/views/images/edit_fields/_location.html.erb
@@ -1,0 +1,3 @@
+<%= f.input :location,
+            as: :multi_authority_controlled_vocabulary,
+            authorities: [:geonames, :fast] %>

--- a/config/authorities/remote_authorities.yml
+++ b/config/authorities/remote_authorities.yml
@@ -1,0 +1,7 @@
+terms:
+  - id: fast
+    label: FAST
+    search: /authorities/search/linked_data/oclc_fast
+  - id: geonames
+    label: GeoNames
+    search: /authorities/search/geonames


### PR DESCRIPTION
adds an input which allows multiple authorities to be used for autocomplete

## todo
- [ ] add hidden field for storing uri
- [ ] update help text
- [ ] reset values when another row is added 
- [ ] add specs

----

closes #414 