### PR TITLE
fix public fields for Image

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -41,7 +41,7 @@ class Image < ActiveFedora::Base
   end
 
   property :source, predicate: ::RDF::Vocab::DC.source do |index|
-    index.as :symbol
+    index.as :stored_searchable, :facetable
   end
 
   property :resource_type, predicate: ::RDF::Vocab::DC.type do |index|

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -9,8 +9,8 @@ module Hyrax
              :original_item_extent, :permalink, :physical_medium,
              :publisher, :related_resource, :repository_location,
              :requested_by, :research_assistance, :resource_type,
-             :rights_holder, :rights_statement, :standard_identifier,
-             :subtitle, :title_alternative,
+             :rights_holder, :rights_statement, :source,
+             :standard_identifier, :subtitle, :title_alternative,
              to: :solr_document
 
     def subject_ocm

--- a/app/views/hyrax/images/_metadata.html.erb
+++ b/app/views/hyrax/images/_metadata.html.erb
@@ -37,7 +37,7 @@
       <%= presenter.attribute_to_html(:research_assistance,
                                       render_as: :faceted,
                                       search_field: :research_assistance_ssim) %>
-      <%= presenter.attribute_to_html(:repostiory_location) %>
+      <%= presenter.attribute_to_html(:repository_location) %>
       <%= presenter.attribute_to_html(:permalink) %>
 
       <%= render 'shared/metadata/rights_statement', presenter: presenter %>

--- a/spec/indexers/image_indexer_spec.rb
+++ b/spec/indexers/image_indexer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ImageIndexer do
     title_alternative: %w[tesim],
     publisher: %w[tesim sim],
     repository_location: %w[ssim],
-    source: %w[ssim],
+    source: %w[tesim sim],
     resource_type: %w[tesim sim],
     physical_medium: %w[tesim sim],
     original_item_extent: %w[tesim],


### PR DESCRIPTION
- corrects a typo in the Image `_metadata` partial
- updates Image#source to be indexed similarly to Publication#source (`:stored_searchable`, `:facetable`)

closes #598