### PR TITLE
add date_uploaded mixin for mappers

### DIFF
--- a/app/services/concerns/spot/mappers/maps_original_create_date.rb
+++ b/app/services/concerns/spot/mappers/maps_original_create_date.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+module Spot::Mappers
+  # The +:date_uploaded+ property is used to store the date of the item's original ingest.
+  # This is preserved in the MetaDB technical metadata field "format.technical.DateModified".
+  # In order to ensure that this is called on every item, we'll add a +date_uploaded+ method
+  # and push it into the +#fields+ array (since the standard practice is to append an array
+  # to the +super+ results, this will be called first).
+  #
+  # @example Adding a date_uploaded field to a mapper with the default metadata field "format.technical.DateModified"
+  #
+  #   module Spot::Mappers
+  #     class LegacyCollectionMapper < BaseMapper
+  #       include MapsOriginalCreateDate
+  #     end
+  #   end
+  #
+  #   Spot::Mappers::LegacyCollectionMapper.new.fields.include?(:date_uploaded)
+  #   # => true
+  #
+  # @see https://github.com/samvera/hyrax/blob/v2.8.0/app/models/concerns/hyrax/core_metadata.rb#L20-L28
+  module MapsOriginalCreateDate
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :original_create_date_field
+      self.original_create_date_field = 'format.technical.DateModified'
+    end
+
+    # @return [Array<Symbol>]
+    def fields
+      super + [:date_uploaded]
+    end
+
+    # @return [String, nil]
+    def date_uploaded
+      return unless metadata.include?(original_create_date_field)
+
+      begin
+        DateTime.parse(metadata[original_create_date_field]).utc
+      rescue ArgumentError
+        nil
+      end
+    end
+  end
+end

--- a/app/services/concerns/spot/mappers/maps_original_create_date.rb
+++ b/app/services/concerns/spot/mappers/maps_original_create_date.rb
@@ -35,11 +35,9 @@ module Spot::Mappers
     def date_uploaded
       return unless metadata.include?(original_create_date_field)
 
-      begin
-        DateTime.parse(metadata[original_create_date_field]).utc
-      rescue ArgumentError
-        nil
-      end
+      DateTime.parse(metadata[original_create_date_field]).utc
+    rescue ArgumentError
+      nil
     end
   end
 end

--- a/app/services/spot/mappers/alsace_images_mapper.rb
+++ b/app/services/spot/mappers/alsace_images_mapper.rb
@@ -4,6 +4,7 @@ module Spot::Mappers
     # note: we're not using the public #title or #title_alternative methods
     # but we are using the #field_to_tagged_literals helper
     include LanguageTaggedTitles
