### PR TITLE
rename master branch to primary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 spot
 ====
 
-[![Build Status - CircleCI](https://circleci.com/gh/LafayetteCollegeLibraries/spot/tree/master.svg?style=svg)](https://circleci.com/gh/LafayetteCollegeLibraries/spot/tree/master)
+[![Build Status - CircleCI](https://circleci.com/gh/LafayetteCollegeLibraries/spot/tree/primary.svg?style=svg)](https://circleci.com/gh/LafayetteCollegeLibraries/spot/tree/primary)
 [![Maintainability](https://api.codeclimate.com/v1/badges/41507959fedd0b4c973f/maintainability)](https://codeclimate.com/github/LafayetteCollegeLibraries/spot/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/41507959fedd0b4c973f/test_coverage)](https://codeclimate.com/github/LafayetteCollegeLibraries/spot/test_coverage)
 

--- a/app/services/spot/importers/readme.markdown
+++ b/app/services/spot/importers/readme.markdown
@@ -122,8 +122,8 @@ See the [readme document](validator-readme) for more details.
 
 
 [Darlingtonia]: https://github.com/curationexperts/darlingtonia
-[`Spot::Importers::Base::RecordImporter`]: https://github.com/LafayetteCollegeLibraries/spot/blob/master/app/services/spot/importers/base/record_importer.rb
-[Spot::Importers::Bag::Parser]: https://github.com/LafayetteCollegeLibraries/spot/blob/master/app/services/spot/importers/bag/parser.rb
-[`Spot::StreamLogger`]: https://github.com/LafayetteCollegeLibraries/spot/blob/master/app/services/spot/stream_logger.rb
-[mapper-readme]: https://github.com/LafayetteCollegeLibraries/spot/blob/master/app/services/spot/mappers/readme.markdown
-[validator-readme]: https://github.com/LafayetteCollegeLibraries/spot/blob/master/app/services/spot/validators/readme.markdown
+[`Spot::Importers::Base::RecordImporter`]: https://github.com/LafayetteCollegeLibraries/spot/blob/primary/app/services/spot/importers/base/record_importer.rb
+[Spot::Importers::Bag::Parser]: https://github.com/LafayetteCollegeLibraries/spot/blob/primary/app/services/spot/importers/bag/parser.rb
+[`Spot::StreamLogger`]: https://github.com/LafayetteCollegeLibraries/spot/blob/primary/app/services/spot/stream_logger.rb
+[mapper-readme]: https://github.com/LafayetteCollegeLibraries/spot/blob/primary/app/services/spot/mappers/readme.markdown
+[validator-readme]: https://github.com/LafayetteCollegeLibraries/spot/blob/primary/app/services/spot/validators/readme.markdown

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,7 +5,7 @@ lock '~> 3.11.0'
 
 # application variables
 set :application, 'spot'
-set :branch, ENV['BRANCH'] || 'master'
+set :branch, ENV['BRANCH'] || 'primary'
 set :deploy_to, '/var/www/spot'
 set :keep_releases, 3
 set :repo_url, 'https://github.com/LafayetteCollegeLibraries/spot.git'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# we're releasing off of `master`, so anything going on to
+# we're releasing off of `primary`, so anything going on to
 # the stage application will most likely be from our `develop` branch
 set :branch, ENV.fetch('BRANCH') { 'develop' }
 


### PR DESCRIPTION
in place of #526. pointing references to the old `master` branch to the now-default `primary` branch