### PR TITLE
allow different edtf types for `date_sort_dtsi`

### DIFF
--- a/app/indexers/concerns/indexes_sortable_date.rb
+++ b/app/indexers/concerns/indexes_sortable_date.rb
@@ -39,7 +39,7 @@ module IndexesSortableDate
   # @return [Hash<String => *>]
   def generate_solr_document
     super.tap do |doc|
-      doc['date_sort_dtsi'] = parse_sortable_date || object.create_date
+      doc['date_sort_dtsi'] = parse_sortable_date
     end
   end
 
@@ -60,8 +60,10 @@ module IndexesSortableDate
 
       return Date.parse(object.create_date.to_s).strftime('%FT%TZ') if parsed.nil?
 
-      # if we've got an EDTF range we'll just use the earliest date
-      parsed = parsed.first if parsed.is_a? EDTF::Interval
+      # if we get an edtf range/set/etc, we want the earliest date.
+      # rather than checking if it's a +EDTF::Set+, +EDTF::Interval+, etc.
+      # we'll see if it's inherited from +Enumerable+ and call +#first+ if so
+      parsed = parsed.first if parsed.class < ::Enumerable
 
       parsed.strftime('%FT%TZ')
     end

--- a/spec/indexers/image_indexer_spec.rb
+++ b/spec/indexers/image_indexer_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe ImageIndexer do
   include_context 'indexing'
 
   it_behaves_like 'a Spot indexer'
+  it_behaves_like 'it indexes a sortable date'
 
   {
     title: %w[tesim],
@@ -26,14 +27,6 @@ RSpec.describe ImageIndexer do
     let(:solr_fields) { suffixes.map { |suffix| "#{method}_#{suffix}" } }
 
     it_behaves_like 'simple model indexing'
-  end
-
-  describe 'sortable date' do
-    let(:work) { build(:image, date: ['2019-12?']) }
-
-    it 'parses a sortable date' do
-      expect(solr_doc['date_sort_dtsi']).to eq '2019-12-01T00:00:00Z'
-    end
   end
 
   describe 'years_encompassed' do

--- a/spec/indexers/publication_indexer_spec.rb
+++ b/spec/indexers/publication_indexer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe PublicationIndexer do
 
   it_behaves_like 'a Spot indexer'
   it_behaves_like 'it indexes English-language dates'
+  it_behaves_like 'it indexes a sortable date'
 
   # simple_model_indexing just means that it maps the values
   # on the object (the keys) to the solr_doc fields (the values)
@@ -63,14 +64,6 @@ RSpec.describe PublicationIndexer do
 
     it 'stores the label' do
       expect(solr_doc['location_label_ssim']).to eq [label]
-    end
-  end
-
-  describe 'sortable date' do
-    let(:work) { build(:publication, date_issued: ['2019-12?']) }
-
-    it 'parses a sortable date' do
-      expect(solr_doc['date_sort_dtsi']).to eq '2019-12-01T00:00:00Z'
     end
   end
 

--- a/spec/support/shared_examples/indexing/indexes_sortable_date.rb
+++ b/spec/support/shared_examples/indexing/indexes_sortable_date.rb
@@ -29,5 +29,4 @@ RSpec.shared_examples 'it indexes a sortable date' do
 
     it { is_expected.to eq '1986-02-01T00:00:00Z' }
   end
-
 end

--- a/spec/support/shared_examples/indexing/indexes_sortable_date.rb
+++ b/spec/support/shared_examples/indexing/indexes_sortable_date.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'it indexes a sortable date' do
+  subject { solr_doc['date_sort_dtsi'] }
+
+  let(:solr_doc) { indexer.generate_solr_document }
+  let(:indexer) { described_class.new(work) }
+  let(:work) { build(work_klass, id: 'abc123def', sortable_date_property => date_values) }
+  let(:work_klass) { described_class.name.gsub(/Indexer$/, '').downcase.to_sym }
+
+  let(:sortable_date_property) { described_class.sortable_date_property }
+  let(:date_values) { ['2020-06-08'] }
+
+  it { is_expected.to eq '2020-06-08T00:00:00Z' }
+
+  context 'when an EDTF set' do
+    let(:date_values) { ['{1986,1991,2020}'] }
+
+    it { is_expected.to eq '1986-01-01T00:00:00Z' }
+  end
+
+  context 'when an EDTF interval' do
+    let(:date_values) { ['1986-02/2020-06'] }
+
+    it { is_expected.to eq '1986-02-01T00:00:00Z' }
+  end
+end

--- a/spec/support/shared_examples/indexing/indexes_sortable_date.rb
+++ b/spec/support/shared_examples/indexing/indexes_sortable_date.rb
@@ -12,8 +12,14 @@ RSpec.shared_examples 'it indexes a sortable date' do
 
   it { is_expected.to eq '2020-06-08T00:00:00Z' }
 
-  context 'when an EDTF set' do
+  context 'when an EDTF list' do
     let(:date_values) { ['{1986,1991,2020}'] }
+
+    it { is_expected.to eq '1986-01-01T00:00:00Z' }
+  end
+
+  context 'when a choice EDTF list' do
+    let(:date_values) { ['[1986,1991]'] }
 
     it { is_expected.to eq '1986-01-01T00:00:00Z' }
   end
@@ -23,4 +29,5 @@ RSpec.shared_examples 'it indexes a sortable date' do
 
     it { is_expected.to eq '1986-02-01T00:00:00Z' }
   end
+
 end


### PR DESCRIPTION
previously we were only calling `parsed.first` if the value was an `EDTF::Interval`, which prevented set values from being used

close #506 