### PR TITLE
use solr document fields for iiif manifest

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -149,8 +149,8 @@ Hyrax.config do |config|
   # Fields to display in the IIIF metadata section
   config.iiif_metadata_fields = %i[
     title subtitle title_alternative creator contributor date date_issued
-    abstract description inscription subject subject_ocm keyword language_label
-    location standard_identifier rights_holder rights_statement
+    abstract description inscription subject_label subject_ocm keyword language_label
+    location_label standard_identifier rights_holder rights_statement_label
   ]
 
   # Should a button with "Share my work" show on the front page to all users (even those not logged in)?

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -35,6 +35,7 @@ en:
         license: License
         local_identifier: Local Identifier
         location: Location
+        location_label: Location
         member_of_collections: Collections
         organization: Organization
         original_checksum: Original Checksum (MD5)
@@ -51,6 +52,7 @@ en:
         resource_type: Type
         rights_holder: Rights Holders
         rights_statement: Rights Statement
+        rights_statement_label: Rights Statement
         source: Source
         standard_identifier: Standard Identifier
         subject: Subject


### PR DESCRIPTION
digging a little deeper on the iiif manifest update on hyrax, it looks like they're using the item's SolrDocument, rather than its WorkShowPresenter, as the basis for its manifest metadata. so, for controlled fields, we need to point to their *_label siblings.