### PR TITLE
update iiif manifest generation to match new hyrax patterns

### DIFF
--- a/app/controllers/concerns/spot/configurable_iiif_manifest_presenter.rb
+++ b/app/controllers/concerns/spot/configurable_iiif_manifest_presenter.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module Spot
+  # abstracts out a +:iiif_manifest_presenter_klass+ attribute to override the Hyrax one.
+  # in our case, we want to change how the metadata is rendered.
+  #
+  # @see https://github.com/samvera/hyrax/blob/v2.9.0/app/controllers/concerns/hyrax/works_controller_behavior.rb#L146-L151
+  module ConfigurableIiifManifestPresenter
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :iiif_manifest_presenter_klass
+      self.iiif_manifest_presenter_klass = ::Spot::IiifManifestPresenter
+    end
+
+    private
+
+      # same behavior as Hyrax::WorksControllerBehavior#iiif_manifest_presenter,
+      # but uses the configurable +:iiif_manifest_presenter_klass+ attribute
+      # to allow for other subclassed presenters.
+      #
+      # @return [Hyrax::IiifManifestPresenter]
+      def iiif_manifest_presenter
+        iiif_manifest_presenter_klass.new(curation_concern_from_search_results).tap do |p|
+          p.hostname = request.hostname
+          p.ability = current_ability
+        end
+      end
+  end
+end

--- a/app/controllers/hyrax/images_controller.rb
+++ b/app/controllers/hyrax/images_controller.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
-
-# Generated via
-#  `rails generate hyrax:work Image`
 module Hyrax
   # Generated controller for Image
   class ImagesController < ApplicationController
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
+
+    # use our local IiifManifestPresenter for rendering manifest metadata
+    include Spot::ConfigurableIiifManifestPresenter
+
     self.curation_concern_type = ::Image
 
     # Use this line if you want to use a custom presenter

--- a/app/controllers/hyrax/publications_controller.rb
+++ b/app/controllers/hyrax/publications_controller.rb
@@ -6,6 +6,9 @@ module Hyrax
     include Hyrax::BreadcrumbsForWorks
     include Spot::AdditionalFormatsForController
 
+    # use our local IiifManifestPresenter for rendering manifest metadata
+    include Spot::ConfigurableIiifManifestPresenter
+
     self.curation_concern_type = ::Publication
 
     # Use this line if you want to use a custom presenter

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -11,14 +11,6 @@ module Hyrax
              :subtitle, :title_alternative,
              to: :solr_document
 
-    def manifest_metadata_fields
-      %i[
-        title subtitle title_alternative creator contributor date
-        description inscription keyword language_label location
-        subject subject_ocm standard_identifier rights_statement
-      ]
-    end
-
     def subject_ocm
       solr_document.subject_ocm.sort
     end

--- a/app/presenters/hyrax/publication_presenter.rb
+++ b/app/presenters/hyrax/publication_presenter.rb
@@ -21,13 +21,6 @@ module Hyrax
       @local_identifier ||= solr_document.local_identifier.map { |id| Spot::Identifier.from_string(id) }
     end
 
-    def manifest_metadata_fields
-      %i[
-        title subtitle title_alternative creator contributor abstract description
-        subject keyword date_issued standard_identifier rights_holder rights_statement
-      ]
-    end
-
     # @return [Array<Spot::Identifier>]
     def standard_identifier
       @standard_identifier ||= solr_document.standard_identifier.map { |id| Spot::Identifier.from_string(id) }

--- a/app/presenters/spot/base_presenter.rb
+++ b/app/presenters/spot/base_presenter.rb
@@ -38,18 +38,6 @@ module Spot
       solr_document.location.zip(solr_document.location_label).reject(&:empty?)
     end
 
-    # @return [Array<Hash<String => *>>]
-    def manifest_metadata
-      return super unless respond_to?(:manifest_metadata_fields)
-
-      manifest_metadata_fields.inject([]) do |metadata, field|
-        values = iiif_metadata_for(field)
-        next metadata if values.nil?
-
-        metadata << values
-      end
-    end
-
     # @return [true, false]
     def multiple_members?
       list_of_item_ids_to_display.count > 1
@@ -87,27 +75,5 @@ module Spot
     def work_featurable?
       false
     end
-
-    private
-
-      # Maps a field + its values to a Hash of 'label' and 'value',
-      # where 'label' is our translated field name and 'value' is
-      # an Array of values.
-      #
-      # @return [Hash<String => String,Array<String>>
-      # @todo for LD fields, can we include both the URI and the label?
-      def iiif_metadata_for(field)
-        raw_values = send(field.to_sym)
-        return if raw_values.blank?
-
-        # our controlled fields are typically zipped a [uri, label]
-        # tuple. for now, we'll only use the label of the value,
-        # but this is where we would map to a Hash of URI and label
-        # in the future
-        wrapped_values = Array.wrap(raw_values).map { |v| v.is_a?(Array) ? v.last : v }
-
-        { 'label' => I18n.t("blacklight.search.fields.#{field}", field.to_s.humanize.titleize),
-          'value' => wrapped_values }
-      end
   end
 end

