### PR TITLE
fix how rights_statement values are handled in the form

### DIFF
--- a/app/actors/spot/base_actor.rb
+++ b/app/actors/spot/base_actor.rb
@@ -14,6 +14,14 @@ module Spot
     include ::DeserializesRdfLiterals
     include ::CreateHandleIdentifiers
 
+    def create(env)
+      convert_rights_statement(env) && super
+    end
+
+    def update(env)
+      convert_rights_statement(env) && super
+    end
+
     private
 
       # Overrides the BaseActor method to allow us to stuff in
@@ -22,6 +30,15 @@ module Spot
       # @return [void]
       def apply_deposit_date(env)
         env.curation_concern.date_uploaded = get_date_uploaded_value(env)
+      end
+
+      # ensures that our rights_statement attribute values are RDF::URIs instead
+      # of Strings.
+      #
+      # @param [Hyrax::Actors::Environment] env
+      # @return [void]
+      def convert_rights_statement(env)
+        env.attributes[:rights_statement] = Array.wrap(env.attributes[:rights_statement]).map { |v| RDF::URI(v) }
       end
 
       # @param [Hyrax::Actors::Environment] env

--- a/app/forms/spot/forms/work_form.rb
+++ b/app/forms/spot/forms/work_form.rb
@@ -58,7 +58,8 @@ module Spot
       #
       # @return [Array<String>]
       def rights_statement
-        self['rights_statement'].map { |v| v.respond_to?(:id) ? v.id : v }
+        mapped_strings = Array.wrap(self['rights_statement']).map { |v| v.respond_to?(:id) ? v.id : v }
+        multiple?('rights_statement') ? mapped_strings : mapped_strings.first
       end
     end
   end

--- a/app/forms/spot/forms/work_form.rb
+++ b/app/forms/spot/forms/work_form.rb
@@ -22,21 +22,6 @@ module Spot
         :member_of_collection_ids, :admin_set_id
       ]
 
-      # class method used to transform the form parameters into attributes for the work.
-      # a bunch of the form concerns will sub-method this and use a +super+ call to chain
-      # them together, so don't forget to include +super+!
-      #
-      # we're using this in the form to ensure that the values for +rights_statement+ are
-      # stored as +ActiveTriples::Resource+s
-      #
-      # @param [ActionController::Parameters, Hash] form_params
-      # @return [ActionController::Parameters]
-      def self.model_attributes(form_params)
-        super.tap do |params|
-          params['rights_statement'] = Array.wrap(params['rights_statement']).map { |v| RDF::URI(v) }
-        end
-      end
-
       # samvera/hydra-editor uses both the class method (new form) and
       # instance method (edit form) versions of this method, so we need
       # to provide both (otherwise we're head-first down a rabbit hole
@@ -58,8 +43,10 @@ module Spot
       #
       # @return [Array<String>]
       def rights_statement
-        mapped_strings = Array.wrap(self['rights_statement']).map { |v| v.respond_to?(:id) ? v.id : v }
-        multiple?('rights_statement') ? mapped_strings : mapped_strings.first
+        @rights_statement ||= begin
+          mapped_strings = Array.wrap(self['rights_statement']).map { |v| v.respond_to?(:id) ? v.id : v }
+          multiple?('rights_statement') ? mapped_strings : mapped_strings.first
+        end
       end
     end
   end

--- a/app/forms/spot/forms/work_form.rb
+++ b/app/forms/spot/forms/work_form.rb
@@ -44,7 +44,19 @@ module Spot
       # @return [Array<String>]
       def rights_statement
         @rights_statement ||= begin
-          mapped_strings = Array.wrap(self['rights_statement']).map { |v| v.respond_to?(:id) ? v.id : v }
+          source = self['rights_statement']
+          wrapped = source.respond_to?(:to_a) ? source.to_a : Array.wrap(source)
+          mapped_strings = wrapped.map do |value|
+            # most likely case, ActiveTriples::Resource
+            next value.rdf_subject.to_s if value.respond_to?(:rdf_subject)
+
+            # might be an RDF::URI?
+            next value.id if value.respond_to?(:id)
+
+            # otherwise, leave it as-is
+            value
+          end
+
           multiple?('rights_statement') ? mapped_strings : mapped_strings.first
         end
       end

--- a/app/forms/spot/forms/work_form.rb
+++ b/app/forms/spot/forms/work_form.rb
@@ -22,6 +22,21 @@ module Spot
         :member_of_collection_ids, :admin_set_id
       ]
 
