### PR TITLE
flatten tifs to create access derivatives

### DIFF
--- a/app/services/spot/derivatives/access_master_service.rb
+++ b/app/services/spot/derivatives/access_master_service.rb
@@ -21,10 +21,10 @@ module Spot
       # @return [void]
       def create_derivatives(filename)
         MiniMagick::Tool::Convert.new do |magick|
-          magick << "#{filename}[0]"
+          magick << "#{filename}"
           # note: we need to use an array for each piece of this command;
           # using a string will cause an error
-          magick.merge! %w[-define tiff:tile-geometry=128x128 -compress jpeg]
+          magick.merge! %w[-define tiff:tile-geometry=128x128 -compress jpeg +swap -flatten]
           magick << "ptif:#{derivative_path}"
         end
       end

--- a/spec/services/spot/derivatives/access_master_service_spec.rb
+++ b/spec/services/spot/derivatives/access_master_service_spec.rb
@@ -40,9 +40,10 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
 
     let(:expected_commands) do
       [
-        '/path/to/file.jpg[0]',
+        '/path/to/file.jpg',
         '-define', 'tiff:tile-geometry=128x128',
         '-compress', 'jpeg',
+        '+swap', '-flatten',
         'ptif:/path/to/a/fs-access.tif'
       ]
     end


### PR DESCRIPTION
still a wip until i can confirm that this works for image formats other than tiff (or just add a check before flattening), but this should help keep our access-derivative tif sizes under control

closes #632 