### PR TITLE
iso-639-update-final-draft_FINAL-b.docx

### DIFF
--- a/app/authorities/qa/authorities/language.rb
+++ b/app/authorities/qa/authorities/language.rb
@@ -11,7 +11,7 @@ module Qa::Authorities
     #
     # @return [Array<Hash<Symbol => String>>]
     def all
-      Spot::ISO6391.all.map { |key, val| wrap(id: key, label: val) }
+      Spot::ISO6391.all.map { |key, val| wrap(id: key, label: val) }.compact
     end
 
     # @param [String] id
@@ -38,7 +38,7 @@ module Qa::Authorities
       # @param [String] label
       # @return [Hash<Symbol => String>]
       def wrap(id:, label:)
-        return if id.nil? || label.nil?
+        return if id == label
 
         { id: id, label: label, value: id }
       end

--- a/app/indexers/concerns/indexes_language_and_label.rb
+++ b/app/indexers/concerns/indexes_language_and_label.rb
@@ -14,7 +14,7 @@ module IndexesLanguageAndLabel
 
       object.language.each do |lang|
         doc[value_field] << lang
-        doc[label_field] << (Spot::ISO6391.label_for(lang) || lang)
+        doc[label_field] << (Spot::ISO6391.label_for(lang))
       end
     end
   end

--- a/app/indexers/concerns/indexes_language_and_label.rb
+++ b/app/indexers/concerns/indexes_language_and_label.rb
@@ -14,7 +14,7 @@ module IndexesLanguageAndLabel
 
       object.language.each do |lang|
         doc[value_field] << lang
-        doc[label_field] << (Spot::ISO6391.label_for(lang))
+        doc[label_field] << Spot::ISO6391.label_for(lang)
       end
     end
   end

--- a/config/locales/iso_639.en.yml
+++ b/config/locales/iso_639.en.yml
@@ -1,0 +1,3 @@
+en:
+  iso_639_1:
+    es: Spanish

--- a/spec/services/spot/iso_6391_spec.rb
+++ b/spec/services/spot/iso_6391_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Spot::ISO6391 do
       before do
         allow(I18n)
           .to receive(:t)
-          .with(id, { default: [original_value, id], scope: ['iso_639_1'] })
+          .with(id, default: [original_value, id], scope: ['iso_639_1'])
           .and_return(expected_value)
       end
 

--- a/spec/services/spot/iso_6391_spec.rb
+++ b/spec/services/spot/iso_6391_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 RSpec.describe Spot::ISO6391 do
-  describe '#all' do
+  describe '.all' do
     subject { described_class.all }
 
     it { is_expected.to be_a Hash }
     it { is_expected.not_to be_empty }
   end
 
-  describe '#label_for' do
+  describe '.label_for' do
     subject { described_class.label_for(id) }
 
     context 'when a 2-char entry exists' do
@@ -17,17 +17,25 @@ RSpec.describe Spot::ISO6391 do
     end
 
     context 'when a local override for an entry exists' do
-      let(:id) { 'es' }
+      let(:id) { 'en' }
       let(:original_value) { ISO_639.find(id).english_name }
+      let(:expected_value) { 'ANGLISH' }
+
+      before do
+        allow(I18n)
+          .to receive(:t)
+          .with(id, { default: [original_value, id], scope: ['iso_639_1'] })
+          .and_return(expected_value)
+      end
 
       it { is_expected.not_to eq original_value }
-      it { is_expected.to eq described_class::OVERRIDES[id] }
+      it { is_expected.to eq expected_value }
     end
 
     context 'when an entry does not exist' do
       let(:id) { ':(' }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to eq id }
     end
   end
 end

--- a/spec/support/shared_examples/indexing/indexes_language_and_label.rb
+++ b/spec/support/shared_examples/indexing/indexes_language_and_label.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples 'it indexes ISO language and label' do
     # rubocop:enable RSpec/InstanceVariable
 
     let(:languages) { ['en', 'ja', 'nope'] }
-    let(:labels) { ['English', 'Japanese', 'nope'] }
+    let(:labels) { languages.map { |lang| Spot::ISO6391.label_for(lang) }
 
     it 'stores the raw values as _ssim' do
       expect(solr_doc['language_ssim']).to contain_exactly(*languages)

--- a/spec/support/shared_examples/indexing/indexes_language_and_label.rb
+++ b/spec/support/shared_examples/indexing/indexes_language_and_label.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples 'it indexes ISO language and label' do
     # rubocop:enable RSpec/InstanceVariable
 
     let(:languages) { ['en', 'ja', 'nope'] }
-    let(:labels) { languages.map { |lang| Spot::ISO6391.label_for(lang) }
+    let(:labels) { languages.map { |lang| Spot::ISO6391.label_for(lang) } }
 
     it 'stores the raw values as _ssim' do
       expect(solr_doc['language_ssim']).to contain_exactly(*languages)


### PR DESCRIPTION
lol changing #692 to rely on `I18n.t` as the local override rather than an internal hash. also updates the indexer mixin that uses the service.