+      # class method used to transform the form parameters into attributes for the work.
+      # a bunch of the form concerns will sub-method this and use a +super+ call to chain
+      # them together, so don't forget to include +super+!
+      #
+      # we're using this in the form to ensure that the values for +rights_statement+ are
+      # stored as +ActiveTriples::Resource+s
+      #
+      # @param [ActionController::Parameters, Hash] form_params
+      # @return [ActionController::Parameters]
+      def self.model_attributes(form_params)
+        super.tap do |params|
+          params['rights_statement'] = Array.wrap(params['rights_statement']).map { |v| RDF::URI(v) }
+        end
+      end
+
       # samvera/hydra-editor uses both the class method (new form) and
       # instance method (edit form) versions of this method, so we need
       # to provide both (otherwise we're head-first down a rabbit hole
@@ -35,6 +50,15 @@ module Spot
       # @return [TrueClass, FalseClass]
       def multiple?(term)
         self.class.multiple?(term)
+      end
+
+      # our rights_statement URIs may be stored as +ActiveTriples::Resource+ objects
+      # (rather than Strings), so we'll want to make sure that the value is displayed
+      # in the <select> object.
+      #
+      # @return [Array<String>]
+      def rights_statement
+        self['rights_statement'].map { |v| v.respond_to?(:id) ? v.id : v }
       end
     end
   end

--- a/app/validators/spot/required_local_authority_validator.rb
+++ b/app/validators/spot/required_local_authority_validator.rb
@@ -20,8 +20,9 @@ module Spot
       values = record.send(field)
       values = Array.wrap(values) unless values.respond_to?(:each)
 
