### PR TITLE
oai: replace spaces in setSpec properties

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -280,6 +280,7 @@ class CatalogController < ApplicationController
       },
 
       document: {
+        set_model: Spot::OaiCollectionSolrSet,
         set_fields: [
           { label: 'collection', solr_field: 'member_of_collections_ssim' }
         ]

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -42,6 +42,7 @@ class SolrDocument
   # rubocop:disable Metrics/MethodLength
   def self.field_semantics
     {
+      collection_name: 'member_of_collections_ssim',
       contributor: 'contributor_tesim',
       coverage: 'location_label_ssim',
       creator: 'creator_tesim',

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -61,6 +61,10 @@ class SolrDocument
   end
   # rubocop:enable Metrics/MethodLength
 
+  def sets
+    Spot::OaiCollectionSolrSet.sets_for(self)
+  end
+
   # Overrides +Hyrax::SolrDocumentBehavior#to_param+ by preferring collection slugs
   # (where present).
   #

--- a/app/models/spot/oai_collection_solr_set.rb
+++ b/app/models/spot/oai_collection_solr_set.rb
@@ -1,16 +1,22 @@
 # frozen_string_literal: true
 module Spot
+  # Subclass of +BlacklightOaiProvider::SolrSet+ that translates
+  # spaces to underscores, making the following assumptions:
+  #   a) we'll be using +member_of_collections_ssim+ as our only hook for OAI-PMG ListSets
+  #   b) collection titles will never contain underscores
   class OaiCollectionSolrSet < ::BlacklightOaiProvider::SolrSet
+    # @param [String] spec
+    # @return [String] solr filter for set
     def self.from_spec(spec)
-      new(spec.gsub(/_/, ' ')).solr_filter
+      new(spec.tr('_', ' ')).solr_filter
     end
 
     def initialize(spec)
-      super(spec.gsub(/_/, ' '))
+      super(spec.tr('_', ' '))
     end
 
     def spec
-      "#{@label}:#{@value.gsub(/\s/, '_')}"
+      "#{@label}:#{@value.tr(' ', '_')}"
     end
   end
 end

--- a/app/models/spot/oai_collection_solr_set.rb
+++ b/app/models/spot/oai_collection_solr_set.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module Spot
+  class OaiCollectionSolrSet < ::BlacklightOaiProvider::SolrSet
+    def self.from_spec(spec)
+      new(spec.gsub(/_/, ' ')).solr_filter
+    end
+
+    def initialize(spec)
+      super(spec.gsub(/_/, ' '))
+    end
+
+    def spec
+      "#{@label}:#{@value.gsub(/\s/, '_')}"
+    end
+  end
+end

--- a/spec/models/spot/oai_collection_solr_set_spec.rb
+++ b/spec/models/spot/oai_collection_solr_set_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+RSpec.describe Spot::OaiCollectionSolrSet do
+  before do
+    described_class.fields = fields
+  end
+
+  let(:fields) { [{ label: 'Collection', solr_field: 'member_of_collections_ssim' }] }
+
+  describe '.from_spec' do
+    subject(:solr_filter) { described_class.from_spec(spec) }
+
+    context 'when a spec has underscores in it' do
+      let(:spec) { 'Collection:A_Test_Collection' }
+
+      it 'replaces them with spaces' do
+        expect(solr_filter).to eq 'member_of_collections_ssim:"A Test Collection"'
+      end
+    end
+
+    context 'when a spec has no spaces' do
+      let(:spec) { 'Collection:Photographs' }
+
+      it 'does nothing' do
+        expect(solr_filter).to eq 'member_of_collections_ssim:"Photographs"'
+      end
+    end
+  end
+
+  describe '#initialize' do
+    subject(:solr_set) { described_class.new(spec) }
+
+    let(:spec) { 'Collection:A_Test_Collection' }
+
+    it 'replaces underscores with spaces for the @value property' do
+      expect(solr_set.value).to eq 'A Test Collection'
+    end
+
+    it 'puts the underscores back when calling #spec' do
+      expect(solr_set.spec).to eq spec
+    end
+  end
+end


### PR DESCRIPTION
we're gathering oai-pmh ListSets via the `member_of_collections_ssim` solr property, which consists of collection titles. however, our titles include spaces, which are invalid as setSpecs. this creates a new `SolrSet` which replaces them with underscores (and puts them back for solr).