### PR TITLE
force http for islandora uris

### DIFF
--- a/app/services/spot/mappers/base_mapper.rb
+++ b/app/services/spot/mappers/base_mapper.rb
@@ -96,13 +96,8 @@ module Spot::Mappers
       # @return [Array<String>]
       def islandora_url_identifiers
         metadata.fetch('islandora_url', []).map do |url|
-          parsed = URI.parse(url)
-
-          args = URI::Generic.component.each_with_object({}) do |component, obj|
-            obj[component.to_sym] = parsed.send(component)
-          end
-
-          http_uri = URI::HTTP.build(args).to_s
+          # force the uri into HTTP
+          http_uri = URI.parse(url).tap { |uri| url.scheme = 'http' }.to_s
 
           Spot::Identifier.new('url', http_uri).to_s
         end

--- a/app/services/spot/mappers/base_mapper.rb
+++ b/app/services/spot/mappers/base_mapper.rb
@@ -95,7 +95,17 @@ module Spot::Mappers
 
       # @return [Array<String>]
       def islandora_url_identifiers
-        metadata.fetch('islandora_url', []).map { |url| Spot::Identifier.new('url', url).to_s }
+        metadata.fetch('islandora_url', []).map do |url|
+          parsed = URI.parse(url)
+
+          args = URI::Generic.component.each_with_object({}) do |component, obj|
+            obj[component.to_sym] = parsed.send(component)
+          end
+
+          http_uri = URI::HTTP.build(args).to_s
+
+          Spot::Identifier.new('url', http_uri).to_s
+        end
       end
 
       # Helper method to group the values for multiple fields into one place.

--- a/app/services/spot/mappers/base_mapper.rb
+++ b/app/services/spot/mappers/base_mapper.rb
@@ -95,9 +95,9 @@ module Spot::Mappers
 
       # @return [Array<String>]
       def islandora_url_identifiers
-        metadata.fetch('islandora_url', []).map do |url|
+        metadata.fetch('islandora_url', []).map do |value|
           # force the uri into HTTP
-          http_uri = URI.parse(url).tap { |uri| url.scheme = 'http' }.to_s
+          http_uri = URI.parse(value).tap { |uri| uri.scheme = 'http' }.to_s
 
           Spot::Identifier.new('url', http_uri).to_s
         end

--- a/spec/support/shared_examples/mappers/maps_islandora_url.rb
+++ b/spec/support/shared_examples/mappers/maps_islandora_url.rb
@@ -2,7 +2,7 @@
 RSpec.shared_examples 'it maps Islandora URLs to identifiers' do
   subject { mapper.identifier }
 
-  let(:metadata) { { 'islandora_url' => ['http://digital.lafayette.edu/collections/example/aa1234'] } }
+  let(:metadata) { { 'islandora_url' => ['https://digital.lafayette.edu/collections/example/aa1234'] } }
 
   it { is_expected.to include 'url:http://digital.lafayette.edu/collections/example/aa1234' }
 end


### PR DESCRIPTION
ensure that we're mapping islandora uris as http (rather than https) as this is the expected identifier form for the redirect_controller