### PR TITLE
add label overrides hash to Spot::ISO6391 service

### DIFF
--- a/app/services/spot/iso6391.rb
+++ b/app/services/spot/iso6391.rb
@@ -3,37 +3,29 @@
 # An utility class for the +iso-639+ gem. We're storing the dictionary
 # in a class variable so we don't need to load it every time.
 module Spot
-  class ISO6391
-    class << self
-      # All of the ISO-639-1 entries in a key/val hash
-      #
-      # @example
-      #   Spot::LanguageAuthority.all.first.to_h
-      #   # => {'aa' => 'Afar'}
-      #
-      # @return [Array<Hash<Symbol => String>>]
-      def all
-        @all ||= mapped_639_1_entries
-      end
+  module ISO6391
+    OVERRIDES = {
+      'es' => 'Spanish'
+    }.freeze
 
-      # Find the label for a language by its 2-char entry.
-      #
-      # @param [String] id
-      # @return [String, NilClass]
-      def label_for(id)
-        all[id.downcase]
-      end
+    # All of the ISO-639-1 entries in a key/val hash
+    #
+    # @example
+    #   Spot::LanguageAuthority.all.first.to_h
+    #   # => {'aa' => 'Afar'}
+    #
+    # @return [Array<Hash<String => String>>]
+    def self.all
+      @all ||= ISO_639::ISO_639_1.select { |e| e.alpha2.present? }.map { |e| [e.alpha2, e.english_name] }.to_h
+    end
 
-      private
-
-        # iso639-1 entries mapped to a key/val hash
-        #
-        # @return [Hash<String => String>]
-        def mapped_639_1_entries
-          ISO_639::ISO_639_1.select { |e| e.alpha2.present? }
-                            .map { |e| [e.alpha2, e.english_name] }
-                            .to_h
-        end
+    # Find the label for a language by its 2-char entry.
+    #
+    # @param [String] id
+    # @return [String, NilClass]
+    def self.label_for(id)
+      id = id.to_s.downcase
+      OVERRIDES[id] || all[id]
     end
   end
 end

--- a/app/services/spot/iso6391.rb
+++ b/app/services/spot/iso6391.rb
@@ -1,9 +1,22 @@
 # frozen_string_literal: true
-
-# An utility class for the +iso-639+ gem. We're storing the dictionary
-# in a class variable so we don't need to load it every time.
 module Spot
+  # Helper module for ISO-639 language code -> english-name conversion. Essentially a wrapper
+  # around the +iso-639+ gem, with the ability to provide overrides for some language labels.
+  #
+  # @example Getting the English label for a language from the iso-639 gem
+  #   Spot::ISO6391.label_for('en')
+  #   # => "English"
+  #
+  # @example Getting the English label for a language that uses a local override
+  #   Spot::ISO6391::OVERRIDES
+  #   # => { 'es' => 'Spanish' }
+  #   ISO_639.find('es').english_name
+  #   # => "Spanish; Castilian"
+  #   Spot::ISO6391.label_for('es')
+  #   # => "Spanish"
   module ISO6391
+    # Local overrides for labels. Allows us to add preferred labels for values
+    # instead of relying on the +iso-639+ gem labels.
     OVERRIDES = {
       'es' => 'Spanish'
     }.freeze
@@ -19,7 +32,8 @@ module Spot
       @all ||= ISO_639::ISO_639_1.select { |e| e.alpha2.present? }.map { |e| [e.alpha2, e.english_name] }.to_h
     end
 
-    # Find the label for a language by its 2-char entry.
+    # Find the label for a language by its 2-char entry. Tries our local overrides hash first
+    # falling back to the +iso-639+ gem label.
     #
     # @param [String] id
     # @return [String, NilClass]

--- a/spec/services/spot/iso_6391_spec.rb
+++ b/spec/services/spot/iso_6391_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe Spot::ISO6391 do
       it { is_expected.to eq 'Esperanto' }
     end
 
+    context 'when a local override for an entry exists' do
+      let(:id) { 'es' }
+      let(:original_value) { ISO_639.find(id).english_name }
+
+      it { is_expected.not_to eq original_value }
+      it { is_expected.to eq described_class::OVERRIDES[id] }
+    end
+
     context 'when an entry does not exist' do
       let(:id) { ':(' }
 


### PR DESCRIPTION
adds a `Spot::ISO6391::OVERRIDES` hash that allows us to provide custom labels for certain languages (addresses the problem raised in #357).