### PR TITLE
2021.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # changelog
 
+## [2021.2] - 2021-01-21
+
+### bug fixes 🐞 
+- ensure bookmark toggles aren't displayed on _any_ controller (#670)
+- point CollectionPresenter to the correct related_resource key (#674)
+- add link to LDR submission form on about page (#679)
+- add partials for Publication and Image json responses (fixes a "stack level too deep" error that would pop up) (#680)
+
+### features 🧑‍🏭 
+- split common work-model behavior into `Spot::CoreMetadata` and `Spot::WorkBehavior` mixins (#676)
+- catalog_controller updates (#677)
+  - facet limit defined globally (rather than per-facet)
+  - added OCM Classification facet to sidebar
+  - fixed field keys for #index views 
+  - humanize edtf date values 
+
+
 ## [2021.1] - 2021-01-04
 
 ### bug fixes 🐞 
@@ -543,6 +560,7 @@ fixes:
 
 Initial pre-release (live on ldr.stage.lafayette.edu)
 
+[2021.2]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2021.2
 [2021.1]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2021.1
 [2020.13]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2020.13
 [2020.12]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2020.12

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,6 +35,16 @@ class ApplicationController < ActionController::Base
     @guest_user ||= User.where(guest: true).first || super
   end
 
+  # Method used by Blacklight to determine whether a bookmarks toggle should be rendered.
+  # This is previously just in CatalogController, but moved to this parent controller to
+  # ensure that any future controllers which inherit configs (but not methods) from CatalogController
+  # also know to not display bookmarks.
+  #
+  # @return false
+  def render_bookmarks_control?
+    false
+  end
+
   private
 
     # Modified from its source in +Hyrax::Controller+ in that we're

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -41,6 +41,9 @@ class CatalogController < ApplicationController
       'hl.snippets': 5
     }
 
+    # save ourselves the hassle of passing this for every facet definition
+    config.default_facet_limit = 5
+
     # solr field configuration for document/show views
     config.index.title_field = 'title_tesim'
     config.index.display_type_field = 'has_model_ssim'
@@ -60,85 +63,48 @@ class CatalogController < ApplicationController
     #        @example
     #          config.add_index_field('keyword_ssim', label: :'blacklight.search.fields.keyword')
 
-    # config.add_facet_field 'human_readable_type_sim', label: "Type", limit: 5
-    config.add_facet_field 'member_of_collections_ssim',
-                           label: :'blacklight.search.fields.member_of_collection',
-                           limit: 5
-    config.add_facet_field 'resource_type_sim',
-                           label: :'blacklight.search.fields.resource_type',
-                           limit: 5
-    config.add_facet_field 'creator_sim',
-                           label: :'blacklight.search.fields.creator',
-                           limit: 5
-    config.add_facet_field 'publisher_sim',
-                           label: :'blacklight.search.fields.publisher',
-                           limit: 5
-    config.add_facet_field 'organization_sim',
-                           label: :'blacklight.search.fields.organization',
-                           limit: 5
-    config.add_facet_field 'division_sim',
-                           label: :'blacklight.search.fields.division',
-                           limit: 5
-    config.add_facet_field 'academic_department_sim',
-                           label: :'blacklight.search.fields.academic_department',
-                           limit: 5
-    config.add_facet_field 'subject_label_ssim',
-                           label: :'blacklight.search.fields.subject',
-                           limit: 5
-    config.add_facet_field 'keyword_sim',
-                           label: :'blacklight.search.fields.keyword',
-                           limit: 5
-    config.add_facet_field 'language_label_ssim',
-                           label: :'blacklight.search.fields.language',
-                           limit: 5
-    config.add_facet_field 'location_label_ssim',
-                           label: :'blacklight.search.fields.location',
-                           limit: 5
+    config.add_facet_field 'member_of_collections_ssim', label: :'blacklight.search.fields.member_of_collection'
+    config.add_facet_field 'resource_type_sim',          label: :'blacklight.search.fields.resource_type'
+    config.add_facet_field 'creator_sim',                label: :'blacklight.search.fields.creator'
+    config.add_facet_field 'publisher_sim',              label: :'blacklight.search.fields.publisher'
+    config.add_facet_field 'organization_sim',           label: :'blacklight.search.fields.organization'
+    config.add_facet_field 'division_sim',               label: :'blacklight.search.fields.division'
+    config.add_facet_field 'academic_department_sim',    label: :'blacklight.search.fields.academic_department'
+    config.add_facet_field 'subject_label_ssim',         label: :'blacklight.search.fields.subject'
+    config.add_facet_field 'keyword_sim',                label: :'blacklight.search.fields.keyword'
+    config.add_facet_field 'language_label_ssim',        label: :'blacklight.search.fields.language'
+    config.add_facet_field 'location_label_ssim',        label: :'blacklight.search.fields.location'
     config.add_facet_field 'years_encompassed_iim',
                            include_in_advanced_search: false,
                            label: :'blacklight.search.fields.years_encompassed',
                            range: true
-    config.add_facet_field 'rights_statement_shortcode_ssim',
-                           label: :'blacklight.search.fields.rights_statement',
-                           limit: 5
+    config.add_facet_field 'rights_statement_shortcode_ssim', label: :'blacklight.search.fields.rights_statement'
+    config.add_facet_field 'subject_ocm_ssim', label: :'blacklight.search.facets.subject_ocm'
 
     #
     # admin facets
     #
     config.add_facet_field 'visibility_ssi',
                            label: :'blacklight.search.fields.visibility',
-                           limit: 5,
-                           admin: true,
-                           helper_method: :render_catalog_visibility_facet
-    config.add_facet_field 'depositor_ssim',
-                           label: :'blacklight.search.fields.depositor',
-                           limit: 5,
+                           helper_method: :render_catalog_visibility_facet,
                            admin: true
-    config.add_facet_field 'proxy_depositor_ssim',
-                           label: :'blacklight.search.fields.proxy_depositor',
-                           limit: 5,
-                           admin: true
-    config.add_facet_field 'admin_set_sim',
-                           label: :'blacklight.search.fields.admin_set',
-                           limit: 5,
-                           admin: true
+    config.add_facet_field 'depositor_ssim', label: :'blacklight.search.fields.depositor', admin: true
+    config.add_facet_field 'proxy_depositor_ssim', label: :'blacklight.search.fields.proxy_depositor', admin: true
+    config.add_facet_field 'admin_set_sim', label: :'blacklight.search.fields.admin_set', admin: true
 
     # The generic_type isn't displayed on the facet list
     # It's used to give a label to the filter that comes from the user profile
     config.add_facet_field 'generic_type_sim', if: false
 
     # see also: has_model_ssim for the 'View collections' link
-    config.add_facet_field 'has_model_ssim',
-                           label: :'blacklight.search.fields.has_model',
-                           if: false
+    config.add_facet_field 'has_model_ssim', label: :'blacklight.search.fields.has_model', if: false
 
     # Facets from the Work-level that aren't provided in the catalog
-    config.add_facet_field 'subject_ocm_ssim',
-                           label: :'blacklight.search.facets.subject_ocm',
-                           if: false
-    config.add_facet_field 'research_assistance_ssim',
-                           label: :'blacklight.search.facets.research_assistance',
-                           if: false
+    config.add_facet_field 'research_assistance_ssim', label: :'blacklight.search.facets.research_assistance', if: false
+
+    # Blacklight will default a facet's limit to the +blacklight_config.default_facet_limit+ value
+    # only if the field config +:limit+ entry is true. This does that.
+    config.facet_fields.each { |(_key, val)| val[:limit] = true }
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -150,10 +116,10 @@ class CatalogController < ApplicationController
     config.add_index_field 'title_tesim',
                            itemprop: 'name',
                            if: false
-    config.add_index_field 'resource_type_ssim',
+    config.add_index_field 'resource_type_tesim',
                            itemprop: 'resourceType',
                            label: :'blacklight.search.fields.resource_type',
-                           link_to_search: 'resource_type_ssim'
+                           link_to_search: 'resource_type_sim'
     config.add_index_field 'academic_department_tesim',
                            itemprop: 'department',
                            label: :'blacklight.search.fields.academic_department',
@@ -162,7 +128,7 @@ class CatalogController < ApplicationController
                            itemprop: 'keywords',
                            label: :'blacklight.search.fields.keyword',
                            link_to_search: 'keyword_sim'
-    config.add_index_field 'subject_tesim',
+    config.add_index_field 'subject_label_ssim',
                            itemprop: 'about',
                            label: :'blacklight.search.fields.subject',
                            link_to_search: 'subject_sim'
@@ -170,10 +136,6 @@ class CatalogController < ApplicationController
                            itemprop: 'creator',
                            label: :'blacklight.search.fields.creator',
                            link_to_search: 'creator_sim'
-    config.add_index_field 'contributor_tesim',
-                           itemprop: 'contributor',
-                           label: :'blacklight.search.fields.contributor',
-                           link_to_search: 'contributor_sim'
     config.add_index_field 'publisher_tesim',
                            itemprop: 'publisher',
                            label: :'blacklight.search.fields.publisher',
@@ -183,7 +145,11 @@ class CatalogController < ApplicationController
                            label: :'blacklight.search.fields.language',
                            link_to_search: 'language_sim'
     config.add_index_field 'date_issued_ssim',
-                           label: :'blacklight.search.fields.date_issued'
+                           label: :'blacklight.search.fields.date_issued',
+                           helper_method: :humanize_edtf_values
+    config.add_index_field 'date_ssim',
+                           label: :'blacklight.search.fields.date',
+                           helper_method: :humanize_edtf_values
     config.add_index_field 'rights_statement_tesim',
                            helper_method: :rights_statement_links,
                            label: :'blacklight.search.fields.rights_statement'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -287,11 +287,4 @@ class CatalogController < ApplicationController
       }
     }
   end
-
-  # disable the bookmark control from displaying in gallery view
-  # Hyrax doesn't show any of the default controls on the list view, so
-  # this method is not called in that context.
-  def render_bookmarks_control?
-    false
-  end
 end

--- a/app/helpers/spot/catalog_helper.rb
+++ b/app/helpers/spot/catalog_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Spot
+  module CatalogHelper
+    # Used in CatalogController to humanize date values on catalog#index results displays.
+    # Falls back to the original value.
+    #
+    # @return [String]
+    def humanize_edtf_values(args)
+      Array.wrap(args[:value]).map { |val| humanize_edtf_value(val) }.to_sentence
+    end
+
+    def humanize_edtf_value(value)
+      Date.edtf(value).humanize
+    rescue
+      value
+    end
+  end
+end

--- a/app/helpers/spot/json_helper.rb
+++ b/app/helpers/spot/json_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module Spot
+  # Helper methods intended to be used within jbuilder settings
+  module JsonHelper
+    # Converts an array (or array-like thing that responds to +:to_a+) of
+    # ControlledVocabulary objects into URIs
+    #
+    # @param [Array<String>, #to_a] raw_values
+    # @return [Array<String>]
+    def map_uris(raw_values)
+      raw_values = raw_values.to_a if raw_values.respond_to?(:to_a)
+
+      Array.wrap(raw_values).map do |raw|
+        uri = raw.respond_to?(:rdf_subject) ? raw.send(:rdf_subject) : raw
+        uri.to_s
+      end
+    end
+  end
+end

--- a/app/models/concerns/spot/core_metadata.rb
+++ b/app/models/concerns/spot/core_metadata.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+module Spot
+  # Mixin to provide common metadata fields for our work types
+  #
+  # @example
+  #   class WorkType < ActiveFedora::Base
+  #     include ::Hyrax::WorkBehavior
+  #     include ::Spot::NoidIdentifier
+  #     include ::Spot::CoreMetadata
+  #   end
+  module CoreMetadata
+    extend ActiveSupport::Concern
+
+    # rubocop:disable Metrics/BlockLength
+    included do
+      # Free text, use authorized version if possible.
+      #
+      # @todo metadata application profile has this as non-faceted, remove :facetable ?
+      property :contributor, predicate: ::RDF::Vocab::DC11.contributor do |index|
+        index.as :stored_searchable, :facetable
+      end
+
+      # Free text, use authorized version if possible.
+      #
+      # @todo metadata application profile has this as non-faceted, remove :facetable ?
+      property :creator, predicate: ::RDF::Vocab::DC11.creator do |index|
+        index.as :stored_searchable, :facetable
+      end
+
+      # Free text description of the resource.
+      property :description, predicate: ::RDF::Vocab::DC11.description do |index|
+        index.as :stored_searchable
+      end
+
+      # Both standard and local identifiers. Values should have an prefix declaring the source.
+      # @see {Spot::Identifier}
+      property :identifier, predicate: ::RDF::Vocab::DC.identifier do |index|
+        index.as :symbol
+      end
+
+      # Free text keywords describing the resource.
+      property :keyword, predicate: ::RDF::Vocab::SCHEMA.keywords do |index|
+        index.as :stored_searchable, :facetable
+      end
+
+      # ISO 639-1 codes of the language(s). See {IndexesLanguageAndLabel} mixin for indexing
+      property :language, predicate: ::RDF::Vocab::DC11.language
+
+      # Geonames or Getty TGN URI, displayed as human- readable prefLabel.
+      # @see {Spot::DeepIndexingService} for label indexing details
+      property :location, predicate: ::RDF::Vocab::DC.spatial,
+                          class_name: Spot::ControlledVocabularies::Location do |index|
+        index.as :symbol
+      end
+
+      # Information relevant to internal maintenance of records or the original items, such as
+      # administrative, digitization hardware/software, or decision documentation.
+      #
+      # Intended for Admin-only display
+      property :note, predicate: ::RDF::Vocab::SKOS.note do |index|
+        index.as :stored_searchable
+      end
+
+      # A physical material or carrier. Examples include paper, canvas, or DVD.
+      property :physical_medium, predicate: ::RDF::Vocab::DC.PhysicalMedium do |index|
+        index.as :stored_searchable, :facetable
+      end
+
+      # Free text, use authorized version if possible.
+      property :publisher, predicate: ::RDF::Vocab::DC11.publisher do |index|
+        index.as :stored_searchable, :facetable
+      end
+
+      # Include a unique identifier (such as a DOI or ISBN) and a permalink URI if one exists.
+      #
+      # @todo metadata application profile has this as non-faceted, remove :facetable ?
+      property :related_resource, predicate: ::RDF::RDFS.seeAlso do |index|
+        index.as :stored_searchable, :facetable
+      end
+
+      # The nature or genre of the resource, e.g. periodical, image.
+      # Select one or more from local controlled list.
+      property :resource_type, predicate: ::RDF::Vocab::DC.type do |index|
+        index.as :stored_searchable, :facetable
+      end
+
+      # Free text name of the person or organization who holds rights over the resource. Use authorized version if possible.
+      property :rights_holder, predicate: ::RDF::Vocab::DC.rightsHolder do |index|
+        index.as :stored_searchable, :facetable
+      end
+
+      # URI rights statement, from a local list.
+      #
+      # @see {IndexesRightsStatements} for indexing details
+      # @note values found at {APP_ROOT}/config/authorities/rights_statements.yml
+      property :rights_statement, predicate: ::RDF::Vocab::EDM.rights
+
+      # A related resource from which the described resource is derived. Use string
+      # conforming to a formal identification system, such as a DOI, permalink URI, ISBN,
+      # ISSN, or OCLC Number.
+      #
+      # @todo metadata application profile has this as non-faceted, remove :facetable ?
+      property :source, predicate: ::RDF::Vocab::DC.source do |index|
+        index.as :stored_searchable, :facetable
+      end
+
+      # Stored as OCLC FAST URI, displayed as human-readable prefLabel.
+      # @see {Spot::DeepIndexingService} for label indexing details
+      property :subject, predicate: ::RDF::Vocab::DC11.subject,
+                         class_name: Spot::ControlledVocabularies::Base do |index|
+        index.as :symbol
+      end
+
+      # Ancillary title information for the resource. A main title is required before subtitle(s) may be used.
+      property :subtitle, predicate: ::RDF::URI.new('http://purl.org/spar/doco/Subtitle') do |index|
+        index.as :stored_searchable
+      end
+
+      # Other forms of the title, e.g. for versions of the title in languages other than English.
+      property :title_alternative, predicate: ::RDF::Vocab::DC.alternative do |index|
+        index.as :stored_searchable
+      end
+    end
+    # rubocop:enable Metrics/BlockLength
+  end
+end

--- a/app/models/concerns/spot/work_behavior.rb
+++ b/app/models/concerns/spot/work_behavior.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+module Spot
+  # Mixin to provide core work-model behavior
+  module WorkBehavior
+    extend ActiveSupport::Concern
+
+    include ::Hyrax::WorkBehavior
+    include NoidIdentifier
+    include CoreMetadata
+
+    included do
+      # The `controlled_properties` attribute is used by the Hyrax::DeepIndexingService,
+      # which is used to fetch RDF labels for indexing. This is implemented in
+      # Hyrax::BasicMetadata, but since we're implementing our basic metadata fields
+      # outside of that mixin, we'll need to define this manually.
+
+      # @!attribute [rw] controlled_properties
+      #   @return [Array<Symbol>]
+      class_attribute :controlled_properties
+      self.controlled_properties = [:location, :subject]
+
+      # validations for CoreMetadata fields. it should be safe to include these here
+      # rather than at the individual model level
+      validates :title, presence: { message: 'Your work must include a Title.' }
+      validates :resource_type, presence: { message: 'Your work must include a Resource Type.' }
+      validates :rights_statement, presence: { message: 'Your work must include a Rights Statement.' }
+
+      validates_with ::Spot::RequiredLocalAuthorityValidator,
+                     field: :resource_type, authority: 'resource_types'
+      validates_with ::Spot::RequiredLocalAuthorityValidator,
+                     field: :rights_statement, authority: 'rights_statements'
+    end
+
+    module ClassMethods
+      # Intended to be called at the end of your model to setup +accepts_nested_attributes_for+
+      # for your controlled properties. Uses the +controlled_properties+ attribute.
+      #
+      # @note from Hyrax::BasicMetadata mixin:
+      #   This must be mixed after all other properties are defined because no other
+      #   properties will be defined once accepts_nested_attributes_for is called
+      # @return true
+      def setup_nested_attributes!
+        id_blank = proc { |attributes| attributes[:id].blank? }
+
+        controlled_properties.each do |property|
+          accepts_nested_attributes_for property, reject_if: id_blank, allow_destroy: true
+        end
+
+        true
+      end
+    end
+  end
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,71 +1,18 @@
 # frozen_string_literal: true
 #
-# Images are digital representations of physical objects
-# obtained by scanning or photographing the object.
+# Images are digital representations of physical objects obtained by scanning or photographing the object.
 class Image < ActiveFedora::Base
-  include ::Hyrax::WorkBehavior
-  include ::Spot::NoidIdentifier
-
-  class_attribute :controlled_properties
-  self.controlled_properties = [:location, :subject]
+  include Spot::WorkBehavior
 
   self.indexer = ImageIndexer
 
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
 
-  validates :title, presence: { message: 'Your work must include a Title.' }
-  validates :resource_type, presence: { message: 'Your work must include a Resource Type.' }
-  validates :rights_statement, presence: { message: 'Your work must include a Rights Statement.' }
-
-  validates_with ::Spot::RequiredLocalAuthorityValidator,
-                 field: :resource_type, authority: 'resource_types'
-  validates_with ::Spot::RequiredLocalAuthorityValidator,
-                 field: :rights_statement, authority: 'rights_statements'
-
-  # title is included with ::ActiveFedora::Base
-  property :subtitle, predicate: ::RDF::URI.new('http://purl.org/spar/doco/Subtitle') do |index|
-    index.as :stored_searchable
-  end
-
-  property :title_alternative, predicate: ::RDF::Vocab::DC.alternative do |index|
-    index.as :stored_searchable
-  end
-
-  property :publisher, predicate: ::RDF::Vocab::DC11.publisher do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :repository_location, predicate: ::RDF::URI.new('http://purl.org/vra/placeOfRepository') do |index|
-    index.as :symbol
-  end
-
-  property :source, predicate: ::RDF::Vocab::DC.source do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :resource_type, predicate: ::RDF::Vocab::DC.type do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :physical_medium, predicate: ::RDF::Vocab::DC.PhysicalMedium do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :original_item_extent, predicate: ::RDF::Vocab::DC.extent do |index|
-    index.as :stored_searchable
-  end
-
-  # see {IndexesLanguageAndLabel} mixin for indexing
-  property :language, predicate: ::RDF::Vocab::DC11.language
-
-  property :description, predicate: ::RDF::Vocab::DC11.description do |index|
-    index.as :stored_searchable
-  end
-
-  property :inscription, predicate: ::RDF::URI.new('http://dbpedia.org/ontology/inscription') do |index|
-    index.as :stored_searchable
-  end
+  # if adding controlled fields (other than :location and :subject), uncomment this
+  # and add the fields to the +controlled_properties+ array
+  #
+  # self.controlled_properties += []
 
   # date indexing is covered in ImageIndexer
   property :date, predicate: ::RDF::Vocab::DC.date do |index|
@@ -81,42 +28,19 @@ class Image < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :creator, predicate: ::RDF::Vocab::DC11.creator do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :contributor, predicate: ::RDF::Vocab::DC11.contributor do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :related_resource, predicate: ::RDF::RDFS.seeAlso do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :subject, predicate: ::RDF::Vocab::DC11.subject,
-                     class_name: Spot::ControlledVocabularies::Base do |index|
+  property :donor, predicate: ::RDF::Vocab::DC.provenance do |index|
     index.as :symbol
   end
 
-  # @note The URI provided is the landing page for the OCM, as a predicate doesn't exist
-  property :subject_ocm, predicate: ::RDF::URI('https://hraf.yale.edu/resources/reference/outline-of-cultural-materials') do |index|
-    index.as :symbol
+  property :inscription, predicate: ::RDF::URI.new('http://dbpedia.org/ontology/inscription') do |index|
+    index.as :stored_searchable
   end
 
-  property :keyword, predicate: ::RDF::Vocab::SCHEMA.keywords do |index|
-    index.as :stored_searchable, :facetable
+  property :original_item_extent, predicate: ::RDF::Vocab::DC.extent do |index|
+    index.as :stored_searchable
   end
 
-  property :location, predicate: ::RDF::Vocab::DC.spatial,
-                      class_name: Spot::ControlledVocabularies::Location do |index|
-    index.as :symbol
-  end
-
-  # rights_statements are stored as URIs
-  property :rights_statement, predicate: ::RDF::Vocab::EDM.rights
-  property :rights_holder, predicate: ::RDF::Vocab::DC.rightsHolder
-
-  property :identifier, predicate: ::RDF::Vocab::DC.identifier do |index|
+  property :repository_location, predicate: ::RDF::URI.new('http://purl.org/vra/placeOfRepository') do |index|
     index.as :symbol
   end
 
@@ -128,23 +52,11 @@ class Image < ActiveFedora::Base
     index.as :symbol
   end
 
-  property :donor, predicate: ::RDF::Vocab::DC.provenance do |index|
+  # @note The URI provided is the landing page for the OCM, as a predicate doesn't exist
+  property :subject_ocm, predicate: ::RDF::URI('https://hraf.yale.edu/resources/reference/outline-of-cultural-materials') do |index|
     index.as :symbol
   end
 
-  property :note, predicate: ::RDF::Vocab::SKOS.note do |index|
-    index.as :stored_searchable
-  end
-
-  # accepts_nested_attributes_for needs to be defined at the end of the model.
-  # see note from Hyrax::BasicMetadata mixin:
-  #
-  #   This must be mixed after all other properties are defined because no other
-  #   properties will be defined once accepts_nested_attributes_for is called
-
-  id_blank = proc { |attributes| attributes[:id].blank? }
-
-  controlled_properties.each do |property|
-    accepts_nested_attributes_for property, reject_if: id_blank, allow_destroy: true
-  end
+  # see {Spot::WorkBehavior.setup_nested_attributes!}
+  setup_nested_attributes!
 end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -1,77 +1,26 @@
 # frozen_string_literal: true
 class Publication < ActiveFedora::Base
-  include ::Hyrax::WorkBehavior
-  include ::Spot::NoidIdentifier
+  include Spot::WorkBehavior
 
-  # The `controlled_properties` attribute is used by the Hyrax::DeepIndexingService,
-  # which is used to fetch RDF labels for indexing. This is used out-of-the-box
-  # for :place (which, I believe, uses GeoNames), but could be used for,
-  # say, LCSH headings in other models, if not this one. This is implemented in
-  # Hyrax::BasicMetadata, but since we're implementing our basic metadata fields
-  # outside of that mixin, we'll need to define this manually.
+  # if adding controlled fields (other than :location and :subject), uncomment this
+  # and add the fields to the +controlled_properties+ array
   #
-  # (You'll probably also need to switch on `accepts_nested_attributes` below)
-
-  class_attribute :controlled_properties
-  self.controlled_properties = [:location, :subject]
+  # self.controlled_properties += []
 
   self.indexer = PublicationIndexer
 
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
 
-  validates :title, presence: { message: 'Your work must include a Title.' }
-  validates :resource_type, presence: { message: 'Your work must include a Resource Type.' }
-  validates :rights_statement, presence: { message: 'Your work must include a Rights Statement.' }
-
-  validates_with ::Spot::DateIssuedValidator
-  validates_with ::Spot::RequiredLocalAuthorityValidator,
-                 field: :resource_type, authority: 'resource_types'
-  validates_with ::Spot::RequiredLocalAuthorityValidator,
-                 field: :rights_statement, authority: 'rights_statements'
-
-  # title is included with ::ActiveFedora::Base
-  property :subtitle, predicate: ::RDF::URI.new('http://purl.org/spar/doco/Subtitle') do |index|
-    index.as :stored_searchable
-  end
-
-  property :title_alternative, predicate: ::RDF::Vocab::DC.alternative do |index|
-    index.as :stored_searchable
-  end
-
-  property :publisher, predicate: ::RDF::Vocab::DC11.publisher do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :source, predicate: ::RDF::Vocab::DC.source do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :resource_type, predicate: ::RDF::Vocab::DC.type do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :physical_medium, predicate: ::RDF::Vocab::DC.PhysicalMedium do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  # see {IndexesLanguageAndLabel} mixin for indexing
-  property :language, predicate: ::RDF::Vocab::DC11.language
+  # additional validation
+  validates_with Spot::DateIssuedValidator
 
   property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
     index.as :stored_searchable
   end
 
-  property :description, predicate: ::RDF::Vocab::DC11.description do |index|
-    index.as :stored_searchable
-  end
-
-  property :note, predicate: ::RDF::Vocab::SKOS.note do |index|
-    index.as :stored_searchable
-  end
-
-  property :identifier, predicate: ::RDF::Vocab::DC.identifier do |index|
-    index.as :symbol
+  property :academic_department, predicate: ::RDF::URI.new('http://vivoweb.org/ontology/core#AcademicDepartment') do |index|
+    index.as :stored_searchable, :facetable
   end
 
   property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation do |index|
@@ -86,65 +35,19 @@ class Publication < ActiveFedora::Base
     index.as :symbol
   end
 
-  property :creator, predicate: ::RDF::Vocab::DC11.creator do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :contributor, predicate: ::RDF::Vocab::DC11.contributor do |index|
+  property :division, predicate: ::RDF::URI.new('http://vivoweb.org/ontology/core#Division') do |index|
     index.as :stored_searchable, :facetable
   end
 
   property :editor, predicate: ::RDF::Vocab::BIBO.editor do |index|
     index.as :stored_searchable, :facetable
   end
-
-  property :academic_department, predicate: ::RDF::URI.new('http://vivoweb.org/ontology/core#AcademicDepartment') do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :division, predicate: ::RDF::URI.new('http://vivoweb.org/ontology/core#Division') do |index|
-    index.as :stored_searchable, :facetable
-  end
+  property :license, predicate: ::RDF::Vocab::DC.license
 
   property :organization, predicate: ::RDF::URI.new('http://vivoweb.org/ontology/core#Organization') do |index|
     index.as :stored_searchable, :facetable
   end
 
-  property :related_resource, predicate: ::RDF::RDFS.seeAlso do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :subject, predicate: ::RDF::Vocab::DC11.subject,
-                     class_name: Spot::ControlledVocabularies::Base do |index|
-    index.as :symbol
-  end
-
-  property :keyword, predicate: ::RDF::Vocab::SCHEMA.keywords do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :location, predicate: ::RDF::Vocab::DC.spatial,
-                      class_name: Spot::ControlledVocabularies::Location do |index|
-    index.as :symbol
-  end
-
-  property :license, predicate: ::RDF::Vocab::DC.license
-
-  # rights_statements are stored as URIs. indexing is done via {IndexesRightsStatements} mixin
-  property :rights_statement, predicate: ::RDF::Vocab::EDM.rights
-
-  property :rights_holder, predicate: ::RDF::Vocab::DC.rightsHolder do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  # accepts_nested_attributes_for needs to be defined at the end of the model.
-  # see note from Hyrax::BasicMetadata mixin:
-  #
-  #   This must be mixed after all other properties are defined because no other
-  #   properties will be defined once accepts_nested_attributes_for is called
-  id_blank = proc { |attributes| attributes[:id].blank? }
-
-  controlled_properties.each do |prop|
-    accepts_nested_attributes_for prop, reject_if: id_blank, allow_destroy: true
-  end
+  # see {Spot::WorkBehavior.setup_nested_attributes!}
+  setup_nested_attributes!
 end

--- a/app/presenters/spot/collection_presenter.rb
+++ b/app/presenters/spot/collection_presenter.rb
@@ -6,7 +6,7 @@ module Spot
     include ActionView::Helpers::AssetUrlHelper
     include PresentsAttributes
 
-    delegate :abstract, :permalink, :related_resource, to: :solr_document
+    delegate :abstract, :permalink, to: :solr_document
 
     # Presenter fields displayed on the #show sidebar (on the right).
     # Modify this to change what's displayed + the order.
@@ -47,6 +47,15 @@ module Spot
     # @return [true, false]
     def public?
       solr_document.visibility == ::Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    # SolrDocument#related_resource maps to +related_resource_tesim+, since Publication and Image both
+    # index the field as +:stored_searchable, :facetable+. We store links in Collection#related_resource
+    # and index them as +:symbol+ (aka '*_ssim'), so we need to point there instead.
+    #
+    # @return [Array<String>]
+    def related_resource
+      solr_document.fetch('related_resource_ssim', [])
     end
 
     # @return [true,false]

--- a/app/views/hyrax/collections/_collection_description.html.erb
+++ b/app/views/hyrax/collections/_collection_description.html.erb
@@ -7,5 +7,6 @@
 <% end %>
 
 <% unless presenter.related_resource.empty? %>
+  <hr />
   <p><%= render_related_resource_language(presenter) %></p>
 <% end %>

--- a/app/views/hyrax/images/show.json.jbuilder
+++ b/app/views/hyrax/images/show.json.jbuilder
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+#
+# Jbuilder template for rendering Image works as JSON. The out-of-the-box template
+# from hyrax (see <hyrax-root>/app/views/hyrax/base/show.json.jbuilder) will generate a
+# stack depth error for some reason (the logs aren't very helpful) that seems to be related
+# to fields with non-standard values (namely wrapped URIs). So our current solution is to
+# explicitly declare what fields are returned.
+#
+# @todo are :note, :donor, and :requested_by admin only?
+json.id(@curation_concern.id)
+
+# titles
+json.title(@curation_concern.title.map(&:to_s))
+json.title_alternative(@curation_concern.title_alternative.map(&:to_s))
+json.subtitle(@curation_concern.subtitle.map(&:to_s))
+
+# creators
+json.extract!(@curation_concern, :creator, :contributor, :publisher)
+
+# descriptive text
+json.resource_type(@curation_concern.resource_type)
+json.description(@curation_concern.description.map(&:to_s))
+json.inscription(@curation_concern.inscription.map(&:to_s))
+
+# subjects, locations, identifiers
+json.subject(map_uris(@curation_concern.subject))
+json.keyword(@curation_concern.keyword)
+json.location(map_uris(@curation_concern.location))
+json.extract!(@curation_concern, :identifier, :source, :language)
+json.ocm_classification(@curation_concern.subject_ocm.sort)
+
+# dates
+json.extract!(@curation_concern, :date, :date_scope_note, :date_associated, :date_uploaded, :date_modified)
+
+# more descriptions
+json.extract!(@curation_concern, :physical_medium, :original_item_extent, :repository_location, :related_resource, :research_assistance)
+
+# rights info
+json.rights_statement(map_uris(@curation_concern.rights_statement))
+json.rights_holder(@curation_concern.rights_holder)
+
+json.version(@curation_concern.etag)

--- a/app/views/hyrax/publications/show.json.jbuilder
+++ b/app/views/hyrax/publications/show.json.jbuilder
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+#
+# Jbuilder template for rendering Publication works as JSON. The out-of-the-box template
+# from hyrax (see <hyrax-root>/app/views/hyrax/base/show.json.jbuilder) will generate a
+# stack depth error for some reason (the logs aren't very helpful) that seems to be related
+# to fields with non-standard values (namely wrapped URIs). So our current solution is to
+# explicitly declare what fields are returned.
+#
+# @todo is :note admin only?
+json.id(@curation_concern.id)
+
+# titles
+json.title(@curation_concern.title.map(&:to_s))
+json.title_alternative(@curation_concern.title_alternative.map(&:to_s))
+json.subtitle(@curation_concern.subtitle.map(&:to_s))
+
+# creators
+json.extract!(@curation_concern, :creator, :contributor, :editor, :publisher)
+
+# descriptions
+json.extract!(@curation_concern, :resource_type)
+json.abstract(@curation_concern.abstract.map(&:to_s))
+json.description(@curation_concern.description.map(&:to_s))
+json.extract!(@curation_concern, :bibliographic_citation)
+
+# subjects, locations, identifiers
+json.subject(map_uris(@curation_concern.subject))
+json.extract!(@curation_concern, :keyword)
+json.location(map_uris(@curation_concern.location))
+json.extract!(@curation_concern, :identifier, :source, :language, :physical_medium, :related_resource)
+
+# dates
+json.extract!(@curation_concern, :date_issued, :date_available, :date_uploaded, :date_modified)
+
+# academic dept. info
+json.extract!(@curation_concern, :academic_department, :division, :organization)
+
+# rights stuff
+json.rights_statement(map_uris(@curation_concern.rights_statement))
+json.extract!(@curation_concern, :rights_holder, :license)
+
+json.version(@curation_concern.etag)

--- a/app/views/spot/page/about.html.erb
+++ b/app/views/spot/page/about.html.erb
@@ -57,15 +57,16 @@
 <h2 id="why-submit-your-content">Why submit your content to the LDR?</h2>
 <ul>
   <li>boost the search engine discoverability of your research</li>
-  <li>provide persistent access to your research over time (i.e. prevent “link rot” in citations to your work)</li>
+  <li>provide persistent access to your research over time (i.e. prevent “link rot" in citations to your work)</li>
   <li>satisfy funding agency requirements for sharing and preserving research data and published findings</li>
   <li>preserve your work for the long term in an institutional environment</li>
 </ul>
 <p>
-  Members of the faculty and administrative departments may use the LDR submission form to deposit
-  articles to the Lafayette Digital Repository.  For other content types, such as presentations,
+  Members of the faculty and administrative departments may use the
+  <%= link_to 'LDR submission form', 'https://library.lafayette.edu/lafayette-digital-repository-submission-form/' %>
+  to deposit articles to the Lafayette Digital Repository.  For other content types, such as presentations,
   research data, audiovisual materials, etc. please contact Nora Egloff, Digital Repository Librarian,
-  at egloffn@lafayette.edu for more information.
+  at <%= mail_to 'egloffn@lafayette.edu' %> for more information.
 </p>
 
 <h2 id="policies">Policies</h2>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -5,4 +5,10 @@ RSpec.describe ApplicationController do
 
     it { is_expected.not_to include :locale }
   end
+
+  describe '#render_bookmarks_control?' do
+    subject { described_class.new.render_bookmarks_control? }
+
+    it { is_expected.to be false }
+  end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe CatalogController, clean: true do
-  # tryna get that coverage percentage up
-  describe '#render_bookmarks_control?' do
-    subject { described_class.new.render_bookmarks_control? }
-
-    it { is_expected.to be false }
-  end
-
   describe '#index' do
     before do
       objects.each { |obj| ActiveFedora::SolrService.add(obj) }

--- a/spec/helpers/spot/catalog_helper_spec.rb
+++ b/spec/helpers/spot/catalog_helper_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+RSpec.describe Spot::CatalogHelper, type: :helper do
+  describe '#humanize_edtf_value' do
+    subject { helper.humanize_edtf_value(value) }
+
+    context 'when a value is parseable by Date.edtf' do
+      let(:value) { '1912-06-01/2002-08-10' }
+
+      it { is_expected.to eq 'June 1, 1912 to August 10, 2002' }
+    end
+
+    context 'when a value is not parseable by Date.edtf' do
+      let(:value) { 'unparseable' }
+
+      it { is_expected.to eq 'unparseable' }
+    end
+  end
+end

--- a/spec/helpers/spot/catalog_helper_spec.rb
+++ b/spec/helpers/spot/catalog_helper_spec.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 RSpec.describe Spot::CatalogHelper, type: :helper do
-  describe '#humanize_edtf_value' do
-    subject { helper.humanize_edtf_value(value) }
+  describe '#humanize_edtf_values' do
+    subject { helper.humanize_edtf_values(args) }
+    let(:args) { { value: value } }
 
     context 'when a value is parseable by Date.edtf' do
-      let(:value) { '1912-06-01/2002-08-10' }
+      let(:value) { ['1912-06-01/2002-08-10'] }
 
       it { is_expected.to eq 'June 1, 1912 to August 10, 2002' }
     end
 
     context 'when a value is not parseable by Date.edtf' do
-      let(:value) { 'unparseable' }
+      let(:value) { ['unparseable'] }
 
       it { is_expected.to eq 'unparseable' }
     end

--- a/spec/helpers/spot/json_helper_spec.rb
+++ b/spec/helpers/spot/json_helper_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+RSpec.describe Spot::JsonHelper do
+  describe '.map_uris' do
+    subject { helper.map_uris(values) }
+
+    context 'when a value is a controlled resource' do
+      let(:values) { [Spot::ControlledVocabularies::Base.new(URI('http://cool.example.org'))] }
+
+      it { is_expected.to eq ['http://cool.example.org'] }
+    end
+
+    context 'when a value is a string' do
+      let(:values) { ['http://cool.example.org/2'] }
+
+      it { is_expected.to eq ['http://cool.example.org/2'] }
+    end
+
+    context 'when a value responds to #to_a' do
+      let(:values) { OpenStruct.new(to_a: ['http://cool.example.org/3']) }
+
+      it { is_expected.to eq ['http://cool.example.org/3'] }
+    end
+  end
+end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -4,45 +4,19 @@ RSpec.describe Image do
 
   it_behaves_like 'a model with hyrax core metadata'
 
+  # @todo might be useful to turn this into a shared_example?
   [
-    [:subtitle, 'http://purl.org/spar/doco/Subtitle'],
-    [:title_alternative, RDF::Vocab::DC.alternative],
-    [:publisher, RDF::Vocab::DC11.publisher],
-    [:repository_location, 'http://purl.org/vra/placeOfRepository'],
-    [:source, RDF::Vocab::DC.source],
-    [:resource_type, RDF::Vocab::DC.type],
-    [:physical_medium, RDF::Vocab::DC.PhysicalMedium],
+    [:date,                 RDF::Vocab::DC.date],
+    [:date_scope_note,      RDF::Vocab::SKOS.scopeNote],
+    [:date_associated,      'https://d-nb.info/standards/elementset/gnd#associatedDate'],
+    [:donor,                RDF::Vocab::DC.provenance],
+    [:inscription,          'http://dbpedia.org/ontology/inscription'],
     [:original_item_extent, RDF::Vocab::DC.extent],
-    [:language, RDF::Vocab::DC11.language],
-    [:description, RDF::Vocab::DC11.description],
-    [:inscription, 'http://dbpedia.org/ontology/inscription'],
-    [:date, RDF::Vocab::DC.date],
-    [:date_scope_note, RDF::Vocab::SKOS.scopeNote],
-    [:date_associated, 'https://d-nb.info/standards/elementset/gnd#associatedDate'],
-    [:creator, RDF::Vocab::DC11.creator],
-    [:contributor, RDF::Vocab::DC11.contributor],
-    [:related_resource, RDF::RDFS.seeAlso],
-    [:subject, RDF::Vocab::DC11.subject],
-    [:subject_ocm, 'https://hraf.yale.edu/resources/reference/outline-of-cultural-materials'],
-    [:keyword, RDF::Vocab::SCHEMA.keywords],
-    [:location, RDF::Vocab::DC.spatial],
-    [:rights_statement, RDF::Vocab::EDM.rights],
-    [:rights_holder, RDF::Vocab::DC.rightsHolder],
-    [:identifier, RDF::Vocab::DC.identifier],
-    [:requested_by, 'http://rdf.myexperiment.org/ontologies/base/has-requester'],
-    [:research_assistance, 'http://www.rdaregistry.info/Elements/a/#P50265'],
-    [:donor, RDF::Vocab::DC.provenance],
-    [:note, RDF::Vocab::SKOS.note]
+    [:repository_location,  'http://purl.org/vra/placeOfRepository'],
+    [:requested_by,         'http://rdf.myexperiment.org/ontologies/base/has-requester'],
+    [:research_assistance,  'http://www.rdaregistry.info/Elements/a/#P50265'],
+    [:subject_ocm,          'https://hraf.yale.edu/resources/reference/outline-of-cultural-materials']
   ].each do |(prop, uri)|
     it { is_expected.to have_editable_property(prop).with_predicate(uri) }
-  end
-
-  describe 'validations' do
-    it_behaves_like 'it validates field presence', field: :title
-    it_behaves_like 'it validates field presence', field: :resource_type, value: ['Image']
-    it_behaves_like 'it validates field presence', field: :rights_statement
-    it_behaves_like 'it validates local authorities', field: :resource_type, authority: 'resource_types'
-    it_behaves_like 'it validates local authorities', field: :rights_statement, authority: 'rights_statements'
-    it_behaves_like 'it ensures the existence of a NOID identifier'
   end
 end

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -1,48 +1,24 @@
 # frozen_string_literal: true
-describe Publication do
-  it_behaves_like 'a model with hyrax core metadata'
+RSpec.describe Publication do
+  it_behaves_like 'it includes Spot::WorkBehavior'
 
+  # @todo might be useful to turn this into a shared_example?
   [
-    [:subtitle, 'http://purl.org/spar/doco/Subtitle'],
-    [:title_alternative, RDF::Vocab::DC.alternative],
-    [:publisher, RDF::Vocab::DC11.publisher],
-    [:source, RDF::Vocab::DC.source],
-    [:resource_type, RDF::Vocab::DC.type],
-    [:physical_medium, RDF::Vocab::DC.PhysicalMedium],
-    [:language, RDF::Vocab::DC11.language],
-    [:abstract, RDF::Vocab::DC.abstract],
-    [:description, RDF::Vocab::DC11.description],
-    [:note, RDF::Vocab::SKOS.note],
-    [:identifier, RDF::Vocab::DC.identifier],
+    [:abstract,               RDF::Vocab::DC.abstract],
+    [:academic_department,    'http://vivoweb.org/ontology/core#AcademicDepartment'],
     [:bibliographic_citation, RDF::Vocab::DC.bibliographicCitation],
-    [:date_issued, RDF::Vocab::DC.issued],
-    [:date_available, RDF::Vocab::DC.available],
-    [:creator, RDF::Vocab::DC11.creator],
-    [:contributor, RDF::Vocab::DC11.contributor],
-    [:editor, RDF::Vocab::BIBO.editor],
-    [:academic_department, 'http://vivoweb.org/ontology/core#AcademicDepartment'],
-    [:division, 'http://vivoweb.org/ontology/core#Division'],
-    [:organization, 'http://vivoweb.org/ontology/core#Organization'],
-    [:related_resource, RDF::RDFS.seeAlso],
-    [:subject, RDF::Vocab::DC11.subject],
-    [:keyword,  RDF::Vocab::SCHEMA.keywords],
-    [:location, RDF::Vocab::DC.spatial],
-    [:license, RDF::Vocab::DC.license],
-    [:rights_statement, RDF::Vocab::EDM.rights],
-    [:rights_holder, RDF::Vocab::DC.rightsHolder]
+    [:date_available,         RDF::Vocab::DC.available],
+    [:date_issued,            RDF::Vocab::DC.issued],
+    [:division,               'http://vivoweb.org/ontology/core#Division'],
+    [:editor,                 RDF::Vocab::BIBO.editor],
+    [:license,                RDF::Vocab::DC.license],
+    [:organization,           'http://vivoweb.org/ontology/core#Organization']
   ].each do |(prop, uri)|
     it { is_expected.to have_editable_property(prop).with_predicate(uri) }
   end
 
   describe 'validations' do
     let(:work) { build(:publication) }
-
-    it_behaves_like 'it validates local authorities', field: :resource_type, authority: 'resource_types'
-    it_behaves_like 'it validates local authorities', field: :rights_statement, authority: 'rights_statements'
-    it_behaves_like 'it validates field presence', field: :title
-    it_behaves_like 'it validates field presence', field: :resource_type, value: ['Article']
-    it_behaves_like 'it validates field presence', field: :rights_statement
-    it_behaves_like 'it ensures the existence of a NOID identifier'
 
     describe 'date_issued' do
       it 'can not be absent' do

--- a/spec/presenters/spot/collection_presenter_spec.rb
+++ b/spec/presenters/spot/collection_presenter_spec.rb
@@ -104,4 +104,12 @@ RSpec.describe Spot::CollectionPresenter do
       it { is_expected.to be false }
     end
   end
+
+  describe '#related_resource' do
+    subject { presenter.related_resource }
+
+    let(:metadata) { core_metadata.merge('related_resource_ssim': ['http://cool.example.org']) }
+
+    it { is_expected.to eq ['http://cool.example.org'] }
+  end
 end

--- a/spec/support/shared_examples/spot_core_metadata.rb
+++ b/spec/support/shared_examples/spot_core_metadata.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'it includes Spot::CoreMetadata' do
+  subject { described_class.new }
+
+  [
+    [:contributor,       RDF::Vocab::DC11.contributor],
+    [:creator,           RDF::Vocab::DC11.creator],
+    [:description,       RDF::Vocab::DC11.description],
+    [:identifier,        RDF::Vocab::DC.identifier],
+    [:keyword,           RDF::Vocab::SCHEMA.keywords],
+    [:language,          RDF::Vocab::DC11.language],
+    [:location,          RDF::Vocab::DC.spatial],
+    [:note,              RDF::Vocab::SKOS.note],
+    [:physical_medium,   RDF::Vocab::DC.PhysicalMedium],
+    [:publisher,         RDF::Vocab::DC11.publisher],
+    [:related_resource,  RDF::RDFS.seeAlso],
+    [:resource_type,     RDF::Vocab::DC.type],
+    [:rights_holder,     RDF::Vocab::DC.rightsHolder],
+    [:rights_statement,  RDF::Vocab::EDM.rights],
+    [:source,            RDF::Vocab::DC.source],
+    [:subject,           RDF::Vocab::DC11.subject],
+    [:subtitle,          RDF::URI.new('http://purl.org/spar/doco/Subtitle')],
+    [:title_alternative, RDF::Vocab::DC.alternative]
+  ].each do |(property, predicate)|
+    it { is_expected.to have_editable_property(property).with_predicate(predicate) }
+  end
+end

--- a/spec/support/shared_examples/spot_work_behavior.rb
+++ b/spec/support/shared_examples/spot_work_behavior.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'it includes Spot::WorkBehavior' do
+  subject { described_class.new }
+
+  # mixins
+  it_behaves_like 'a model with hyrax core metadata'
+  it_behaves_like 'it ensures the existence of a NOID identifier'
+  it_behaves_like 'it includes Spot::CoreMetadata'
+
+  # validations
+  it_behaves_like 'it validates field presence', field: :title
+  it_behaves_like 'it validates field presence', field: :resource_type, value: ['Image']
+  it_behaves_like 'it validates field presence', field: :rights_statement
+  it_behaves_like 'it validates local authorities', field: :resource_type, authority: 'resource_types'
+  it_behaves_like 'it validates local authorities', field: :rights_statement, authority: 'rights_statements'
+
+  # unique behaviors
+  describe '.controlled_properties (class_attribute)' do
+    subject { described_class }
+
+    it { is_expected.to respond_to(:controlled_properties) }
+    it { is_expected.to respond_to(:controlled_properties=) }
+  end
+end


### PR DESCRIPTION
## bug fixes 🐞 
- ensure bookmark toggles aren't displayed on _any_ controller (#670)
- point CollectionPresenter to the correct related_resource key (#674)
- add link to LDR submission form on about page (#679)
- add partials for Publication and Image json responses (fixes a "stack level too deep" error that would pop up) (#680)

## features 🧑‍🏭 
- split common work-model behavior into `Spot::CoreMetadata` and `Spot::WorkBehavior` mixins (#676)
- catalog_controller updates (#677)
  - facet limit defined globally (rather than per-facet)
  - added OCM Classification facet to sidebar
  - fixed field keys for #index views 
  - humanize edtf date values 

---- 
closes #657
closes #678 