### PR TITLE
lock nokogiri at ~> 1.10.10 until migration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,12 +125,13 @@ gem 'mini_magick', '4.10.1'
 # manually add this gem to enable questioning_authority to parse linked-data results
 gem 'linkeddata', '~> 3.0'
 
-# hydra-role-management requires bootstrap_form without declaring a version,
-# bootstrap_form >=4.5.0 requires a ruby version >= 2.5 (we're stuck on 2.4.3
-# until we migrate to aws).
 #
-# @todo remove this restriction after aws migration
+# these are gems that we need to lock until we can upgrade ruby to >= 2.5
+# (on-prem is locked at 2.4.3).
+#
+# @todo remove these restriction after aws migration
 gem 'bootstrap_form', '~> 4.4.0'
+gem 'nokogiri', '~> 1.10.10'
 
 # development dependencies (not as necessary to
 # lock down versions here)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1007,6 +1007,7 @@ DEPENDENCIES
   linkeddata (~> 3.0)
   listen (>= 3.0.5, < 3.3)
   mini_magick (= 4.10.1)
+  nokogiri (~> 1.10.10)
   okcomputer (= 1.18.2)
   pg (= 1.2.3)
   puma (= 3.12.6)


### PR DESCRIPTION
this should help us with the failing dependabot upgrades that arrived this morning (only #683 has a direct nokogiri upgrade that we can't currently support)