### PR TITLE
use single-quotes for tooltip html

### DIFF
--- a/app/renderers/spot/renderers/attribute_renderer.rb
+++ b/app/renderers/spot/renderers/attribute_renderer.rb
@@ -2,6 +2,24 @@
 #
 # Rewriting Hyrax::Renderers::AttributeRenderer to better suit
 # how we're displaying metadata.
+#
+# @example
+#   renderer = Spot::Renderers::AttributeRenderer.new(:title, ['Title of Work'])
+#   renderer.render
+#   #=> "<tr><th rowspan=\"1\">Title</th><td>Title of Work</td></tr>"
+#
+# @exampe Using {Spot::Presenters::BasePresenter} (intended use)
+#   work = Publication.find('abc123def')
+#   ability = Ability.new(nil)
+#   presenter = Spot::Presenters::PublicationPresenter(SolrDocument.new(work.to_solr), ability, nil)
+#   presenter.attribute_to_html(:title)
+#   #=> "<tr><th rowspan=\"1\">Title</th><td>Title of Work</td></tr>"
+#
+# @example Render with a Bootstrap Tooltip displaying help text
+#   presenter.attribute_to_html(:title, show_help_text: true)
+#   #=> "<tr><th rowspan=\"1\">Title <span ...>Name of the work</span></th><td>Title of Work</td></tr>"
+#
+# @note: if rendering a help tooltip, _be sure to use single quotes for HTML elements_
 module Spot
   module Renderers
     class AttributeRenderer
@@ -93,9 +111,10 @@ module Spot
           %(#{label_text}
             <span
               class="fa fa-question-circle-o"
+              data-html="true"
               data-toggle="popover"
-              data-content="#{help_text}"
               data-trigger="hover click"
+              data-content="#{help_text}"
             ></span>
           )
         end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -27,8 +27,8 @@ en:
         keyword: Words or phrases you select to describe what the work is about. These are used to search for content.
         language: The language of the work's content.
         license: Licensing and distribution information governing access to the work. Select from the provided drop-down list.
-        local_identifier: A reference to the work from an internal authority. These are free-text but need to have an identifying prefix followed by a colon (ex. "lafayette:magazine_113")
-        location: A place name related to the work, such as its site of publication, or the city, state, or country the work contents are about. <strong>Uses the <a href="http://www.geonames.org" target="_blank">GeoNames web service</a></strong>.
+        local_identifier: A reference to the work from an internal authority. These are free-text but need to have an identifying prefix followed by a colon (ex. &quot;lafayette:magazine_113&quot;)
+        location: A place name related to the work, such as its site of publication, or the city, state, or country the work contents are about. <strong>Uses the <a href='http://www.geonames.org' target='_blank'>GeoNames web service</a></strong>.
         note: Information important to internal maintenance of records or relevant to the original items, such as administrative, digitization, or decision documentation.
         organization: The organization associated with the resource.
         original_item_extent: The size or duration of the physical resource.
@@ -44,8 +44,8 @@ en:
         source: A related resource from which the described resource is derived.
         sponsor: A person or organization that supports a thing through a pledge, promise, or financial contribution.
         standard_identifier: "A reference to the work from an outside authority. Currently, we support: <strong>DOI, Handle, ISSN, ISBN</strong>"
-        subject: Headings or index terms describing what the work is about; these do need to conform to an existing vocabulary. <strong>Uses <a href="http://fast.oclc.org/" target="_blank">OCLC's FAST subject headings</a>.</strong>
-        subject_ocm: Yale Human Relations Area Files ethnographic subject classification index system. Visit the <strong><a href="https://hraf.yale.edu/resources/reference/outline-of-cultural-materials" target="_blank">Yale guide</a></strong> to learn more.
+        subject: Headings or index terms describing what the work is about; these do need to conform to an existing vocabulary. <strong>Uses <a href='http://fast.oclc.org/' target='_blank'>OCLC's FAST subject headings</a>.</strong>
+        subject_ocm: Yale Human Relations Area Files ethnographic subject classification index system. Visit the <strong><a href='https://hraf.yale.edu/resources/reference/outline-of-cultural-materials' target='_blank'>Yale guide</a></strong> to learn more.
         subtitle: An explanatory or alternative title of a publication.
         title: A name to aid in identifying a work.
         title_alternative: An alternative name for the resource.

--- a/spec/renderers/spot/renderers/attribute_renderer_spec.rb
+++ b/spec/renderers/spot/renderers/attribute_renderer_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe Spot::Renderers::AttributeRenderer do
           <th rowspan="1">Title
             <span
               class="fa fa-question-circle-o"
+              data-html="true"
               data-toggle="popover"
               data-trigger="hover click"
               data-content="#{help_text}"

--- a/spec/renderers/spot/renderers/attribute_renderer_spec.rb
+++ b/spec/renderers/spot/renderers/attribute_renderer_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe Spot::Renderers::AttributeRenderer do
             <span
               class="fa fa-question-circle-o"
               data-toggle="popover"
-              data-content="#{help_text}"
               data-trigger="hover click"
+              data-content="#{help_text}"
             ></span>
           </th>
           <td class="attribute attribute-title">


### PR DESCRIPTION
when using html in a simple_form help text, use single quotes so that those elements render properly in a bootstrap tooltip (using `presenter.attribute_to_html(:attribute, show_help_text: true)`)

closes #409 