### PR TITLE
store image creation metadata as a note

### DIFF
--- a/app/services/concerns/spot/mappers/maps_image_creation_note.rb
+++ b/app/services/concerns/spot/mappers/maps_image_creation_note.rb
@@ -26,8 +26,8 @@ module Spot::Mappers
 
     # @return [Array<String>]
     def note
-      metadata.fetch(image_creation_note_field, [])
-              .map { |s| s.to_s.gsub(/Online display image was converted to JPG format\.$/, '').trim }
+      Array.wrap(metadata.fetch(image_creation_note_field, []))
+           .map { |s| s.to_s.gsub(/Online display image was converted to JPG format\.$/, '').trim }
     end
   end
 end

--- a/app/services/concerns/spot/mappers/maps_image_creation_note.rb
+++ b/app/services/concerns/spot/mappers/maps_image_creation_note.rb
@@ -27,7 +27,7 @@ module Spot::Mappers
     # @return [Array<String>]
     def note
       Array.wrap(metadata.fetch(image_creation_note_field, []))
-           .map { |s| s.to_s.gsub(/Online display image was converted to JPG format\.$/, '').trim }
+           .map { |s| s.to_s.gsub(/Online display image was converted to JPG format\.$/, '').strip }
     end
   end
 end

--- a/app/services/concerns/spot/mappers/maps_image_creation_note.rb
+++ b/app/services/concerns/spot/mappers/maps_image_creation_note.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+module Spot::Mappers
+  # Mixin to store information about the original image's creation as a note.
+  #
+  # @example changing the note field (default is "format.digital")
+  #   module Spot::Mappers
+  #     class LegacyCollectionMapper < BaseMapper
+  #       include MapsImageCreationNote
+  #
+  #       self.image_creation_note_field = 'note'
+  #     end
+  #   end
+  #
+  module MapsImageCreationNote
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :image_creation_note_field
+      self.image_creation_note_field = 'format.digital'
+    end
+
+    # @return [Array<Symbol>]
+    def fields
+      super + [:note]
+    end
+
+    # @return [Array<String>]
+    def note
+      metadata.fetch(image_creation_note_field, [])
+              .map { |s| s.to_s.gsub(/Online display image was converted to JPG format\.$/, '').trim }
+    end
+  end
+end

--- a/app/services/spot/mappers/base_eaic_mapper.rb
+++ b/app/services/spot/mappers/base_eaic_mapper.rb
@@ -16,6 +16,7 @@ module Spot::Mappers
   #
   class BaseEaicMapper < BaseMapper
     include LanguageTaggedTitles
+    include MapsImageCreationNote
     include MapsOriginalCreateDate
 
     # 'date.artifact.lower' and 'date.artifact.upper' fields concatted into

--- a/app/services/spot/mappers/cap_mapper.rb
+++ b/app/services/spot/mappers/cap_mapper.rb
@@ -2,6 +2,7 @@
 module Spot::Mappers
   class CapMapper < BaseMapper
     include LanguageTaggedTitles
+    include MapsImageCreationNote
     include MapsOriginalCreateDate
 
     self.primary_title_map = { 'title' => :en }

--- a/app/services/spot/mappers/mckelvy_house_mapper.rb
+++ b/app/services/spot/mappers/mckelvy_house_mapper.rb
@@ -2,6 +2,7 @@
 module Spot::Mappers
   class MckelvyHouseMapper < BaseMapper
     include LanguageTaggedTitles
+    include MapsImageCreationNote
     include MapsOriginalCreateDate
 
     self.primary_title_map = { 'title' => :en }

--- a/app/services/spot/mappers/mdl_prints_mapper.rb
+++ b/app/services/spot/mappers/mdl_prints_mapper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module Spot::Mappers
   class MdlPrintsMapper < BaseMapper
