### PR TITLE
explicitly include favicon

### DIFF
--- a/app/views/_head_tag_extras.html.erb
+++ b/app/views/_head_tag_extras.html.erb
@@ -1,0 +1,2 @@
+<%# overridden from hyrax, which allows us to insert tags in the <head> %>
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />


### PR DESCRIPTION
adds a `<link>` tag for favicon, which i can't believe wasn't there to begin with