### PR TITLE
add create_image_spec

### DIFF
--- a/app/assets/javascripts/multi-auth-input.js
+++ b/app/assets/javascripts/multi-auth-input.js
@@ -12,9 +12,6 @@
 
     $formElement
       .find('.form-group.multi_auth_controlled_vocabulary')
-      .each((_idx, field) => {
-        console.log('adding multi-auth cv to our field', field)
-        return new MultiAuthControlledVocabulary(field, paramKey)
-      });
+      .each((_idx, field) => new MultiAuthControlledVocabulary(field, paramKey));
   });
 })(jQuery);

--- a/app/assets/javascripts/spot/editor/multi_auth_controlled_vocabulary.es6
+++ b/app/assets/javascripts/spot/editor/multi_auth_controlled_vocabulary.es6
@@ -19,6 +19,7 @@ export default class MultiAuthControlledVocabulary extends ControlledVocabulary 
     var controls = this.controls.clone();
     var placeholder = this.element.find('input.multi-text-field').attr('placeholder');
     var $selectElement = this.element.find('select.form-control').last().clone();
+    $selectElement.attr('name', $selectElement.attr('name').replace(/\d+$/, this._maxIndex()));
     $selectElement.on('change', e => this.handleAuthoritySelect(e));
 
     var $selectField = $('<div class="col-sm-4"></div>').append($selectElement);

--- a/app/inputs/multi_authority_controlled_vocabulary_input.rb
+++ b/app/inputs/multi_authority_controlled_vocabulary_input.rb
@@ -31,7 +31,7 @@ class MultiAuthorityControlledVocabularyInput < ControlledVocabularyInput
 
       <<-HTML
       <div class="row">
-        #{authority_dropdown(authorities) if value.node?}
+        #{authority_dropdown(authorities, index) if value.node?}
 
         <div class="col-sm-#{value.node? ? '8' : '12'}">
           #{super}
@@ -87,6 +87,10 @@ class MultiAuthorityControlledVocabularyInput < ControlledVocabularyInput
       object.model.class.properties[attribute_name.to_s].class_name
     end
 
+    def id_for_select(index)
+      "#{@builder.object_name}_#{attribute_name}_authority_select_#{index}"
+    end
+
     # @return [Spot::AuthoritySelectService]
     def select_service
       @select_service ||= Spot::AuthoritySelectService.new
@@ -101,10 +105,10 @@ class MultiAuthorityControlledVocabularyInput < ControlledVocabularyInput
 
     # @todo make this an i18n translation
     # @return [String]
-    def authority_dropdown(authorities)
+    def authority_dropdown(authorities, index)
       <<-HTML
       <div class="col-sm-4">
-        <select class="form-control authority-select" name="_authority-select-options">
+        <select id="#{id_for_select(index)}" class="form-control authority-select" name="#{id_for_select(index)}">
           <option value="" selected>Select an Authority source</option>
           #{authority_option_html(authorities)}
         </select>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -18,6 +18,7 @@ en:
         date_created: Date Created
         date_issued: Date Issued
         date_modified: Date Modified
+        date_scope_note: Date Scope Note
         date_uploaded: Date Uploaded
         depositor: Deposited by
         description: Description
@@ -37,11 +38,15 @@ en:
         member_of_collections: Collections
         organization: Organization
         original_checksum: Original Checksum (MD5)
+        original_item_extent: Original Item Extent
         page_count: Page Count
         permalink: Permalink
         physical_medium: Physical Medium
         proxy_depositor: Proxy Depositor
         publisher: Publisher
+        related_resource: Related Resource
+        repository_location: Repository Location
+        requested_by: Requested By
         research_assistance: Research Assistance
         resource_type: Type
         rights_holder: Rights Holders

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -3,6 +3,7 @@ en:
   activefedora:
     models:
       publication: 'Publication'
+      image: 'Image'
   hyrax:
     account_name:           "My Institution Account Id"
 

--- a/spec/factories/image.rb
+++ b/spec/factories/image.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     inscription { ['hey look over here'] }
     keyword { ['photo'] }
     language { ['en'] }
-    location { [] }
+    location { ['http://sws.geonames.org/5188140/'] }
     note { ['Some staff-side information'] }
     original_item_extent { ['24 x 19.5 cm.'] }
     physical_medium { ['Photograph'] }
