### PR TITLE
add wrapper_html to subject edit partial

### DIFF
--- a/app/views/records/edit_fields/_subject.html.erb
+++ b/app/views/records/edit_fields/_subject.html.erb
@@ -9,5 +9,12 @@
               'autocomplete' => 'subject'
             }
           },
+          ### Required for the ControlledVocabulary javascript:
+          wrapper_html: {
+            data: {
+              'autocomplete-url' => '/authorities/search/linked_data/oclc_fast',
+              'field-name' => 'subject'
+            }
+          },
           required: f.object.required?(:subject)
 %>


### PR DESCRIPTION
this ought to fix a bug where new subject rows weren't having their autocomplete fields initialized