### PR TITLE
update robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,6 +5,7 @@ Disallow: /concern
 
 # Prevent indexers from crawling every facet/search option
 User-agent: *
+Disallow: /bookmarks/*
 Disallow: /catalog
 Disallow: /catalog/*
 Disallow: /downloads

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,14 +3,17 @@
 User-agent: archive.org_bot
 Disallow: /concern
 
-# Prevent indexers from crawling every facet/search option
+# Things we don't need to be crawled
 User-agent: *
 Disallow: /bookmarks/*
 Disallow: /catalog
 Disallow: /catalog/*
+Disallow: /dashboard
+Disallow: /dashboard/*
 Disallow: /downloads
 Disallow: /downloads/*
 Disallow: /export/*
+Disallow: /iiif/*
 Disallow: /redirect/*
 
 # Legacy DSpace paths we no longer support

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,13 +2,15 @@
 # repository items, which will be too much data for our budget.
 User-agent: archive.org_bot
 Disallow: /concern
-Disallow: /downloads
 
 # Prevent indexers from crawling every facet/search option
 User-agent: *
 Disallow: /catalog
 Disallow: /catalog/*
 Disallow: /downloads
+Disallow: /downloads/*
+Disallow: /export/*
+Disallow: /redirect/*
 
 # Legacy DSpace paths we no longer support
 Disallow: /bitstream


### PR DESCRIPTION
adds rules for `/bookmarks/*`, `/export/*` and `/redirect/*`

closes #570 