### PR TITLE
2020.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # changelog
 
+## [2020.6] - 2020-04-30
+
+### updates ⛰
+- use `URL_HOST` environment variable for slack fixity notifications, falling back to `hostname` (#460)
+- add location to image iiif manifest (#463)
+- add `research_assistance` to image display view (#472)
+
+### bug fixes 🐞
+- use subject labels for image iiif manifests (#463)
+- eradicate collections during tests to prevent `Ldp::Gone` errors (#470)
+- restrict guest accounts to a single db entry (#469)
+- use single quotes when adding html to simple_form hints to allow links to render properly in tooltips (#471)
+- collection_form now strips whitespace from all strings (#474)
+- Image#resource_type now indexes as `_tesim` and `_sim`, similarly to Publication (#475)
+- logging in from an Image show page will no longer redirect back to the item's iiif manifest (#477)
+- date values with matching start/end values are mapped to the single value (rather than `1930/1930`) (#480)
+- w/ eaic collections, map rights_statement values from either `rights.digital` or `rights.statement` (#481)
+
+
 ## [2020.5] - 2020-04-06
 
 ### features 🏔
@@ -350,6 +369,7 @@ fixes:
 
 Initial pre-release (live on ldr.stage.lafayette.edu)
 
+[2020.6]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2020.6
 [2020.5]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2020.5
 [2020.4]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2020.4
 [2020.3]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2020.3

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,6 +25,16 @@ class ApplicationController < ActionController::Base
     super.reject { |k, _v| k == :locale }
   end
 
+  # Borrowed from pul's figgy app. Restricts our guests to a single entry
+  # in the database, preventing hundreds of fake user accounts from being
+  # generated.
+  #
+  # @see https://github.com/pulibrary/figgy/blob/801141d/app/controllers/application_controller.rb#L31-L35
+  # @return [User]
+  def guest_user
+    @guest_user ||= User.where(guest: true).first || super
+  end
+
   private
 
     # Modified from its source in +Hyrax::Controller+ in that we're

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,7 +79,7 @@ class ApplicationController < ActionController::Base
     # Also adds a check to ignore download paths (iframe requests made by an item
     # viewer will take precedence over the user's last visited path).
     def storable_location?
-      return false if request.path.start_with? '/downloads'
+      return false if request.path.start_with?('/downloads') || request.path.end_with?('/manifest')
       request.get? && is_navigational_format? && !devise_controller? && !request.xhr?
     end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -136,6 +136,9 @@ class CatalogController < ApplicationController
     config.add_facet_field 'subject_ocm_ssim',
                            label: :'blacklight.search.facets.subject_ocm',
                            if: false
+    config.add_facet_field 'research_assistance_ssim',
+                           label: :'blacklight.search.facets.research_assistance',
+                           if: false
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/app/forms/concerns/strips_whitespace.rb
+++ b/app/forms/concerns/strips_whitespace.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+#
+# Mixin to remove whitespace from form param fields when calling +.model_attributes+
+module StripsWhitespace
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    # @param [ActionController::Parameters, Hash] form_params
+    # @return [Hash<Symbol => Array<String>>]
+    def model_attributes(form_params)
+      super.tap do |params|
+        terms.each do |key|
+          if params[key].is_a? Array
+            params[key] = params[key].map { |v| v.respond_to?(:strip) ? v.strip : v }.reject(&:blank?)
+          elsif params[key].is_a? String
+            params[key] = params[key].strip
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/forms/spot/forms/collection_form.rb
+++ b/app/forms/spot/forms/collection_form.rb
@@ -23,6 +23,7 @@ module Spot
       include ::LanguageTaggedFormFields
       include ::NestedFormFields
       include ::SingularFormFields
+      include ::StripsWhitespace
 
       transforms_language_tags_for :title, :abstract, :description
       transforms_nested_fields_for :language

--- a/app/forms/spot/forms/work_form.rb
+++ b/app/forms/spot/forms/work_form.rb
@@ -7,6 +7,7 @@ module Spot
       include ::LanguageTaggedFormFields
       include ::NestedFormFields
       include ::SingularFormFields
+      include ::StripsWhitespace
 
       # These are Hyrax-specific fields that deal with embargoes,
       # parent/child relationships. These need to be present in
@@ -34,33 +35,6 @@ module Spot
       # @return [TrueClass, FalseClass]
       def multiple?(term)
         self.class.multiple?(term)
-      end
-
-      class << self
-        # Used to transform values from the form into those that
-        # get added to the object.
-        #
-        # @param [ActionController::Parameters, Hash] form_params
-        # @return [Hash<Symbol => Array<String>>]
-        def model_attributes(form_params)
-          super.tap do |params|
-            strip_whitespace(params)
-          end
-        end
-
-        private
-
-          # @param [ActiveController::Parameters, Hash<String => *>]
-          # @return [void]
-          def strip_whitespace(params)
-            terms.each do |key|
-              if params[key].is_a? Array
-                params[key] = params[key].map(&:strip).reject(&:blank?)
-              elsif params[key].is_a? String
-                params[key] = params[key].strip
-              end
-            end
-          end
       end
     end
   end

--- a/app/jobs/spot/send_fixity_status_job.rb
+++ b/app/jobs/spot/send_fixity_status_job.rb
@@ -38,6 +38,10 @@ module Spot
                           as_user: true)
       end
 
+      def fixity_host
+        ENV.fetch('URL_HOST', "`#{`hostname`.chomp}`")
+      end
+
       # rubocop:disable Metrics/MethodLength
       #
       # The expected API format to create a 'block', rather than
@@ -51,7 +55,7 @@ module Spot
             text: {
               type: 'mrkdwn',
               text: "Performed #{@item_count} fixity #{'check'.pluralize(@item_count)} " \
-                    "in #{@job_time} seconds on `#{`hostname`.chomp}`"
+                    "in #{@job_time} seconds on #{fixity_host}"
             },
             fields: [
               { type: 'mrkdwn',     text: ':white_check_mark: *Successes*' },

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -38,7 +38,7 @@ class Image < ActiveFedora::Base
   end
 
   property :resource_type, predicate: ::RDF::Vocab::DC.type do |index|
-    index.as :symbol
+    index.as :stored_searchable, :facetable
   end
 
   property :physical_medium, predicate: ::RDF::Vocab::DC.PhysicalMedium do |index|

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -7,14 +7,15 @@ module Hyrax
              :original_item_extent, :physical_medium, :publisher,
              :related_resource, :repository_location, :requested_by,
              :research_assistance, :resource_type, :rights_holder,
-             :rights_statement, :standard_identifier, :subtitle, :title_alternative,
+             :rights_statement, :standard_identifier, :subtitle,
+             :title_alternative,
              to: :solr_document
 
     def manifest_metadata_fields
       %i[
         title subtitle title_alternative creator contributor date
-        description inscription keyword language_label subject subject_ocm
-        standard_identifier rights_statement
+        description inscription keyword language_label location
+        subject subject_ocm standard_identifier rights_statement
       ]
     end
 

--- a/app/renderers/spot/renderers/attribute_renderer.rb
+++ b/app/renderers/spot/renderers/attribute_renderer.rb
@@ -2,6 +2,24 @@
 #
 # Rewriting Hyrax::Renderers::AttributeRenderer to better suit
 # how we're displaying metadata.
+#
+# @example
+#   renderer = Spot::Renderers::AttributeRenderer.new(:title, ['Title of Work'])
+#   renderer.render
+#   #=> "<tr><th rowspan=\"1\">Title</th><td>Title of Work</td></tr>"
+#
+# @exampe Using {Spot::Presenters::BasePresenter} (intended use)
+#   work = Publication.find('abc123def')
+#   ability = Ability.new(nil)
+#   presenter = Spot::Presenters::PublicationPresenter(SolrDocument.new(work.to_solr), ability, nil)
+#   presenter.attribute_to_html(:title)
+#   #=> "<tr><th rowspan=\"1\">Title</th><td>Title of Work</td></tr>"
+#
+# @example Render with a Bootstrap Tooltip displaying help text
+#   presenter.attribute_to_html(:title, show_help_text: true)
+#   #=> "<tr><th rowspan=\"1\">Title <span ...>Name of the work</span></th><td>Title of Work</td></tr>"
+#
+# @note: if rendering a help tooltip, _be sure to use single quotes for HTML elements_
 module Spot
   module Renderers
     class AttributeRenderer
@@ -93,9 +111,10 @@ module Spot
           %(#{label_text}
             <span
               class="fa fa-question-circle-o"
+              data-html="true"
               data-toggle="popover"
-              data-content="#{help_text}"
               data-trigger="hover click"
+              data-content="#{help_text}"
             ></span>
           )
         end

--- a/app/services/spot/mappers/base_eaic_mapper.rb
+++ b/app/services/spot/mappers/base_eaic_mapper.rb
@@ -119,7 +119,7 @@ module Spot::Mappers
 
         start_dates.zip(end_dates).map do |(start_date, end_date)|
           # EDTF date ranges are "#{start_date}/#{end_date}"
-          [start_date, end_date].reject(&:blank?).join('/')
+          [start_date, end_date].reject(&:blank?).uniq.join('/')
         end
       end
   end

--- a/app/services/spot/mappers/base_eaic_mapper.rb
+++ b/app/services/spot/mappers/base_eaic_mapper.rb
@@ -70,12 +70,12 @@ module Spot::Mappers
     end
     alias representative_file representative_files
 
-    # Grabs and convert values in 'rights.statement' to RDF::URI objects
-    # (where applicable). Non-URIs are retained as strings.
+    # Grabs and convert values in 'rights.statement' and 'rights.digital'
+    # to RDF::URI objects (where applicable). Non-URIs are retained as strings.
     #
     # @return [Array<RDF::URI, String>]
     def rights_statement
-      convert_uri_strings(metadata.fetch('rights.statement', []))
+      convert_uri_strings(merge_fields('rights.statement', 'rights.digital').uniq)
     end
 
     # Grabs and convert values in 'subject' to RDF::URI objects

--- a/app/services/spot/mappers/base_mapper.rb
+++ b/app/services/spot/mappers/base_mapper.rb
@@ -108,7 +108,7 @@ module Spot::Mappers
       # @param [Array<String>] *names field names to merge
       # @return [Array<String>]
       def merge_fields(*names)
-        names.map { |name| metadata[name] }.flatten.reject(&:blank?).compact
+        names.map { |name| metadata.fetch(name, nil) }.flatten.reject(&:blank?)
       end
   end
 end

--- a/app/services/spot/mappers/warner_souvenirs_mapper.rb
+++ b/app/services/spot/mappers/warner_souvenirs_mapper.rb
@@ -26,15 +26,5 @@ module Spot::Mappers
         :title_alternative
       ]
     end
-
-    # @return [Array<RDF::URI>]
-    def location
-      convert_uri_strings(merge_fields('coverage.location', 'coverage.location.country'))
-    end
-
-    # @return [Array<RDF::URI>]
-    def rights_statement
-      convert_uri_strings(metadata.fetch('rights.statement', []))
-    end
   end
 end

--- a/app/views/hyrax/images/_metadata.html.erb
+++ b/app/views/hyrax/images/_metadata.html.erb
@@ -31,6 +31,7 @@
                                       search_field: :location_label_ssim) %>
       <%= presenter.attribute_to_html(:standard_identifier, render_as: :identifier) %>
       <%= presenter.attribute_to_html(:related_resource) %>
+      <%= presenter.attribute_to_html(:research_assistance, render_as: :faceted) %>
       <%= presenter.attribute_to_html(:permalink) %>
 
       <%= render 'shared/metadata/rights_statement', presenter: presenter %>

--- a/app/views/hyrax/images/_metadata.html.erb
+++ b/app/views/hyrax/images/_metadata.html.erb
@@ -31,7 +31,9 @@
                                       search_field: :location_label_ssim) %>
       <%= presenter.attribute_to_html(:standard_identifier, render_as: :identifier) %>
       <%= presenter.attribute_to_html(:related_resource) %>
-      <%= presenter.attribute_to_html(:research_assistance, render_as: :faceted) %>
+      <%= presenter.attribute_to_html(:research_assistance,
+                                      render_as: :faceted,
+                                      search_field: :research_assistance_ssim) %>
       <%= presenter.attribute_to_html(:permalink) %>
 
       <%= render 'shared/metadata/rights_statement', presenter: presenter %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -2,6 +2,7 @@ en:
   blacklight:
     search:
       facets:
+        research_assistance: Research Assistance
         subject_ocm: OCM Classification
         admin:
           title: Admin Facets
@@ -41,6 +42,7 @@ en:
         physical_medium: Physical Medium
         proxy_depositor: Proxy Depositor
         publisher: Publisher
+        research_assistance: Research Assistance
         resource_type: Type
         rights_holder: Rights Holders
         rights_statement: Rights Statement

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -27,8 +27,8 @@ en:
         keyword: Words or phrases you select to describe what the work is about. These are used to search for content.
         language: The language of the work's content.
         license: Licensing and distribution information governing access to the work. Select from the provided drop-down list.
-        local_identifier: A reference to the work from an internal authority. These are free-text but need to have an identifying prefix followed by a colon (ex. "lafayette:magazine_113")
-        location: A place name related to the work, such as its site of publication, or the city, state, or country the work contents are about. <strong>Uses the <a href="http://www.geonames.org" target="_blank">GeoNames web service</a></strong>.
+        local_identifier: A reference to the work from an internal authority. These are free-text but need to have an identifying prefix followed by a colon (ex. &quot;lafayette:magazine_113&quot;)
+        location: A place name related to the work, such as its site of publication, or the city, state, or country the work contents are about. <strong>Uses the <a href='http://www.geonames.org' target='_blank'>GeoNames web service</a></strong>.
         note: Information important to internal maintenance of records or relevant to the original items, such as administrative, digitization, or decision documentation.
         organization: The organization associated with the resource.
         original_item_extent: The size or duration of the physical resource.
@@ -44,8 +44,8 @@ en:
         source: A related resource from which the described resource is derived.
         sponsor: A person or organization that supports a thing through a pledge, promise, or financial contribution.
         standard_identifier: "A reference to the work from an outside authority. Currently, we support: <strong>DOI, Handle, ISSN, ISBN</strong>"
-        subject: Headings or index terms describing what the work is about; these do need to conform to an existing vocabulary. <strong>Uses <a href="http://fast.oclc.org/" target="_blank">OCLC's FAST subject headings</a>.</strong>
-        subject_ocm: Yale Human Relations Area Files ethnographic subject classification index system. Visit the <strong><a href="https://hraf.yale.edu/resources/reference/outline-of-cultural-materials" target="_blank">Yale guide</a></strong> to learn more.
+        subject: Headings or index terms describing what the work is about; these do need to conform to an existing vocabulary. <strong>Uses <a href='http://fast.oclc.org/' target='_blank'>OCLC's FAST subject headings</a>.</strong>
+        subject_ocm: Yale Human Relations Area Files ethnographic subject classification index system. Visit the <strong><a href='https://hraf.yale.edu/resources/reference/outline-of-cultural-materials' target='_blank'>Yale guide</a></strong> to learn more.
         subtitle: An explanatory or alternative title of a publication.
         title: A name to aid in identifying a work.
         title_alternative: An alternative name for the resource.

--- a/spec/forms/spot/forms/collection_form_spec.rb
+++ b/spec/forms/spot/forms/collection_form_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Spot::Forms::CollectionForm do
   let(:hyrax_fields) { %i[visibility collection_type_gid] }
 
   it_behaves_like 'it handles identifier form fields'
+  it_behaves_like 'it strips whitespaces from values'
 
   shared_context 'required fields' do
     it 'contains required fields' do

--- a/spec/indexers/image_indexer_spec.rb
+++ b/spec/indexers/image_indexer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ImageIndexer do
     publisher: %w[tesim sim],
     repository_location: %w[ssim],
     source: %w[ssim],
-    resource_type: %w[ssim],
+    resource_type: %w[tesim sim],
     physical_medium: %w[tesim sim],
     original_item_extent: %w[tesim],
     description: %w[tesim],

--- a/spec/jobs/spot/send_fixity_status_job_spec.rb
+++ b/spec/jobs/spot/send_fixity_status_job_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Spot::SendFixityStatusJob do
     before do
       stub_env('SLACK_API_TOKEN', 'abc123')
       stub_env('SLACK_FIXITY_CHANNEL', '#the-cool-zone')
+      stub_env('URL_HOST', 'https://ldr.lafayette.edu')
 
       perform_job!
     end
@@ -38,8 +39,7 @@ RSpec.describe Spot::SendFixityStatusJob do
                               type: 'section',
                               text: {
                                 type: 'mrkdwn',
-                                text: 'Performed 100 fixity checks in 25 seconds on ' \
-                    "`#{`hostname`.chomp}`"
+                                text: 'Performed 100 fixity checks in 25 seconds on https://ldr.lafayette.edu'
                               },
                               fields: [
                                 { type: 'mrkdwn', text: ':white_check_mark: *Successes*' },

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -20,15 +20,15 @@ RSpec.describe Collection do
   it { is_expected.to have_editable_property(:sponsor).with_predicate(schema.sponsor) }
 
   describe '.find' do
+    subject { described_class.find(param) }
+
     before { collection.save }
-    after { collection.destroy }
+    after { collection.destroy(eradicate: true) }
 
     context 'when a slug' do
       let(:param) { 'cool-collection' }
 
       context 'when a collection with that slug exists' do
-        subject { described_class.find(param) }
-
         let(:params) { base_params.merge(identifier: ["slug:#{param}"]) }
 
         it { is_expected.to eq collection }

--- a/spec/renderers/spot/renderers/attribute_renderer_spec.rb
+++ b/spec/renderers/spot/renderers/attribute_renderer_spec.rb
@@ -72,9 +72,10 @@ RSpec.describe Spot::Renderers::AttributeRenderer do
           <th rowspan="1">Title
             <span
               class="fa fa-question-circle-o"
+              data-html="true"
               data-toggle="popover"
-              data-content="#{help_text}"
               data-trigger="hover click"
+              data-content="#{help_text}"
             ></span>
           </th>
           <td class="attribute attribute-title">

--- a/spec/support/shared_examples/forms/strips_whitespace.rb
+++ b/spec/support/shared_examples/forms/strips_whitespace.rb
@@ -2,10 +2,11 @@
 RSpec.shared_examples 'it strips whitespaces from values' do
   subject(:attributes) { described_class.model_attributes(params) }
 
+  let(:field) { :language }
   let(:params) { ActionController::Parameters.new(raw_params) }
-  let(:raw_params) { { creator: ['   An important scholar   ', '  '] } }
+  let(:raw_params) { { field => [' en   ', '  '] } }
 
   it do
-    expect(attributes[:creator]).to eq ['An important scholar']
+    expect(attributes[field]).to eq ['en']
   end
 end

--- a/spec/support/shared_examples/mappers/base_eaic_mapper.rb
+++ b/spec/support/shared_examples/mappers/base_eaic_mapper.rb
@@ -136,9 +136,16 @@ RSpec.shared_examples 'a base EAIC mapper' do |options|
     describe '#rights_statement' do
       subject { mapper.rights_statement }
 
-      let(:metadata) { { 'rights.statement' => ['http://rightsstatements.org/vocab/InC-EDU/1.0/'] } }
+      let(:uri) { 'http://rightsstatements.org/vocab/InC-EDU/1.0/' }
+      let(:metadata) { { 'rights.statement' => [uri] } }
 
-      it { is_expected.to eq [RDF::URI('http://rightsstatements.org/vocab/InC-EDU/1.0/')] }
+      it { is_expected.to eq [RDF::URI(uri)] }
+
+      context 'when the field used is rights.digital' do
+        let(:metadata) { { 'rights.digital' => [uri] } }
+
+        it { is_expected.to eq [RDF::URI(uri)] }
+      end
     end
   end
 

--- a/spec/support/shared_examples/mappers/base_eaic_mapper.rb
+++ b/spec/support/shared_examples/mappers/base_eaic_mapper.rb
@@ -57,6 +57,13 @@ RSpec.shared_examples 'a base EAIC mapper' do |options|
 
         it { is_expected.to eq ['1930'] }
       end
+
+      context 'when lower + upper dates match' do
+        let(:date_lower) { ['1930'] }
+        let(:date_upper) { ['1930'] }
+
+        it { is_expected.to eq ['1930'] }
+      end
     end
   end
 
@@ -69,6 +76,14 @@ RSpec.shared_examples 'a base EAIC mapper' do |options|
       end
 
       it { is_expected.to eq ['1921-01/1932-02-11'] }
+
+      context 'when lower + upper dates match' do
+        let(:metadata) do
+          { 'date.image.lower' => ['1921-01'], 'date.image.upper' => ['1921-01'] }
+        end
+
+        it { is_expected.to eq ['1921-01'] }
+      end
     end
   end
 


### PR DESCRIPTION
## updates ⛰ 
- use `URL_HOST` environment variable for slack fixity notifications, falling back to `hostname` (#460)
- add location to image iiif manifest (#463)
- add `research_assistance` to image display view (#472)

## bug fixes 🐞 
- use subject labels for image iiif manifests (#463)
- eradicate collections during tests to prevent `Ldp::Gone` errors (#470)
- restrict guest accounts to a single db entry (#469)
- use single quotes when adding html to simple_form hints to allow links to render properly in tooltips (#471)
- collection_form now strips whitespace from all strings (#474) 
- Image#resource_type now indexes as `_tesim` and `_sim`, similarly to Publication (#475)
- logging in from an Image show page will no longer redirect back to the item's iiif manifest (#477)
- date values with matching start/end values are mapped to the single value (rather than `1930/1930`) (#480)
- w/ eaic collections, map rights_statement values from either `rights.digital` or `rights.statement` (#481) 

## 🚨 notes for deployment 🚨 
- cache needs to be cleared (both app + sidekiq) in order for iiif manifest updates to display
- `ReindexJob` will need to be run in order for Image#resource_type values to appear in facets

-----

closes #434
closes #449
closes #450
closes #458
closes #465
closes #466 
closes #467
closes #468