### PR TITLE
don't store /manifest locations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,7 +79,7 @@ class ApplicationController < ActionController::Base
     # Also adds a check to ignore download paths (iframe requests made by an item
     # viewer will take precedence over the user's last visited path).
     def storable_location?
-      return false if request.path.start_with? '/downloads'
+      return false if request.path.start_with? '/downloads' || request.path.end_with? '/manifest'
       request.get? && is_navigational_format? && !devise_controller? && !request.xhr?
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,7 +79,7 @@ class ApplicationController < ActionController::Base
     # Also adds a check to ignore download paths (iframe requests made by an item
     # viewer will take precedence over the user's last visited path).
     def storable_location?
-      return false if request.path.start_with? '/downloads' || request.path.end_with? '/manifest'
+      return false if request.path.start_with?('/downloads') || request.path.end_with?('/manifest')
       request.get? && is_navigational_format? && !devise_controller? && !request.xhr?
     end
 


### PR DESCRIPTION
should prevent a bug where users logging in while viewing an image would be returned to that item's iiif manifest (as that url was visited via the universalviewer after pageload) instead of the work page itself.

closes #434 