### PR TITLE
update collection sort fields

### DIFF
--- a/app/controllers/concerns/spot/collections_controller_behavior.rb
+++ b/app/controllers/concerns/spot/collections_controller_behavior.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Spot
+  module CollectionsControllerBehavior
+    extend ActiveSupport::Concern
+
+    included do
+      configure_blacklight do |config|
+        # clear out sort_fields from CatalogController
+        config[:sort_fields] = ActiveSupport::OrderedHash.new
+
+        config.add_sort_field 'title_sort_si asc', label: "Title \u25B2"
+        config.add_sort_field 'title_sort_si desc', label: "Title \u25BC"
+        config.add_sort_field 'date_sort_dtsi asc', label: "Date \u25B2"
+        config.add_sort_field 'date_sort_dtsi desc', label: "Date \u25BC"
+      end
+    end
+  end
+end

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -7,9 +7,11 @@ Rails.application.config.to_prepare do
   # Spot overrides Hyrax
   Hyrax::Dashboard::CollectionsController.presenter_class = Spot::CollectionPresenter
   Hyrax::Dashboard::CollectionsController.form_class = Spot::Forms::CollectionForm
+  Hyrax::Dashboard::CollectionsController.include Spot::CollectionsControllerBehavior
 
   Hyrax::CollectionsController.presenter_class = Spot::CollectionPresenter
   Hyrax::CollectionsController.include Spot::CollectionSlugsBehavior
+  Hyrax::CollectionsController.include Spot::CollectionsControllerBehavior
 
   Hyrax::DerivativeService.services = [
     ::Spot::ImageDerivativesService,


### PR DESCRIPTION
`Hyrax::CollectionsController` and `Hyrax::Dashboard::CollectionsController` both copy the default Blacklight configuration from `CatalogController`, which defines sort fields. We don't have a need for the "relevancy" ranking, as the collection views just display the items, and we'd prefer to default to having items sorted by title (most of the EAIC items have their intended sequence number as part of the title).

this creates a `Spot::CollectionsControllerBehavior` mixin and injects it into those aforementioned controllers within `config/initializers/spot_overrides.rb`

closes #459 