+    include MapsOriginalCreateDate
 
     self.fields_map = {
       date_scope_note: 'date.period',

--- a/app/services/spot/mappers/base_eaic_mapper.rb
+++ b/app/services/spot/mappers/base_eaic_mapper.rb
@@ -16,6 +16,7 @@ module Spot::Mappers
   #
   class BaseEaicMapper < BaseMapper
     include LanguageTaggedTitles
+    include MapsOriginalCreateDate
 
     # 'date.artifact.lower' and 'date.artifact.upper' fields concatted into
     # an EDTF date string. When both fields are available, a range object

--- a/app/services/spot/mappers/cap_mapper.rb
+++ b/app/services/spot/mappers/cap_mapper.rb
@@ -2,6 +2,7 @@
 module Spot::Mappers
   class CapMapper < BaseMapper
     include LanguageTaggedTitles
+    include MapsOriginalCreateDate
 
     self.primary_title_map = { 'title' => :en }
     self.fields_map = {

--- a/app/services/spot/mappers/mckelvy_house_mapper.rb
+++ b/app/services/spot/mappers/mckelvy_house_mapper.rb
@@ -2,6 +2,7 @@
 module Spot::Mappers
   class MckelvyHouseMapper < BaseMapper
     include LanguageTaggedTitles
+    include MapsOriginalCreateDate
 
     self.primary_title_map = { 'title' => :en }
     self.fields_map = {

--- a/app/services/spot/mappers/mdl_prints_mapper.rb
+++ b/app/services/spot/mappers/mdl_prints_mapper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Spot::Mappers
   class MdlPrintsMapper < BaseMapper
+    include MapsOriginalCreateDate
+
     self.fields_map = {
       creator: 'creator',
       date: 'date.original',

--- a/spec/services/spot/mappers/alsace_images_mapper_spec.rb
+++ b/spec/services/spot/mappers/alsace_images_mapper_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Spot::Mappers::AlsaceImagesMapper do
   before { mapper.metadata = metadata }
 
   it_behaves_like 'it maps Islandora URLs to identifiers'
+  it_behaves_like 'it maps original create date'
 
   describe '#date_scope_note' do
     subject { mapper.date_scope_note }

--- a/spec/services/spot/mappers/cap_mapper_spec.rb
+++ b/spec/services/spot/mappers/cap_mapper_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Spot::Mappers::CapMapper do
   before { mapper.metadata = metadata }
 
   it_behaves_like 'it has language-tagged titles'
+  it_behaves_like 'it maps original create date'
 
   describe '#creator' do
     subject { mapper.creator }

--- a/spec/services/spot/mappers/mckelvy_house_mapper_spec.rb
+++ b/spec/services/spot/mappers/mckelvy_house_mapper_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Spot::Mappers::MckelvyHouseMapper do
   before { mapper.metadata = metadata }
 
   it_behaves_like 'it has language-tagged titles'
+  it_behaves_like 'it maps original create date'
 
   describe '#creator' do
     subject { mapper.creator }

--- a/spec/services/spot/mappers/mdl_prints_mapper_spec.rb
+++ b/spec/services/spot/mappers/mdl_prints_mapper_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Spot::Mappers::MdlPrintsMapper do
 
   before { mapper.metadata = metadata }
 
+  it_behaves_like 'it maps original create date'
+
   describe '#creator' do
     subject { mapper.creator }
 

--- a/spec/support/shared_examples/mappers/base_eaic_mapper.rb
+++ b/spec/support/shared_examples/mappers/base_eaic_mapper.rb
@@ -13,6 +13,7 @@ RSpec.shared_examples 'a base EAIC mapper' do |options|
   skip_fields = options.fetch(:skip_fields, [])
 
   it_behaves_like 'it has language-tagged titles', skip_fields: skip_fields
+  it_behaves_like 'it maps original create date'
 
   describe '#representative_file' do
     subject { mapper.representative_file }

--- a/spec/support/shared_examples/mappers/maps_original_create_date.rb
+++ b/spec/support/shared_examples/mappers/maps_original_create_date.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'it maps original create date' do
+  describe '#date_uploaded' do
+    subject { mapper.date_uploaded }
+
+    let(:mapper) { described_class.new }
+    let(:field) { described_class.original_create_date_field }
+    let(:metadata) { field => value }
+
+    before { mapper.metadata = metadata }
+
+    context 'when a valid value exists' do
+      let(:value) { '2015-04-14 15:55:52' }
+
+      it { is_expected.to eq value }
+    end
+
+    context 'when the value is not valid' do
+      let(:value) { 'not a date :(' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the metadata does not contain the field' do
+      let(:metadata) { { 'title' => ['a title'] } }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/support/shared_examples/mappers/maps_original_create_date.rb
+++ b/spec/support/shared_examples/mappers/maps_original_create_date.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples 'it maps original create date' do
 
     let(:mapper) { described_class.new }
     let(:field) { described_class.original_create_date_field }
-    let(:metadata) { field => value }
+    let(:metadata) { { field => value } }
 
     before { mapper.metadata = metadata }
 


### PR DESCRIPTION
adds a `Spot::Mappers::MapsOriginalCreateDate` mixin to automatically add a `:date_uploaded` attribute where present. the default metadata field is `format.technical.DateModified`, but this can be altered with a class attribute.

```ruby
module Spot::Mappers
  class LegacyCollection < BaseMapper
    include MapsOriginalCreateDate

    self.original_create_date_field = 'custom_create_field'
  end
end
```

the `date_uploaded` method will attempt to parse a UTC date from the field, falling back to `nil` if the value isn't parseable.

## notes
- this is already mixed in to `Spot::Mappers::BaseEaicMapper`. so descendants won't need to include it
- `date_uploaded` will return a single value

closes #552 