### PR TITLE
deduplicate edtf dates in base_eaic_mapper

### DIFF
--- a/app/services/spot/mappers/base_eaic_mapper.rb
+++ b/app/services/spot/mappers/base_eaic_mapper.rb
@@ -119,7 +119,7 @@ module Spot::Mappers
 
         start_dates.zip(end_dates).map do |(start_date, end_date)|
           # EDTF date ranges are "#{start_date}/#{end_date}"
-          [start_date, end_date].reject(&:blank?).join('/')
+          [start_date, end_date].reject(&:blank?).uniq.join('/')
         end
       end
   end

--- a/spec/support/shared_examples/mappers/base_eaic_mapper.rb
+++ b/spec/support/shared_examples/mappers/base_eaic_mapper.rb
@@ -57,6 +57,13 @@ RSpec.shared_examples 'a base EAIC mapper' do |options|
 
         it { is_expected.to eq ['1930'] }
       end
+
+      context 'when lower + upper dates match' do
+        let(:date_lower) { ['1930'] }
+        let(:date_upper) { ['1930'] }
+
+        it { is_expected.to eq ['1930'] }
+      end
     end
   end
 
@@ -69,6 +76,14 @@ RSpec.shared_examples 'a base EAIC mapper' do |options|
       end
 
       it { is_expected.to eq ['1921-01/1932-02-11'] }
+
+      context 'when lower + upper dates match' do
+        let(:metadata) do
+          { 'date.image.lower' => ['1921-01'], 'date.image.upper' => ['1921-01'] }
+        end
+
+        it { is_expected.to eq ['1921-01'] }
+      end
     end
   end
 


### PR DESCRIPTION
when creating edtf ranges for date fields, only display one date if both upper + lower values are the same

closes #465 