### PR TITLE
more docker updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 !/log/.keep
 /tmp/*
 !/tmp/.keep
+/spec/*
 /coverage
 .byebug_history
 fits.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     env_file: .env
     restart: always
     entrypoint: ["bin/spot-dev-entrypoint.sh"]
-    command: ["bundle", "exec", "puma", "-v", "-b", "tcp://0.0.0.0:3000"]
+    command: ["bundle", "exec", "rails", "s", "-p", "3000", "-b", "0.0.0.0"]
     depends_on:
       - cantaloupe
       - db


### PR DESCRIPTION
- ignore spec files when creating docker container
- use `bundle exec rails s` as docker-compose start command (rather than puma) so we can `docker attach spot_app_1` for debugging