+    include MapsImageCreationNote
     include MapsOriginalCreateDate
 
     self.fields_map = {

--- a/spec/services/spot/mappers/cap_mapper_spec.rb
+++ b/spec/services/spot/mappers/cap_mapper_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Spot::Mappers::CapMapper do
   before { mapper.metadata = metadata }
 
   it_behaves_like 'it has language-tagged titles'
+  it_behaves_like 'it maps image creation note'
   it_behaves_like 'it maps original create date'
 
   describe '#creator' do

--- a/spec/services/spot/mappers/mckelvy_house_mapper_spec.rb
+++ b/spec/services/spot/mappers/mckelvy_house_mapper_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Spot::Mappers::MckelvyHouseMapper do
   before { mapper.metadata = metadata }
 
   it_behaves_like 'it has language-tagged titles'
+  it_behaves_like 'it maps image creation note'
   it_behaves_like 'it maps original create date'
 
   describe '#creator' do

--- a/spec/services/spot/mappers/mdl_prints_mapper_spec.rb
+++ b/spec/services/spot/mappers/mdl_prints_mapper_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Spot::Mappers::MdlPrintsMapper do
 
   before { mapper.metadata = metadata }
 
+  it_behaves_like 'it maps image creation note'
   it_behaves_like 'it maps original create date'
 
   describe '#creator' do

--- a/spec/support/shared_examples/mappers/base_eaic_mapper.rb
+++ b/spec/support/shared_examples/mappers/base_eaic_mapper.rb
@@ -14,6 +14,7 @@ RSpec.shared_examples 'a base EAIC mapper' do |options|
 
   it_behaves_like 'it has language-tagged titles', skip_fields: skip_fields
   it_behaves_like 'it maps original create date'
+  it_behaves_like 'it maps image creation note'
 
   describe '#representative_file' do
     subject { mapper.representative_file }

--- a/spec/support/shared_examples/mappers/maps_image_creation_note.rb
+++ b/spec/support/shared_examples/mappers/maps_image_creation_note.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'it maps image creation note' do
+  describe '#note' do
+    subject { mapper.note }
+
+    let(:mapper) { described_class.new }
+    let(:field) { described_class.image_creation_note_field }
+    let(:metadata) { { field => value } }
+
+    before { mapper.metadata = metadata }
+
+    context 'when a value exists' do
+      let(:value) { 'Created on an Epson scanner' }
+
+      it { is_expected.to eq value }
+    end
+
+    context 'when no value exists' do
+      let(:metadata) { { 'title' => ['work title'] } }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when value contains magic string' do
+      let(:value) do
+        'Master TIF image captured at 4000 pixels across the long edge using SilverFast AI 6.6 software and an Epson v700 scanner. Online display image was converted to JPG format.'
+      end
+
+      it { is_expected.to eq ['Master TIF image captured at 4000 pixels across the long edge using SilverFast AI 6.6 software and an Epson v700 scanner.'] }
+    end
+  end
+end

--- a/spec/support/shared_examples/mappers/maps_image_creation_note.rb
+++ b/spec/support/shared_examples/mappers/maps_image_creation_note.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples 'it maps image creation note' do
     before { mapper.metadata = metadata }
 
     context 'when a value exists' do
-      let(:value) { 'Created on an Epson scanner' }
+      let(:value) { ['Created on an Epson scanner'] }
 
       it { is_expected.to eq value }
     end
@@ -23,7 +23,7 @@ RSpec.shared_examples 'it maps image creation note' do
 
     context 'when value contains magic string' do
       let(:value) do
-        'Master TIF image captured at 4000 pixels across the long edge using SilverFast AI 6.6 software and an Epson v700 scanner. Online display image was converted to JPG format.'
+        ['Master TIF image captured at 4000 pixels across the long edge using SilverFast AI 6.6 software and an Epson v700 scanner. Online display image was converted to JPG format.']
       end
 
       it { is_expected.to eq ['Master TIF image captured at 4000 pixels across the long edge using SilverFast AI 6.6 software and an Epson v700 scanner.'] }


### PR DESCRIPTION
adds mixin to map `format.digital` information about source image creation to the `#note` field

closes #554