### PR TITLE
explicitly use Jbuilder for work-type json responses

### DIFF
--- a/app/helpers/spot/json_helper.rb
+++ b/app/helpers/spot/json_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module Spot
+  # Helper methods intended to be used within jbuilder settings
+  module JsonHelper
+    # Converts an array (or array-like thing that responds to +:to_a+) of
+    # ControlledVocabulary objects into URIs
+    #
+    # @param [Array<String>, #to_a] raw_values
+    # @return [Array<String>]
+    def map_uris(raw_values)
+      raw_values = raw_values.to_a if raw_values.respond_to?(:to_a)
+
+      Array.wrap(raw_values).map do |raw|
+        uri = raw.respond_to?(:rdf_subject) ? raw.send(:rdf_subject) : raw
+        uri.to_s
+      end
+    end
+  end
+end

--- a/app/views/hyrax/images/show.json.jbuilder
+++ b/app/views/hyrax/images/show.json.jbuilder
@@ -1,4 +1,4 @@
-# Jbuilder template for rendering Publication works as JSON. The out-of-the-box template
+# Jbuilder template for rendering Image works as JSON. The out-of-the-box template
 # from hyrax (see <hyrax-root>/app/views/hyrax/base/show.json.jbuilder) will generate a
 # stack depth error for some reason (the logs aren't very helpful) that seems to be related
 # to fields with non-standard values (namely wrapped URIs). So our current solution is to

--- a/app/views/hyrax/images/show.json.jbuilder
+++ b/app/views/hyrax/images/show.json.jbuilder
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+#
 # Jbuilder template for rendering Image works as JSON. The out-of-the-box template
 # from hyrax (see <hyrax-root>/app/views/hyrax/base/show.json.jbuilder) will generate a
 # stack depth error for some reason (the logs aren't very helpful) that seems to be related

--- a/app/views/hyrax/images/show.json.jbuilder
+++ b/app/views/hyrax/images/show.json.jbuilder
@@ -36,3 +36,5 @@ json.extract!(@curation_concern, :physical_medium, :original_item_extent, :repos
 # rights info
 json.rights_statement(map_uris(@curation_concern.rights_statement))
 json.rights_holder(@curation_concern.rights_holder)
+
+json.version(@curation_concern.etag)

--- a/app/views/hyrax/images/show.json.jbuilder
+++ b/app/views/hyrax/images/show.json.jbuilder
@@ -1,0 +1,38 @@
+# Jbuilder template for rendering Publication works as JSON. The out-of-the-box template
+# from hyrax (see <hyrax-root>/app/views/hyrax/base/show.json.jbuilder) will generate a
+# stack depth error for some reason (the logs aren't very helpful) that seems to be related
+# to fields with non-standard values (namely wrapped URIs). So our current solution is to
+# explicitly declare what fields are returned.
+#
+# @todo are :note, :donor, and :requested_by admin only?
+json.id(@curation_concern.id)
+
+# titles
+json.title(@curation_concern.title.map(&:to_s))
+json.title_alternative(@curation_concern.title_alternative.map(&:to_s))
+json.subtitle(@curation_concern.subtitle.map(&:to_s))
+
+# creators
+json.extract!(@curation_concern, :creator, :contributor, :publisher)
+
+# descriptive text
+json.resource_type(@curation_concern.resource_type)
+json.description(@curation_concern.description.map(&:to_s))
+json.inscription(@curation_concern.inscription.map(&:to_s))
+
+# subjects, locations, identifiers
+json.subject(map_uris(@curation_concern.subject))
+json.keyword(@curation_concern.keyword)
+json.location(map_uris(@curation_concern.location))
+json.extract!(@curation_concern, :identifier, :source, :language)
+json.ocm_classification(@curation_concern.subject_ocm.sort)
+
+# dates
+json.extract!(@curation_concern, :date, :date_scope_note, :date_associated, :date_uploaded, :date_modified)
+
+# more descriptions
+json.extract!(@curation_concern, :physical_medium, :original_item_extent, :repository_location, :related_resource, :research_assistance)
+
+# rights info
+json.rights_statement(map_uris(@curation_concern.rights_statement))
+json.rights_holder(@curation_concern.rights_holder)

--- a/app/views/hyrax/publications/show.json.jbuilder
+++ b/app/views/hyrax/publications/show.json.jbuilder
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+#
 # Jbuilder template for rendering Publication works as JSON. The out-of-the-box template
 # from hyrax (see <hyrax-root>/app/views/hyrax/base/show.json.jbuilder) will generate a
 # stack depth error for some reason (the logs aren't very helpful) that seems to be related

--- a/app/views/hyrax/publications/show.json.jbuilder
+++ b/app/views/hyrax/publications/show.json.jbuilder
@@ -1,0 +1,38 @@
+# Jbuilder template for rendering Publication works as JSON. The out-of-the-box template
+# from hyrax (see <hyrax-root>/app/views/hyrax/base/show.json.jbuilder) will generate a
+# stack depth error for some reason (the logs aren't very helpful) that seems to be related
+# to fields with non-standard values (namely wrapped URIs). So our current solution is to
+# explicitly declare what fields are returned.
+#
+# @todo is :note admin only?
+json.id(@curation_concern.id)
+
+# titles
+json.title(@curation_concern.title.map(&:to_s))
+json.title_alternative(@curation_concern.title_alternative.map(&:to_s))
+json.subtitle(@curation_concern.subtitle.map(&:to_s))
+
+# creators
+json.extract!(@curation_concern, :creator, :contributor, :editor, :publisher)
+
+# descriptions
+json.extract!(@curation_concern, :resource_type)
+json.abstract(@curation_concern.abstract.map(&:to_s))
+json.description(@curation_concern.description.map(&:to_s))
+json.extract!(@curation_concern, :bibliographic_citation)
+
+# subjects, locations, identifiers
+json.subject(map_uris(@curation_concern.subject))
+json.extract!(@curation_concern, :keyword)
+json.location(map_uris(@curation_concern.location))
+json.extract!(@curation_concern, :identifier, :source, :language, :physical_medium, :related_resource)
+
+# dates
+json.extract!(@curation_concern, :date_issued, :date_available, :date_uploaded, :date_modified)
+
+# academic dept. info
+json.extract!(@curation_concern, :academic_department, :division, :organization)
+
+# rights stuff
+json.rights_statement(map_uris(@curation_concern.rights_statement))
+json.extract!(@curation_concern, :rights_holder, :license)

--- a/app/views/hyrax/publications/show.json.jbuilder
+++ b/app/views/hyrax/publications/show.json.jbuilder
@@ -36,3 +36,5 @@ json.extract!(@curation_concern, :academic_department, :division, :organization)
 # rights stuff
 json.rights_statement(map_uris(@curation_concern.rights_statement))
 json.extract!(@curation_concern, :rights_holder, :license)
+
+json.version(@curation_concern.etag)


### PR DESCRIPTION
the default hyrax behavior (found in [hyrax/app/views/hyrax/base/show.json.jbuilder]) doesn't perform any sanitation on the values, and `RDF::Literal` or `RDF::URI` (i'm not really sure which or both?) values will send Rails into a tailspin and crash with a `Stack level too deep` error. by explicitly declaring the fields, and running possible problems through some base sanitation, we can side-step this.

[hyrax/app/views/hyrax/base/show.json.jbuilder]: https://github.com/samvera/hyrax/blob/v2.9.0/app/views/hyrax/base/show.json.jbuilder