### PR TITLE
ensure that we call the #related_resource method on woodsworth mapper

### DIFF
--- a/app/services/spot/mappers/woodsworth_images_mapper.rb
+++ b/app/services/spot/mappers/woodsworth_images_mapper.rb
@@ -20,6 +20,7 @@ module Spot::Mappers
         :description,
         :identifier,
         :location,
+        :related_resource,
         :rights_statement,
         :subject,
         :title,


### PR DESCRIPTION
the `WoodsworthMapper` isn't calling the `#related_resource` method because the symbol isn't in the `#fields` array 🙃 

closes #533 