### PR TITLE
2020.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # changelog
 
+## [2020.10] - 2020-09-17
+
+### features 🥼 
+- add mixin to pass presenter date fields through `edtf-humanize` (#604)
+
+### bug fixes 🐞 
+- be more lenient with error handling in original_create_date mapper (#586)
+- add `resource_type` to LewisPostcardsMapper (#588), PaKoshitsuMapper (#589), and GeologySlideEsiMapper (#602)
+- add `research_assistance` to PaTsubokuraMapper (#596)
+- add `subject` to MammanaPostcardsMapper (#603) 
+- fix typo for `Image#repository_location` in `_metadata` partial (#601)
+- index `Image#source` similarly to `Publication#source` (#601)
+- use the right ENV value for IIIF in docker (77ac980)
+- translate spaces to underscores in OAI-PMH setSpec identifiers (#606)
+
+
 ## [2020.9] - 2020-08-27
 
 ### features 🏖️  
@@ -464,6 +480,7 @@ fixes:
 
 Initial pre-release (live on ldr.stage.lafayette.edu)
 
+[2020.10]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2020.10
 [2020.9]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2020.9
 [2020.8]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2020.8
 [2020.7]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2020.7

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -280,6 +280,7 @@ class CatalogController < ApplicationController
       },
 
       document: {
+        set_model: Spot::OaiCollectionSolrSet,
         set_fields: [
           { label: 'collection', solr_field: 'member_of_collections_ssim' }
         ]

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -41,7 +41,7 @@ class Image < ActiveFedora::Base
   end
 
   property :source, predicate: ::RDF::Vocab::DC.source do |index|
-    index.as :symbol
+    index.as :stored_searchable, :facetable
   end
 
   property :resource_type, predicate: ::RDF::Vocab::DC.type do |index|

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -42,6 +42,7 @@ class SolrDocument
   # rubocop:disable Metrics/MethodLength
   def self.field_semantics
     {
+      collection_name: 'member_of_collections_ssim',
       contributor: 'contributor_tesim',
       coverage: 'location_label_ssim',
       creator: 'creator_tesim',
@@ -59,6 +60,10 @@ class SolrDocument
     }
   end
   # rubocop:enable Metrics/MethodLength
+
+  def sets
+    Spot::OaiCollectionSolrSet.sets_for(self)
+  end
 
   # Overrides +Hyrax::SolrDocumentBehavior#to_param+ by preferring collection slugs
   # (where present).

--- a/app/models/spot/oai_collection_solr_set.rb
+++ b/app/models/spot/oai_collection_solr_set.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module Spot
+  # Subclass of +BlacklightOaiProvider::SolrSet+ that translates
+  # spaces to underscores, making the following assumptions:
+  #   a) we'll be using +member_of_collections_ssim+ as our only hook for OAI-PMG ListSets
+  #   b) collection titles will never contain underscores
+  class OaiCollectionSolrSet < ::BlacklightOaiProvider::SolrSet
+    # @param [String] spec
+    # @return [String] solr filter for set
+    def self.from_spec(spec)
+      new(spec.tr('_', ' ')).solr_filter
+    end
+
+    def initialize(spec)
+      super(spec.tr('_', ' '))
+    end
+
+    def spec
+      "#{@label}:#{@value.tr(' ', '_')}"
+    end
+  end
+end

--- a/app/presenters/concerns/spot/humanizes_date_fields.rb
+++ b/app/presenters/concerns/spot/humanizes_date_fields.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+module Spot
+  module HumanizesDateFields
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Macro to create instance methods that run the values through +edtf-humanize+
+      #
+      # @param [Array<Symbol>] *fields
+      # @return [void]
+      def humanize_date_fields(*fields)
+        fields.flatten.each do |field|
+          field = field.to_sym
+
+          define_method(field) do
+            values = solr_document.send(field)
+            values.is_a?(Array) ? values.map { |v| humanize_value(v) } : humanize_value(values)
+          end
+        end
+      end
+    end
+
+    private
+
+      # run a value through +Date.edtf+, return the +.humanize+ value,
+      # and fallback to the value if it's unparseable.
+      #
+      # @param [String] val
+      # @return [String]
+      def humanize_value(val)
+        Date.edtf(val).humanize
+      rescue
+        val
+      end
+  end
+end

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -9,8 +9,8 @@ module Hyrax
              :original_item_extent, :permalink, :physical_medium,
              :publisher, :related_resource, :repository_location,
              :requested_by, :research_assistance, :resource_type,
-             :rights_holder, :rights_statement, :standard_identifier,
-             :subtitle, :title_alternative,
+             :rights_holder, :rights_statement, :source,
+             :standard_identifier, :subtitle, :title_alternative,
              to: :solr_document
 
     def subject_ocm

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -3,11 +3,12 @@ module Hyrax
   class ImagePresenter < ::Spot::BasePresenter
     include ::Spot::ExportsImageDerivatives
 
-    delegate :contributor, :creator, :date, :date_associated,
-             :date_scope_note, :description, :donor, :inscription,
-             :keyword, :language_label, :local_identifier, :note,
-             :original_item_extent, :permalink, :physical_medium,
-             :publisher, :related_resource, :repository_location,
+    humanize_date_fields :date, :date_associated
+
+    delegate :contributor, :creator, :date_scope_note, :description,
+             :donor, :inscription, :keyword, :language_label,
+             :local_identifier, :note, :original_item_extent, :permalink,
+             :physical_medium, :publisher, :related_resource, :repository_location,
              :requested_by, :research_assistance, :resource_type,
              :rights_holder, :rights_statement, :source,
              :standard_identifier, :subtitle, :title_alternative,

--- a/app/presenters/hyrax/publication_presenter.rb
+++ b/app/presenters/hyrax/publication_presenter.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 module Hyrax
   class PublicationPresenter < ::Spot::BasePresenter
+    humanize_date_fields :date_issued
+
     delegate :abstract, :academic_department, :bibliographic_citation,
-             :contributor, :creator, :date_issued, :date_available,
+             :contributor, :creator, :date_available,
              :division, :editor, :keyword, :language, :language_label,
              :local_identifier, :organization, :permalink, :publisher,
              :resource_type, :rights_holder, :source, :standard_identifier,

--- a/app/presenters/spot/base_presenter.rb
+++ b/app/presenters/spot/base_presenter.rb
@@ -13,7 +13,8 @@ module Spot
   #   end
   #
   class BasePresenter < ::Hyrax::WorkShowPresenter
-    include ::Spot::PresentsAttributes
+    include PresentsAttributes
+    include HumanizesDateFields
 
     # @return [String]
     def export_all_text

--- a/app/services/concerns/spot/mappers/maps_original_create_date.rb
+++ b/app/services/concerns/spot/mappers/maps_original_create_date.rb
@@ -37,7 +37,7 @@ module Spot::Mappers
 
       raw_value = Array.wrap(metadata[original_create_date_field]).first
       DateTime.parse(raw_value).utc.to_s
-    rescue ArgumentError
+    rescue
       nil
     end
   end

--- a/app/services/spot/mappers/geology_slides_esi_mapper.rb
+++ b/app/services/spot/mappers/geology_slides_esi_mapper.rb
@@ -5,7 +5,8 @@ module Spot::Mappers
 
     self.fields_map = {
       keyword: ['keyword', 'relation.ispartof'],
-      related_resource: ['relation.seealso.book', 'relation.seealso.image']
+      related_resource: ['relation.seealso.book', 'relation.seealso.image'],
+      resource_type: 'resource.type'
     }
 
     def fields

--- a/app/services/spot/mappers/lewis_postcards_mapper.rb
+++ b/app/services/spot/mappers/lewis_postcards_mapper.rb
@@ -8,6 +8,7 @@ module Spot::Mappers
       physical_medium: 'format.medium',
       publisher: 'creator.company',
       research_assistance: 'contributor',
+      resource_type: 'resource.type',
       subject_ocm: 'subject.ocm'
     }
 

--- a/app/services/spot/mappers/mammana_postcards_mapper.rb
+++ b/app/services/spot/mappers/mammana_postcards_mapper.rb
@@ -23,6 +23,7 @@ module Spot::Mappers
         :identifier,
         :location,
         :rights_statement,
+        :subject,
         :title,
         :title_alternative
       ]

--- a/app/services/spot/mappers/pa_koshitsu_mapper.rb
+++ b/app/services/spot/mappers/pa_koshitsu_mapper.rb
@@ -9,6 +9,7 @@ module Spot::Mappers
       publisher: 'creator.company',
       related_resource: 'description.citation',
       research_assistance: 'contributor',
+      resource_type: 'resource.type',
       subject_ocm: 'subject.ocm'
     }
 

--- a/app/services/spot/mappers/pa_tsubokura_mapper.rb
+++ b/app/services/spot/mappers/pa_tsubokura_mapper.rb
@@ -8,6 +8,7 @@ module Spot::Mappers
       language: 'language',
       physical_medium: 'format.medium',
       publisher: 'creator.company',
+      research_assistance: 'contributor',
       resource_type: 'resource.type',
       subject_ocm: 'subject.ocm'
     }

--- a/app/views/hyrax/images/_metadata.html.erb
+++ b/app/views/hyrax/images/_metadata.html.erb
@@ -37,7 +37,7 @@
       <%= presenter.attribute_to_html(:research_assistance,
                                       render_as: :faceted,
                                       search_field: :research_assistance_ssim) %>
-      <%= presenter.attribute_to_html(:repostiory_location) %>
+      <%= presenter.attribute_to_html(:repository_location) %>
       <%= presenter.attribute_to_html(:permalink) %>
 
       <%= render 'shared/metadata/rights_statement', presenter: presenter %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       REDIS_URL: redis://redis:6379
       SOLR_URL: http://solr:8983/solr/spot-development
       DEV_USER: dss@lafayette.edu
-      IIIF_URL_BASE: http://localhost:8182/iiif/2
+      IIIF_BASE_URL: http://localhost:8182/iiif/2
     restart: always
     depends_on:
       - cantaloupe

--- a/spec/features/oai_provider_spec.rb
+++ b/spec/features/oai_provider_spec.rb
@@ -37,8 +37,10 @@ RSpec.feature 'OAI-PMH provider (via Blacklight)' do
       visit oai_catalog_path(verb: 'ListSets')
 
       values = xml.css('ListSets setSpec').map(&:text)
-      expect(values).to include('collection:Collection 1')
-      expect(values).not_to include('collection:Collection 2')
+
+      # note: we're translating spaces to underscores for setSpec ids
+      expect(values).to include('collection:Collection_1')
+      expect(values).not_to include('collection:Collection_2')
     end
   end
 

--- a/spec/features/show_publication_spec.rb
+++ b/spec/features/show_publication_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'Show Publication page', js: false do
     expect(page.all('.attribute-creator').map(&:text))
       .to eq pub.creator.map(&:to_s)
     expect(page.all('.attribute-date_issued').map(&:text))
-      .to eq pub.date_issued.map(&:to_s)
+      .to eq pub.date_issued.map(&:to_s).map { |d| Date.edtf(d).humanize }
     expect(page.all('.attribute-date_available').map(&:text))
       .to eq pub.date_available.map(&:to_s)
     expect(page.all('.attribute-division').map(&:text))

--- a/spec/indexers/image_indexer_spec.rb
+++ b/spec/indexers/image_indexer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ImageIndexer do
     title_alternative: %w[tesim],
     publisher: %w[tesim sim],
     repository_location: %w[ssim],
-    source: %w[ssim],
+    source: %w[tesim sim],
     resource_type: %w[tesim sim],
     physical_medium: %w[tesim sim],
     original_item_extent: %w[tesim],

--- a/spec/models/spot/oai_collection_solr_set_spec.rb
+++ b/spec/models/spot/oai_collection_solr_set_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+RSpec.describe Spot::OaiCollectionSolrSet do
+  before do
+    described_class.fields = fields
+  end
+
+  let(:fields) { [{ label: 'Collection', solr_field: 'member_of_collections_ssim' }] }
+
+  describe '.from_spec' do
+    subject(:solr_filter) { described_class.from_spec(spec) }
+
+    context 'when a spec has underscores in it' do
+      let(:spec) { 'Collection:A_Test_Collection' }
+
+      it 'replaces them with spaces' do
+        expect(solr_filter).to eq 'member_of_collections_ssim:"A Test Collection"'
+      end
+    end
+
+    context 'when a spec has no spaces' do
+      let(:spec) { 'Collection:Photographs' }
+
+      it 'does nothing' do
+        expect(solr_filter).to eq 'member_of_collections_ssim:"Photographs"'
+      end
+    end
+  end
+
+  describe '#initialize' do
+    subject(:solr_set) { described_class.new(spec) }
+
+    let(:spec) { 'Collection:A_Test_Collection' }
+
+    it 'replaces underscores with spaces for the @value property' do
+      expect(solr_set.value).to eq 'A Test Collection'
+    end
+
+    it 'puts the underscores back when calling #spec' do
+      expect(solr_set.spec).to eq spec
+    end
+  end
+end

--- a/spec/presenters/hyrax/image_presenter_spec.rb
+++ b/spec/presenters/hyrax/image_presenter_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Hyrax::ImagePresenter do
 
   it_behaves_like 'a Spot presenter'
   it_behaves_like 'it exports image derivatives'
+  it_behaves_like 'it humanizes date fields', for: %i[date date_associated]
 
   describe '#subject_ocm' do
     subject { presenter.subject_ocm }

--- a/spec/presenters/hyrax/publication_presenter_spec.rb
+++ b/spec/presenters/hyrax/publication_presenter_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Hyrax::PublicationPresenter do
   let(:ability) { Ability.new(build(:user)) }
 
   it_behaves_like 'a Spot presenter'
+  it_behaves_like 'it humanizes date fields', for: %i[date_issued]
 
   context 'identifier handling' do
     let(:raw_ids) { ['issn:1234-5678', 'abc:123'] }

--- a/spec/services/spot/mappers/geology_slides_esi_mapper_spec.rb
+++ b/spec/services/spot/mappers/geology_slides_esi_mapper_spec.rb
@@ -70,6 +70,14 @@ RSpec.describe Spot::Mappers::GeologySlidesEsiMapper do
     it_behaves_like 'a mapped field'
   end
 
+  describe '#resource_type' do
+    subject { mapper.resource_type }
+
+    let(:field) { 'resource.type' }
+
+    it_behaves_like 'a mapped field'
+  end
+
   describe '#rights_statement' do
     subject { mapper.rights_statement }
 

--- a/spec/services/spot/mappers/lewis_postcards_mapper_spec.rb
+++ b/spec/services/spot/mappers/lewis_postcards_mapper_spec.rb
@@ -102,6 +102,14 @@ RSpec.describe Spot::Mappers::LewisPostcardsMapper do
     it_behaves_like 'a mapped field'
   end
 
+  describe '#resource_type' do
+    subject { mapper.resource_type }
+
+    let(:field) { 'resource.type' }
+
+    it_behaves_like 'a mapped field'
+  end
+
   describe '#subject_ocm' do
     subject { mapper.subject_ocm }
 

--- a/spec/services/spot/mappers/pa_koshitsu_mapper_spec.rb
+++ b/spec/services/spot/mappers/pa_koshitsu_mapper_spec.rb
@@ -63,6 +63,14 @@ RSpec.describe Spot::Mappers::PaKoshitsuMapper do
     it_behaves_like 'a mapped field'
   end
 
+  describe '#resource_type' do
+    subject { mapper.resource_type }
+
+    let(:field) { 'resource.type' }
+
+    it_behaves_like 'a mapped field'
+  end
+
   describe '#subject_ocm' do
     subject { mapper.subject_ocm }
 

--- a/spec/services/spot/mappers/pa_tsubokura_mapper_spec.rb
+++ b/spec/services/spot/mappers/pa_tsubokura_mapper_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Spot::Mappers::PaTsubokuraMapper do
     [:language],
     [:physical_medium, 'format.medium'],
     [:publisher, 'creator.company'],
+    [:research_assistance, 'contributor'],
     [:resource_type, 'resource.type'],
     [:subject_ocm, 'subject.ocm']
   ].each do |(method, key)|

--- a/spec/support/shared_examples/mappers/maps_original_create_date.rb
+++ b/spec/support/shared_examples/mappers/maps_original_create_date.rb
@@ -26,5 +26,11 @@ RSpec.shared_examples 'it maps original create date' do
 
       it { is_expected.to be_nil }
     end
+
+    context 'when the metadata returns nil for the field' do
+      let(:metadata) { { field => nil } }
+
+      it { is_expected.to be_nil }
+    end
   end
 end

--- a/spec/support/shared_examples/presenters/humanizes_date_fields.rb
+++ b/spec/support/shared_examples/presenters/humanizes_date_fields.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'it humanizes date fields' do |opts|
+  opts ||= {}
+  fields = opts[:for] || []
+
+  raise 'No fields provided for example' if fields.empty?
+
+  fields.each do |field|
+    describe "for :#{field}" do
+      subject { presenter.send(field.to_sym) }
+
+      before do
+        allow(presenter.solr_document).to receive(field.to_sym).and_return(original_value)
+      end
+
+      context 'YYYY-MM-DD values' do
+        let(:original_value) { ['2020-09-09'] }
+
+        it { is_expected.to eq ['September 9, 2020'] }
+      end
+
+      context 'YYYx' do
+        let(:original_value) { ['202x'] }
+
+        it { is_expected.to eq ['2020s'] }
+      end
+
+      context 'YYYY/YYYY' do
+        let(:original_value) { ['1986/2020'] }
+
+        it { is_expected.to eq ['1986 to 2020'] }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## features 🥼 
- add mixin to pass presenter date fields through `edtf-humanize` (#604)

## bug fixes 🐞 
- be more lenient with error handling in original_create_date mapper (#586)
- add `resource_type` to LewisPostcardsMapper (#588), PaKoshitsuMapper (#589), and GeologySlideEsiMapper (#602)
- add `research_assistance` to PaTsubokuraMapper (#596)
- add `subject` to MammanaPostcardsMapper (#603) 
- fix typo for `Image#repository_location` in `_metadata` partial (#601)
- index `Image#source` similarly to `Publication#source` (#601)
- use the right ENV value for IIIF in docker (77ac980)
- translate spaces to underscores in OAI-PMH setSpec identifiers (#606)

## notes 📓 
- will require a reindex for `Image#source` to display properly

----

closes #591
closes #592
closes #598
closes #599
closes #600 