@@ -22,7 +22,7 @@ FactoryBot.define do
     requested_by { ['Requester, Jennifer Q.'] }
     research_assistance { ['Student, Ashley'] }
     resource_type { ['Photograph'] }
-    rights_holder { [] }
+    rights_holder { ['Holder, R.'] }
     rights_statement { ['http://creativecommons.org/publicdomain/mark/1.0/'] }
     source { ['A grouped collection'] }
     subject { ['http://id.worldcat.org/fast/1061714'] }

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -17,7 +17,159 @@ RSpec.feature 'Create an Image', :clean, :js do
     let(:user) { create(:admin_user) }
     let(:attrs) { attributes_for(:image) }
 
-    skip 'can fill out and submit a new Image' do
+    # currently we're hiding the new Image form from the nav menus –
+    # the thinking is that Images are likely to be ingested as part of
+    # a batch, rather than individually. if that changes, you'll want
+    # to uncomment the block below
+    describe 'can fill out and submit a new Image' do
+      scenario do
+        visit '/concern/images/new'
+
+        # visit '/dashboard'
+        # click_link 'Works'
+        # click_link 'Add new work'
+        #
+        # sleep 1
+        #
+        # choose 'Image'
+        # click_button 'Create work'
+
+        expect(page).to have_content "Add New #{i18n_term}"
+
+        fill_in 'image_title', with: attrs[:title].first
+        expect(page).not_to have_css '.image_title .controls-add-text'
+
+        select 'Image', from: 'image_resource_type'
+        expect(page).not_to have_css '.image_resource_type .controls-add-text'
+
+        fill_in 'image_date', with: attrs[:date].first
+        expect(page).to have_css '.image_date .controls-add-text'
+
+        select 'Copyright Undetermined', from: 'image_rights_statement'
+        expect(page).not_to have_css '.image_rights_statement .controls-add-text'
+
+        fill_in 'image_title_alternative', with: attrs[:title_alternative].first
+        fill_in 'image_title_alternative_language', with: 'en'
+        expect(page).to have_css '.image_title_alternative .controls-add-text'
+
+        fill_in 'image_subtitle', with: attrs[:subtitle].first
+        fill_in 'image_subtitle_language', with: 'en'
+        expect(page).to have_css '.image_title_alternative .controls-add-text'
+
+        fill_in 'image_date_associated', with: attrs[:date_associated].first
+        expect(page).to have_css '.image_date_associated .controls-add-text'
+
+        fill_in 'image_date_scope_note', with: attrs[:date_scope_note].first
+        expect(page).to have_css '.image_date_scope_note .controls-add-text'
+
+        fill_in 'image_rights_holder', with: attrs[:rights_holder].first
+        expect(page).to have_css '.image_rights_holder .controls-add-text'
+
+        fill_in 'image_description', with: attrs[:description].first
+        fill_in 'image_description_language', with: 'en'
+        expect(page).to have_css '.image_description .controls-add-text'
+
+        fill_in 'image_inscription', with: attrs[:inscription].first
+        fill_in 'image_inscription_language', with: 'en'
+        expect(page).to have_css '.image_inscription .controls-add-text'
+
+        fill_in 'image_creator', with: attrs[:creator].first
+        expect(page).to have_css '.image_creator .controls-add-text'
+
+        fill_in 'image_publisher', with: attrs[:publisher].first
+        expect(page).to have_css '.image_publisher .controls-add-text'
+
+        fill_in 'image_keyword', with: attrs[:keyword].first
+        expect(page).to have_css '.image_keyword .controls-add-text'
+
+        fill_in_autocomplete '.image_subject', with: attrs[:subject].first
+        expect(page).to have_css('.image_subject.form-control[data-autocomplete="subject"]', visible: false)
+        expect(page).to have_css('.image_subject.form-control[data-autocomplete-url="/authorities/search/linked_data/oclc_fast"]', visible: false)
+        expect(page).to have_css('.image_subject .controls-add-text')
+
+        # multi-authority for location
+        location_selector = 'input.image_location.multi_auth_controlled_vocabulary'
+        expect(page).to have_css("#{location_selector}[data-autocomplete='location']", visible: false)
+
+        # @todo maybe this should be a support thing?
+        [
+          ['GeoNames', '/authorities/search/geonames'],
+          ['Getty Thesaurus of Geo. Names', '/authorities/search/getty/tgn']
+        ].each do |(name, autocomplete_url)|
+          select name, from: 'image_location_authority_select_0'
+          sleep 1
+
+          data_prop = page.evaluate_script("$('#{location_selector}').data('autocomplete-url');")
+          expect(data_prop).to eq autocomplete_url
+
+          sleep 1
+        end
+
+        expect(page).to have_css('.image_location .controls-add-text')
+        # end location
+
+        fill_in_autocomplete '.image_language', with: attrs[:language].first
+        expect(page).to have_css('.image_language .controls-add-text')
+
+        fill_in 'image_source', with: attrs[:source].first
+        expect(page).to have_css('.image_source .controls-add-text')
+
+        fill_in 'image_physical_medium', with: attrs[:physical_medium].first
+        expect(page).to have_css('.image_physical_medium .controls-add-text')
+
+        fill_in 'image_original_item_extent', with: attrs[:original_item_extent].first
+        expect(page).to have_css('.image_original_item_extent .controls-add-text')
+
+        fill_in 'image_repository_location', with: attrs[:repository_location].first
+        expect(page).to have_css('.image_repository_location .controls-add-text')
+
+        fill_in 'image_requested_by', with: attrs[:requested_by].first
+        expect(page).to have_css('.image_requested_by .controls-add-text')
+
+        fill_in 'image_research_assistance', with: attrs[:research_assistance].first
+        expect(page).to have_css('.image_research_assistance .controls-add-text')
+
+        fill_in 'image_donor', with: attrs[:donor].first
+        expect(page).to have_css('.image_donor .controls-add-text')
+
+        fill_in 'image_related_resource', with: attrs[:related_resource].first
+        expect(page).to have_css('.image_related_resource .controls-add-text')
+
+        fill_in 'image_local_identifier', with: 'local:abc123'
+        expect(page).to have_css('.image_local_identifier .controls-add-text')
+
+        fill_in_autocomplete '.image_subject_ocm', with: attrs[:subject_ocm].first
+        expect(page).to have_css('.image_subject_ocm .controls-add-text')
+
+        fill_in 'image_note', with: attrs[:note].first
+        expect(page).to have_css('.image_note .controls-add-text')
+
+        # see long note in +create_publication_spec.rb+ for why we need to scroll back to the top
+        page.execute_script('window.scrollTo(0,0)')
+
+        click_link 'Files'
+        expect(page).to have_content 'Add files'
+
+        within('span#addfiles') do
+          attach_file('files[]', "#{::Rails.root}/spec/fixtures/document.pdf", visible: false)
+        end
+
+        # select visibility
+        choose 'image_visibility_open'
+
+        # check the submission agreement
+        # check 'agreement'
+        sleep(2)
+
+        page.find('#agreement').set(true)
+
+        # give javascript a chance to catch up (otherwise the save button is hidden)
+        sleep(2)
+
+        page.find('#with_files_submit').click
+        expect(page).to have_content attrs[:title].first
+        expect(page).to have_content "Your files are being processed by #{app_name} in the background."
+      end
     end
   end
 end

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Create an Image', :clean, :js do
     let(:user) { create(:admin_user) }
     let(:attrs) { attributes_for(:image) }
 
-    # currently we're hiding the new Image form from the nav menus –
+    # currently we're hiding the new Image form from the nav menus,
     # the thinking is that Images are likely to be ingested as part of
     # a batch, rather than individually. if that changes, you'll want
     # to uncomment the block below

--- a/spec/support/select2_helpers.rb
+++ b/spec/support/select2_helpers.rb
@@ -3,7 +3,7 @@ module Select2Helpers
   # Fills in a form element containing a Select2 autocomplete widget.
   #
   # @param [String] key
-  #   HTML class name of the element (usually '.<work type>_<field camel-cased>')
+  #   HTML class name of the element (usually '.<work type>_<field snake_cased>')
   # @param [Hash] options
   # @option [String] with Value to be added
   # @see https://stackoverflow.com/a/25047358


### PR DESCRIPTION
supplement to #512 that finally fills out the create_image_spec created back in _december_. this should give us test coverage for the multi_authority_controlled_vocabulary_input