### PR TITLE
be more lenient with error handling in original_create_date mapper

### DIFF
--- a/app/services/concerns/spot/mappers/maps_original_create_date.rb
+++ b/app/services/concerns/spot/mappers/maps_original_create_date.rb
@@ -37,7 +37,7 @@ module Spot::Mappers
 
       raw_value = Array.wrap(metadata[original_create_date_field]).first
       DateTime.parse(raw_value).utc.to_s
-    rescue ArgumentError
+    rescue
       nil
     end
   end

--- a/spec/support/shared_examples/mappers/maps_original_create_date.rb
+++ b/spec/support/shared_examples/mappers/maps_original_create_date.rb
@@ -26,5 +26,11 @@ RSpec.shared_examples 'it maps original create date' do
 
       it { is_expected.to be_nil }
     end
+
+    context 'when the metadata returns nil for the field' do
+      let(:metadata) { { field => nil } }
+
+      it { is_expected.to be_nil }
+    end
   end
 end


### PR DESCRIPTION
`DateTime.parse(nil)` raises a TypeError, rather than the ArgumentError we're expecting in the MapsOriginalCreateDate mapper mixin. we should just be catching _any_ error and returning nil anyway.