### PR TITLE
fix missing fields on LewisPostcardsMapper

### DIFF
--- a/app/services/spot/mappers/lewis_postcards_mapper.rb
+++ b/app/services/spot/mappers/lewis_postcards_mapper.rb
@@ -4,7 +4,7 @@ module Spot::Mappers
     self.fields_map = {
       creator: 'creator.maker',
       date_scope_note: 'description.indicia',
-      original_item_extent: 'format.extant',
+      original_item_extent: 'format.extent',
       physical_medium: 'format.medium',
       publisher: 'creator.company',
       research_assistance: 'contributor',
@@ -18,6 +18,7 @@ module Spot::Mappers
         :related_resource,
 
         # inherited methods
+        :date,
         :date_associated,
         :description,
         :identifier,

--- a/spec/services/spot/mappers/lewis_postcards_mapper_spec.rb
+++ b/spec/services/spot/mappers/lewis_postcards_mapper_spec.rb
@@ -51,16 +51,16 @@ RSpec.describe Spot::Mappers::LewisPostcardsMapper do
     subject { mapper.keyword }
 
     let(:metadata) do
-      { 'keyword' => ['East Asia Image Collection'], 'relation.ispartof' => ['lewis-postcards'] }
+      { 'keyword' => ['Han'], 'relation.ispartof' => ['East Asia Image Collection'] }
     end
 
-    it { is_expected.to eq ['East Asia Image Collection', 'lewis-postcards'] }
+    it { is_expected.to eq ['Han', 'East Asia Image Collection'] }
   end
 
   describe '#original_item_extent' do
     subject { mapper.original_item_extent }
 
-    let(:field) { 'format.extant' }
+    let(:field) { 'format.extent' }
 
     it_behaves_like 'a mapped field'
   end


### PR DESCRIPTION
- fixes a typo for `original_item_extent`
- adds `date` to the `fields` array

closes #531 