### PR TITLE
hide blacklight's bookmark feature

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,13 +60,15 @@ Rails.application.routes.draw do
     concerns :exportable
   end
 
-  resources :bookmarks do
-    concerns :exportable
+  # hiding blacklight's bookmark feature for now, but keeping the option available for down the road
+  #
+  # resources :bookmarks do
+  #   concerns :exportable
 
-    collection do
-      delete 'clear'
-    end
-  end
+  #   collection do
+  #     delete 'clear'
+  #   end
+  # end
 
   scope module: 'spot' do
     # adding administrative pages to the site. we'll keep them under


### PR DESCRIPTION
removes the routes for blacklight's bookmarks, as we don't use them + a url_helper was causing 500 errors out the wazoo (sorry honeybadger!)