### PR TITLE
update Image public fields

### DIFF
--- a/app/models/concerns/spot/solr_document_attributes.rb
+++ b/app/models/concerns/spot/solr_document_attributes.rb
@@ -36,6 +36,7 @@ module Spot
       attribute :depositor,              ::Blacklight::Types::String, 'depositor_ssim'
       attribute :description,            ::Blacklight::Types::Array, 'description_tesim'
       attribute :division,               ::Blacklight::Types::Array, 'division_tesim'
+      attribute :donor,                  ::Blacklight::Types::Array, 'donor_ssim'
       attribute :editor,                 ::Blacklight::Types::Array, 'editor_tesim'
       attribute :file_set_ids,           ::Blacklight::Types::Array, 'file_set_ids_ssim'
       attribute :file_size,              ::Blacklight::Types::String, 'file_size_lts'

--- a/app/models/concerns/spot/solr_document_attributes.rb
+++ b/app/models/concerns/spot/solr_document_attributes.rb
@@ -57,7 +57,7 @@ module Spot
       attribute :permalink,              ::Blacklight::Types::String, 'permalink_ss'
       attribute :physical_medium,        ::Blacklight::Types::Array, 'physical_medium_tesim'
       attribute :publisher,              ::Blacklight::Types::Array, 'publisher_tesim'
-      attribute :related_resource,       ::Blacklight::Types::Array, 'related_resource_ssim'
+      attribute :related_resource,       ::Blacklight::Types::Array, 'related_resource_tesim'
       attribute :repository_location,    ::Blacklight::Types::Array, 'repository_location_ssim'
       attribute :requested_by,           ::Blacklight::Types::Array, 'requested_by_ssim'
       attribute :research_assistance,    ::Blacklight::Types::Array, 'research_assistance_ssim'

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -117,14 +117,13 @@ class Image < ActiveFedora::Base
     index.as :symbol
   end
 
-  # @todo
   property :research_assistance, predicate: ::RDF::URI.new('http://www.rdaregistry.info/Elements/a/#P50265') do |index|
     index.as :symbol
   end
 
-  # @todo Should this be indexed as searchable (are we using statements?
-  #       ex. "Donated by Soand So") or as a symbol (are we using a name value?)
-  property :donor, predicate: ::RDF::Vocab::DC.provenance
+  property :donor, predicate: ::RDF::Vocab::DC.provenance do |index|
+    index.as :symbol
+  end
 
   property :note, predicate: ::RDF::Vocab::SKOS.note do |index|
     index.as :stored_searchable

--- a/app/views/hyrax/images/_metadata.html.erb
+++ b/app/views/hyrax/images/_metadata.html.erb
@@ -12,6 +12,7 @@
 
       <%= presenter.attribute_to_html(:date) %>
       <%= presenter.attribute_to_html(:date_associated) %>
+      <%= presenter.attribute_to_html(:date_scope_note) %>
 
       <%= presenter.attribute_to_html(:resource_type, render_as: :faceted) %>
       <%= presenter.attribute_to_html(:physical_medium) %>

--- a/app/views/hyrax/images/_metadata.html.erb
+++ b/app/views/hyrax/images/_metadata.html.erb
@@ -15,6 +15,7 @@
 
       <%= presenter.attribute_to_html(:resource_type, render_as: :faceted) %>
       <%= presenter.attribute_to_html(:physical_medium) %>
+      <%= presenter.attribute_to_html(:original_item_extent) %>
       <%= presenter.attribute_to_html(:language_label,
                                       render_as: :faceted,
                                       search_field: :language_label_ssim) %>
@@ -31,9 +32,11 @@
                                       search_field: :location_label_ssim) %>
       <%= presenter.attribute_to_html(:standard_identifier, render_as: :identifier) %>
       <%= presenter.attribute_to_html(:related_resource) %>
+      <%= presenter.attribute_to_html(:donor) %>
       <%= presenter.attribute_to_html(:research_assistance,
                                       render_as: :faceted,
                                       search_field: :research_assistance_ssim) %>
+      <%= presenter.attribute_to_html(:repostiory_location) %>
       <%= presenter.attribute_to_html(:permalink) %>
 
       <%= render 'shared/metadata/rights_statement', presenter: presenter %>

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe SolrDocument do
     },
     depositor: { type: String, suffix: 'ssim' },
     description: { type: Array, suffix: 'tesim' },
+    donor: { type: Array, suffix: 'ssim' },
     division: { type: Array, suffix: 'tesim' },
     editor: { type: Array, suffix: 'tesim' },
     file_set_ids: { type: Array, suffix: 'ssim', value: ['abc123', 'def456'] },

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe SolrDocument do
     physical_medium: { type: Array, suffix: 'tesim' },
     page_count: { type: String, suffix: 'tesim', value: '100' },
     permalink: { type: String, suffix: 'ss', value: 'http://hdl.handle.net/10385/test' },
-    related_resource: { type: Array, suffix: 'ssim' },
+    related_resource: { type: Array, suffix: 'tesim' },
     repository_location: { type: Array, suffix: 'ssim' },
     requested_by: { type: Array, suffix: 'ssim' },
     research_assistance: { type: Array, suffix: 'ssim' },


### PR DESCRIPTION
- updates indexing for `Image#donor`, treats field as `:symbol` (string, stored, indexed, multiple)
- updates Image view page to display: `donor`, `repository_location`, `original_item_extent`, `date_scope_note`, `related_resource`

closes #523 