-      values.each do |value|
-        record.errors[field] << %("#{value}" is not a valid #{field.to_s.titleize}.) if authority.find(value.to_s).empty?
+      values.each do |v|
+        value = v.is_a?(ActiveTriples::Resource) ? v.id : v.to_s
+        record.errors[field] << %("#{value}" is not a valid #{field.to_s.titleize}.) if authority.find(value).empty?
       end
     end
 

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -104,16 +104,19 @@ describe Publication do
     end
 
     describe 'rights_statement' do
+      let(:uri) { 'http://creativecommons.org/publicdomain/mark/1.0/' }
       it 'must be present' do
         work.rights_statement = []
 
         expect(work.valid?).to be false
         expect(work.errors[:rights_statement]).to include 'Your work must include a Rights Statement.'
 
-        work.rights_statement = ['http://creativecommons.org/publicdomain/mark/1.0/']
+        work.rights_statement = [uri]
         expect(work.valid?).to be true
+      end
 
-        work.rights_statement = [RDF::URI('http://creativecommons.org/publicdomain/mark/1.0/')]
+      it 'can be an ActiveTriples::Resource' do
+        work.rights_statement = [ActiveTriples::Resource.new(RDF::URI(uri))]
         expect(work.valid?).to be true
       end
     end

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -112,6 +112,9 @@ describe Publication do
 
         work.rights_statement = ['http://creativecommons.org/publicdomain/mark/1.0/']
         expect(work.valid?).to be true
+
+        work.rights_statement = [RDF::URI('http://creativecommons.org/publicdomain/mark/1.0/')]
+        expect(work.valid?).to be true
       end
     end
 

--- a/spec/support/shared_examples/forms/spot_work_form.rb
+++ b/spec/support/shared_examples/forms/spot_work_form.rb
@@ -12,21 +12,6 @@ RSpec.shared_examples 'a Spot work form' do
     end
   end
 
-  describe '.model_attributes' do
-    subject(:attributes) { described_class.model_attributes(form_params) }
-
-    let(:form_params) { ActionController::Parameters.new(raw_params) }
-    let(:raw_params) { {} }
-
-    describe '(rights_statement)' do
-      subject { attributes['rights_statement'] }
-
-      let(:raw_params) { { 'rights_statement' => 'http://rightsstatements.org/vocab/NoC-OKLR/1.0/' } }
-
-      it { is_expected.to eq [ActiveTriples::Resource.new('http://rightsstatements.org/vocab/NoC-OKLR/1.0/')] }
-    end
-  end
-
   describe '#rights_statement' do
     subject(:rights) { form.rights_statement }
 

--- a/spec/support/shared_examples/forms/spot_work_form.rb
+++ b/spec/support/shared_examples/forms/spot_work_form.rb
@@ -11,4 +11,32 @@ RSpec.shared_examples 'a Spot work form' do
       expect(terms).to include(*described_class.hyrax_form_fields)
     end
   end
+
+  describe '.model_attributes' do
+    subject(:attributes) { described_class.model_attributes(form_params) }
+
+    let(:form_params) { ActionController::Parameters.new(raw_params) }
+    let(:raw_params) { {} }
+
+    describe '(rights_statement)' do
+      subject { attributes['rights_statement'] }
+
+      let(:raw_params) { { 'rights_statement' => 'http://rightsstatements.org/vocab/NoC-OKLR/1.0/' } }
+
+      it { is_expected.to eq [ActiveTriples::Resource.new('http://rightsstatements.org/vocab/NoC-OKLR/1.0/')] }
+    end
+  end
+
+  describe '#rights_statement' do
+    subject(:rights) { form.rights_statement }
+
+    let(:form) { described_class.new(work, ability, nil) }
+    let(:work) { build(work_klass) }
+    let(:work_klass) { described_class.name.split('::').last.gsub(/Form$/, '').downcase.to_sym }
+    let(:ability) { Ability.new(build(:admin_user)) }
+
+    it 'transforms the values into strings' do
+      expect(rights.all? { |v| v.is_a? String }).to be true
+    end
+  end
 end

--- a/spec/support/shared_examples/forms/spot_work_form.rb
+++ b/spec/support/shared_examples/forms/spot_work_form.rb
@@ -16,12 +16,28 @@ RSpec.shared_examples 'a Spot work form' do
     subject(:rights) { form.rights_statement }
 
     let(:form) { described_class.new(work, ability, nil) }
-    let(:work) { build(work_klass) }
-    let(:work_klass) { described_class.name.split('::').last.gsub(/Form$/, '').downcase.to_sym }
+    let(:work) { build(work_klass.downcase.to_sym) }
+    let(:work_klass) { described_class.name.split('::').last.gsub(/Form$/, '') }
     let(:ability) { Ability.new(build(:admin_user)) }
 
     it 'transforms the values into strings' do
-      expect(rights.all? { |v| v.is_a? String }).to be true
+      if form.multiple?('rights_statement')
+        expect(rights.all? { |v| v.is_a? String }).to be true
+      else
+        expect(rights).to be_a String
+      end
+    end
+
+    context 'when no rights_statement present' do
+      let(:work) { work_klass.constantize.new }
+
+      it do
+        if form.multiple?('rights_statement')
+          expect(rights).to eq []
+        else
+          expect(rights).to eq ''
+        end
+      end
     end
   end
 end

--- a/spec/support/shared_examples/spot_base_actor.rb
+++ b/spec/support/shared_examples/spot_base_actor.rb
@@ -58,4 +58,26 @@ RSpec.shared_examples 'a Spot actor' do
       expect(MintHandleJob).to have_received(:perform_later).with(work)
     end
   end
+
+  describe 'converts rights_statement values to RDF::URIs' do
+    let(:uri) { 'http://creativecommons.org/publicdomain/mark/1.0/' }
+    let(:attributes) { { rights_statement: uri } }
+    let(:expected) { { rights_statement: [RDF::URI(uri)] } }
+
+    context '#create' do
+      before { actor.create(env) }
+
+      it 'converts rights_statement uri strings to RDF::URI objects' do
+        expect(env.attributes).to eq expected
+      end
+    end
+
+    context '#update' do
+      before { actor.update(env) }
+
+      it 'converts rights_statement uri strings to RDF::URI objects' do
+        expect(env.attributes).to eq expected
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/spot_base_actor.rb
+++ b/spec/support/shared_examples/spot_base_actor.rb
@@ -62,7 +62,7 @@ RSpec.shared_examples 'a Spot actor' do
   describe 'converts rights_statement values to RDF::URIs' do
     let(:uri) { 'http://creativecommons.org/publicdomain/mark/1.0/' }
     let(:attributes) { { rights_statement: uri } }
-    let(:expected) { { rights_statement: [RDF::URI(uri)] } }
+    let(:expected) { { 'rights_statement' => [RDF::URI(uri)] } }
 
     context '#create' do
       before { actor.create(env) }


### PR DESCRIPTION
love to discover that one issue impacts another. for Image collections, we're mapping the `rights_statement` URI to an `RDF::URI` object, but on the form we were just treating them as Strings. so when we tried to edit an ingested Image item, the `rights_statement` dropdown wouldn't have a value selected, as the form builder had no idea what to do with an `ActiveTriples::Relation`.

this updates `Spot::Forms::WorkForm` to convert `rights_statement` values to Strings when building the form, and back to `RDF::URI`s on save.

closes #490 
closes #517