### PR TITLE
add resource_type to mckelvy-house mapper 😅

### DIFF
--- a/app/services/spot/mappers/mckelvy_house_mapper.rb
+++ b/app/services/spot/mappers/mckelvy_house_mapper.rb
@@ -13,6 +13,7 @@ module Spot::Mappers
       original_item_extent: 'description.size',
       physical_medium: 'format.medium',
       repository_location: 'source',
+      resource_type: 'resource.type',
       source: 'description.note'
     }
 

--- a/spec/services/spot/mappers/mckelvy_house_mapper_spec.rb
+++ b/spec/services/spot/mappers/mckelvy_house_mapper_spec.rb
@@ -77,6 +77,14 @@ RSpec.describe Spot::Mappers::MckelvyHouseMapper do
     it_behaves_like 'a mapped field'
   end
 
+  describe '#resource_type' do
+    subject { mapper.resource_type }
+
+    let(:field) { 'resource.type' }
+
+    it_behaves_like 'a mapped field'
+  end
+
   describe '#rights_statement' do
     subject { mapper.rights_statement }
 


### PR DESCRIPTION
adds `#resource_type` to `Spot::Mappers::MckelvyHouseMapper`