### PR TITLE
humanize date fields in presenters

### DIFF
--- a/app/presenters/concerns/spot/humanizes_date_fields.rb
+++ b/app/presenters/concerns/spot/humanizes_date_fields.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+module Spot
+  module HumanizesDateFields
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Macro to create instance methods that run the values through +edtf-humanize+
+      #
+      # @param [Array<Symbol>] *fields
+      # @return [void]
+      def humanize_date_fields(*fields)
+        fields.flatten.each do |field|
+          field = field.to_sym
+
+          define_method(field) do
+            values = solr_document.send(field)
+            values.is_a?(Array) ? values.map { |v| humanize_value(v) } : humanize_value(values)
+          end
+        end
+      end
+    end
+
+    private
+
+      # run a value through +Date.edtf+, return the +.humanize+ value,
+      # and fallback to the value if it's unparseable.
+      #
+      # @param [String] val
+      # @return [String]
+      def humanize_value(val)
+        Date.edtf(val).humanize
+      rescue
+        val
+      end
+  end
+end

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -3,11 +3,12 @@ module Hyrax
   class ImagePresenter < ::Spot::BasePresenter
     include ::Spot::ExportsImageDerivatives
 
-    delegate :contributor, :creator, :date, :date_associated,
-             :date_scope_note, :description, :donor, :inscription,
-             :keyword, :language_label, :local_identifier, :note,
-             :original_item_extent, :permalink, :physical_medium,
-             :publisher, :related_resource, :repository_location,
+    humanize_date_fields :date, :date_associated
+
+    delegate :contributor, :creator, :date_scope_note, :description,
+             :donor, :inscription, :keyword, :language_label,
+             :local_identifier, :note, :original_item_extent, :permalink,
+             :physical_medium, :publisher, :related_resource, :repository_location,
              :requested_by, :research_assistance, :resource_type,
              :rights_holder, :rights_statement, :source,
              :standard_identifier, :subtitle, :title_alternative,

--- a/app/presenters/hyrax/publication_presenter.rb
+++ b/app/presenters/hyrax/publication_presenter.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 module Hyrax
   class PublicationPresenter < ::Spot::BasePresenter
+    humanize_date_fields :date_issued
+
     delegate :abstract, :academic_department, :bibliographic_citation,
-             :contributor, :creator, :date_issued, :date_available,
+             :contributor, :creator, :date_available,
              :division, :editor, :keyword, :language, :language_label,
              :local_identifier, :organization, :permalink, :publisher,
              :resource_type, :rights_holder, :source, :standard_identifier,

--- a/app/presenters/spot/base_presenter.rb
+++ b/app/presenters/spot/base_presenter.rb
@@ -13,7 +13,8 @@ module Spot
   #   end
   #
   class BasePresenter < ::Hyrax::WorkShowPresenter
-    include ::Spot::PresentsAttributes
+    include PresentsAttributes
+    include HumanizesDateFields
 
     # @return [String]
     def export_all_text

--- a/spec/features/show_publication_spec.rb
+++ b/spec/features/show_publication_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'Show Publication page', js: false do
     expect(page.all('.attribute-creator').map(&:text))
       .to eq pub.creator.map(&:to_s)
     expect(page.all('.attribute-date_issued').map(&:text))
-      .to eq pub.date_issued.map(&:to_s)
+      .to eq pub.date_issued.map(&:to_s).map { |d| Date.edtf(d).humanize }
     expect(page.all('.attribute-date_available').map(&:text))
       .to eq pub.date_available.map(&:to_s)
     expect(page.all('.attribute-division').map(&:text))

--- a/spec/presenters/hyrax/image_presenter_spec.rb
+++ b/spec/presenters/hyrax/image_presenter_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Hyrax::ImagePresenter do
 
   it_behaves_like 'a Spot presenter'
   it_behaves_like 'it exports image derivatives'
+  it_behaves_like 'it humanizes date fields', for: %i[date date_associated]
 
   describe '#subject_ocm' do
     subject { presenter.subject_ocm }

--- a/spec/presenters/hyrax/publication_presenter_spec.rb
+++ b/spec/presenters/hyrax/publication_presenter_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Hyrax::PublicationPresenter do
   let(:ability) { Ability.new(build(:user)) }
 
   it_behaves_like 'a Spot presenter'
+  it_behaves_like 'it humanizes date fields', for: %i[date_issued]
 
   context 'identifier handling' do
     let(:raw_ids) { ['issn:1234-5678', 'abc:123'] }

--- a/spec/support/shared_examples/presenters/humanizes_date_fields.rb
+++ b/spec/support/shared_examples/presenters/humanizes_date_fields.rb
@@ -5,7 +5,6 @@ RSpec.shared_examples 'it humanizes date fields' do |opts|
 
   raise 'No fields provided for example' if fields.empty?
 
-
   fields.each do |field|
     describe "for :#{field}" do
       subject { presenter.send(field.to_sym) }

--- a/spec/support/shared_examples/presenters/humanizes_date_fields.rb
+++ b/spec/support/shared_examples/presenters/humanizes_date_fields.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'it humanizes date fields' do |opts|
+  opts ||= {}
+  fields = opts[:for] || []
+
+  raise 'No fields provided for example' if fields.empty?
+
+
+  fields.each do |field|
+    describe "for :#{field}" do
+      subject { presenter.send(field.to_sym) }
+
+      before do
+        allow(presenter.solr_document).to receive(field.to_sym).and_return(original_value)
+      end
+
+      context 'YYYY-MM-DD values' do
+        let(:original_value) { ['2020-09-09'] }
+
+        it { is_expected.to eq ['September 9, 2020'] }
+      end
+
+      context 'YYYx' do
+        let(:original_value) { ['202x'] }
+
+        it { is_expected.to eq ['2020s'] }
+      end
+
+      context 'YYYY/YYYY' do
+        let(:original_value) { ['1986/2020'] }
+
+        it { is_expected.to eq ['1986 to 2020'] }
+      end
+    end
+  end
+end


### PR DESCRIPTION
adds a mixin to pass edtf date values through the `edtf-humanize` gem before displaying

closes #600 