--- a/app/presenters/spot/iiif_manifest_presenter.rb
+++ b/app/presenters/spot/iiif_manifest_presenter.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Spot
+  # Our local subclassing of +Hyrax::IiifManifestPresenter+ which allows us to retain the extra
+  # fiddling with manifest_metadata that we were previously doing in the publication/image presenters.
+  class IiifManifestPresenter < ::Hyrax::IiifManifestPresenter
+    def manifest_metadata
+      metadata_fields.map do |field|
+        raw_values = self[field.to_sym]
+        next if raw_values.blank?
+
+        # our controlled fields are typically a [uri, label] tuple.
+        # for now, we'll only use the label of the value,
+        # but this is where we would map to a Hash of URI and label
+        wrapped_and_scrubbed_values = Array.wrap(raw_values).map { |v| v.is_a?(Array) ? v.last : v }.map { |v| scrub(v.to_s) }
+
+        { 'label' => I18n.t("blacklight.search.fields.#{field}", field.to_s.humanize.titleize),
+          'value' => wrapped_and_scrubbed_values }
+      end.compact
+    end
+  end
+end

--- a/app/presenters/spot/iiif_manifest_presenter.rb
+++ b/app/presenters/spot/iiif_manifest_presenter.rb
@@ -13,7 +13,7 @@ module Spot
         # but this is where we would map to a Hash of URI and label
         wrapped_and_scrubbed_values = Array.wrap(raw_values).map { |v| v.is_a?(Array) ? v.last : v }.map { |v| scrub(v.to_s) }
 
-        { 'label' => I18n.t("blacklight.search.fields.#{field}", field.to_s.humanize.titleize),
+        { 'label' => I18n.t("blacklight.search.fields.#{field}", default: field.to_s.humanize.titleize),
           'value' => wrapped_and_scrubbed_values }
       end.compact
     end

--- a/app/presenters/spot/iiif_manifest_presenter.rb
+++ b/app/presenters/spot/iiif_manifest_presenter.rb
@@ -5,7 +5,7 @@ module Spot
   class IiifManifestPresenter < ::Hyrax::IiifManifestPresenter
     def manifest_metadata
       metadata_fields.map do |field|
-        raw_values = self[field.to_sym]
+        raw_values = send(field.to_sym)
         next if raw_values.blank?
 
         # our controlled fields are typically a [uri, label] tuple.

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -146,8 +146,12 @@ Hyrax.config do |config|
   # Returns a IIIF image size default
   config.iiif_image_size_default = Spot::IiifService::DEFAULT_SIZE
 
-  # Fields to display in the IIIF metadata section; default is the required fields
-  config.iiif_metadata_fields = Hyrax::Forms::WorkForm.required_fields
+  # Fields to display in the IIIF metadata section
+  config.iiif_metadata_fields = %i[
+    title subtitle title_alternative creator contributor date date_issued
+    abstract description inscription subject subject_ocm keyword language_label
+    location standard_identifier rights_holder rights_statement
+  ]
 
   # Should a button with "Share my work" show on the front page to all users (even those not logged in)?
   # config.display_share_button_when_not_logged_in = true

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -55,6 +55,7 @@ en:
         standard_identifier: Standard Identifier
         subject: Subject
         subject_ocm: Outline of Cultural Materials classification
+        subtitle: Subtitle
         title: Title
         title_alternative: Alternative Title
         visibility: Visibility

--- a/spec/support/shared_examples/spot_presenter.rb
+++ b/spec/support/shared_examples/spot_presenter.rb
@@ -47,16 +47,6 @@ RSpec.shared_examples 'a Spot presenter' do
     it { is_expected.to eq [[uri, label]] }
   end
 
-  describe '#manifest_metadata' do
-    subject(:manifest_metadata) { presenter.manifest_metadata }
-
-    it 'is an Array of Hashes' do
-      expect(manifest_metadata).to be_an Array
-      expect(manifest_metadata.all? { |v| v.is_a? Hash }).to be true
-      expect(manifest_metadata.all? { |v| v.include?('label') && v.include?('value') })
-    end
-  end
-
   describe '#page_title' do
     subject { presenter.page_title }
 


### PR DESCRIPTION
i completely missed that hyrax@2.9.0's revamp of iiif_manifest generation moved the metadata gathering logic away from the work presenters and into `Hyrax::IiifManifestPresenter`. this update also hard-codes the presenter into the controller logic, making subclassing the manifest presenter trickier.

this adds a class_attribute to controllers, via a mixin, to make the manifest_presenter configurable and injects a subclassed one that handles metadata the way we previously had been doing. 

this also moves the field configuration back to the hyrax initializer