### PR TITLE
ensure bookmark toggles aren't displayed on any controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,6 +35,16 @@ class ApplicationController < ActionController::Base
     @guest_user ||= User.where(guest: true).first || super
   end
 
+  # Method used by Blacklight to determine whether a bookmarks toggle should be rendered.
+  # This is previously just in CatalogController, but moved to this parent controller to
+  # ensure that any future controllers which inherit configs (but not methods) from CatalogController
+  # also know to not display bookmarks.
+  #
+  # @return false
+  def render_bookmarks_control?
+    false
+  end
+
   private
 
     # Modified from its source in +Hyrax::Controller+ in that we're

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -287,11 +287,4 @@ class CatalogController < ApplicationController
       }
     }
   end
-
-  # disable the bookmark control from displaying in gallery view
-  # Hyrax doesn't show any of the default controls on the list view, so
-  # this method is not called in that context.
-  def render_bookmarks_control?
-    false
-  end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -5,4 +5,10 @@ RSpec.describe ApplicationController do
 
     it { is_expected.not_to include :locale }
   end
+
+  describe '#render_bookmarks_control?' do
+    subject { described_class.new.render_bookmarks_control? }
+
+    it { is_expected.to be false }
+  end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe CatalogController, clean: true do
-  # tryna get that coverage percentage up
-  describe '#render_bookmarks_control?' do
-    subject { described_class.new.render_bookmarks_control? }
-
-    it { is_expected.to be false }
-  end
-
   describe '#index' do
     before do
       objects.each { |obj| ActiveFedora::SolrService.add(obj) }


### PR DESCRIPTION
moves `render_bookmarks_control?` to `ApplicationController` to ensure that any controller that may call the method will not render the Blacklight bookmarks toggle (which we don't currently support).

fixes a bug where toggling Gallery View on a collection's browse view would raise an exception 