### PR TITLE
add metadata-only visibility

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -156,12 +156,6 @@ class CatalogController < ApplicationController
     config.add_index_field 'license_tesim',
                            helper_method: :license_links,
                            label: :'blacklight.search.fields.license'
-    config.add_index_field 'embargo_release_date_dtsi',
-                           label: :'blacklight.search.fields.embargo_release_date',
-                           helper_method: :human_readable_date
-    config.add_index_field 'lease_expiration_date_dtsi',
-                           label: :'blacklight.search.fields.lease_expiration_date',
-                           helper_method: :human_readable_date
 
     #
     # search field configuration

--- a/app/helpers/spot/ability_helper.rb
+++ b/app/helpers/spot/ability_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+module Spot
+  module AbilityHelper
+    # Select options for visibility. Overwriting the original method to add our metadata-only
+    # visibility as an option.
+    #
+    # @return [Array<Array<String, String>>]
+    def visibility_options(variant)
+      options = [
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
+        'metadata',
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED,
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      ]
+
+      case variant
+      when :restrict
+        options.delete_at(0)
+        # options.reverse!
+      when :loosen
+        options.delete_at(2)
+      end
+      options.map { |value| [visibility_text(value), value] }
+    end
+  end
+end

--- a/app/helpers/spot/catalog_helper.rb
+++ b/app/helpers/spot/catalog_helper.rb
@@ -5,14 +5,42 @@ module Spot
     # Falls back to the original value.
     #
     # @return [String]
+    # rubocop:disable Style/RescueModifier
     def humanize_edtf_values(args)
-      Array.wrap(args[:value]).map { |val| humanize_edtf_value(val) }.to_sentence
+      Array.wrap(args[:value]).map { |val| humanize_edtf_value(val) rescue value }.to_sentence
+    end
+    # rubocop:enable Style/RescueModifier
+
+    # Should we display an info alert to catalog results?
+    #
+    # @param [SolrDocument]
+    # @return [true, false]
+    def display_info_alert?(document)
+      document.embargo_release_date.present? ||
+        document.lease_expiration_date.present? ||
+        document.registered? ||
+        document.metadata_only?
     end
 
-    def humanize_edtf_value(value)
-      Date.edtf(value).humanize
-    rescue
-      value
+    # @param [SolrDocument]
+    # @return [String]
+    def document_access_display_text(document)
+      key = if document.embargo_release_date.present?
+              :embargo
+            elsif document.lease_expiration_date.present?
+              :lease
+            elsif document.registered?
+              :authenticated
+            elsif document.metadata_only?
+              :metadata
+            else
+              :private # not expecting to get here, but we should have a generic message just in case
+            end
+
+      date_method = [:embargo_release_date, :lease_expiration_date].find { |m| document.send(m).present? }
+      date = document.send(:date_method).strftime('%B %e, %Y') unless date_method.nil?
+
+      I18n.t("#{key}_html", scope: ['spot', 'work', 'access_message'], default: "This item's files are currently unavailable", date: date)
     end
   end
 end

--- a/app/helpers/spot/catalog_helper.rb
+++ b/app/helpers/spot/catalog_helper.rb
@@ -7,7 +7,7 @@ module Spot
     # @return [String]
     # rubocop:disable Style/RescueModifier
     def humanize_edtf_values(args)
-      Array.wrap(args[:value]).map { |value| humanize_edtf_value(value) rescue value }.to_sentence
+      Array.wrap(args[:value]).map { |value| Date.edtf(value).humanize rescue value }.to_sentence
     end
     # rubocop:enable Style/RescueModifier
 
@@ -36,13 +36,13 @@ module Spot
             elsif document.metadata_only?
               :metadata
             else
-              :private # not expecting to get here, but we should have a generic message just in case
+              :default # not expecting to get here, but we should have a generic message just in case
             end
 
       date_method = [:embargo_release_date, :lease_expiration_date].find { |m| document.send(m).present? }
       date = document.send(date_method).strftime('%B %e, %Y') unless date_method.nil?
 
-      I18n.t("#{key}_html", scope: ['spot', 'work', 'access_message'], default: "This item's files are currently unavailable", date: date)
+      I18n.t("#{key}_html", scope: ['spot', 'work', 'access_message'], date: date)
     end
   end
 end

--- a/app/helpers/spot/catalog_helper.rb
+++ b/app/helpers/spot/catalog_helper.rb
@@ -39,8 +39,8 @@ module Spot
               :private # not expecting to get here, but we should have a generic message just in case
             end
 
-      date = [:embargo_release_date, :lease_expiration_date].find { |m| (val = document.send(m)).present? && val }
-      date = date.strftime('%B %e, %Y') unless date.nil?
+      date_method = [:embargo_release_date, :lease_expiration_date].find { |m| document.send(m).present? }
+      date = document.send(date_method).strftime('%B %e, %Y') unless date_method.nil?
 
       I18n.t("#{key}_html", scope: ['spot', 'work', 'access_message'], default: "This item's files are currently unavailable", date: date)
     end

--- a/app/helpers/spot/catalog_helper.rb
+++ b/app/helpers/spot/catalog_helper.rb
@@ -7,7 +7,7 @@ module Spot
     # @return [String]
     # rubocop:disable Style/RescueModifier
     def humanize_edtf_values(args)
-      Array.wrap(args[:value]).map { |val| humanize_edtf_value(val) rescue value }.to_sentence
+      Array.wrap(args[:value]).map { |value| humanize_edtf_value(value) rescue value }.to_sentence
     end
     # rubocop:enable Style/RescueModifier
 
@@ -16,6 +16,8 @@ module Spot
     # @param [SolrDocument]
     # @return [true, false]
     def display_info_alert?(document)
+      return false if document.public?
+
       document.embargo_release_date.present? ||
         document.lease_expiration_date.present? ||
         document.registered? ||
@@ -37,8 +39,8 @@ module Spot
               :private # not expecting to get here, but we should have a generic message just in case
             end
 
-      date_method = [:embargo_release_date, :lease_expiration_date].find { |m| document.send(m).present? }
-      date = document.send(:date_method).strftime('%B %e, %Y') unless date_method.nil?
+      date = [:embargo_release_date, :lease_expiration_date].find { |m| (val = document.send(m)).present? && val }
+      date = date.strftime('%B %e, %Y') unless date.nil?
 
       I18n.t("#{key}_html", scope: ['spot', 'work', 'access_message'], default: "This item's files are currently unavailable", date: date)
     end

--- a/app/helpers/spot/catalog_helper.rb
+++ b/app/helpers/spot/catalog_helper.rb
@@ -16,8 +16,6 @@ module Spot
     # @param [SolrDocument]
     # @return [true, false]
     def display_info_alert?(document)
-      return false if document.public?
-
       document.embargo_release_date.present? ||
         document.lease_expiration_date.present? ||
         document.registered? ||

--- a/app/helpers/spot/catalog_helper.rb
+++ b/app/helpers/spot/catalog_helper.rb
@@ -42,7 +42,7 @@ module Spot
       date_method = [:embargo_release_date, :lease_expiration_date].find { |m| document.send(m).present? }
       date = document.send(date_method).strftime('%B %e, %Y') unless date_method.nil?
 
-      I18n.t("#{key}_html", scope: ['spot', 'work', 'access_message'], date: date)
+      I18n.t("#{key}_html", scope: ['spot', 'work', 'access_message'], date: date).html_safe
     end
   end
 end

--- a/app/jobs/clear_expired_embargoes_and_leases_job.rb
+++ b/app/jobs/clear_expired_embargoes_and_leases_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class ClearExpiredEmbargoesAndLeasesJob < ApplicationJob
   def perform
-    ::Spot::EmbargoLeaseService.clear_all_expired
+    ::Spot::EmbargoLeaseService.clear_all_expired(regenerate_thumbnails: true)
   end
 end

--- a/app/jobs/spot/regenerate_thumbnail_job.rb
+++ b/app/jobs/spot/regenerate_thumbnail_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Spot
+  # Job that allows us to recreate thumbnails without having to run the entirety of
+  # +CreateDerivativesJob+ which generates pyramidal tiffs, extracts full-text content,
+  # basically a whole lot of work that we might not need to repeat.
+  class RegenerateThumbnailJob < ApplicationJob
+    def perform(work)
+      return if work&.thumbnail_id.nil?
+      file_set = FileSet.find(work.thumbnail_id)
+
+      filename = Hyrax::DerivativePath.derivative_path_for_reference(file_set, 'thumbnail')
+      Spot::Derivatives::ThumbnailService.new(file_set).create_derivatives(filename)
+
+      file_set.reload
+      file_set.update_index
+      work.update_index
+
+      true
+    end
+  end
+end

--- a/app/models/concerns/spot/metadata_only_visibility.rb
+++ b/app/models/concerns/spot/metadata_only_visibility.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+module Spot
+  # mixin to enable a 'metadata' visibility, intended to be interpreted as:
+  #   - the work's metadata is visible
+  #   - the work's files are only visible to admins
+  module MetadataOnlyVisibility
+    extend ActiveSupport::Concern
+
+    # @return [void]
+    # @see https://github.com/samvera/hydra-head/blob/v11.0.0/hydra-access-controls/app/models/concerns/hydra/access_controls/visibility.rb#L5-L18
+    def visibility=(value)
+      return super unless value == 'metadata'
+
+      # setup our discover/read groups
+      metadata_only_visibility!
+
+      # need to set this manually, as +super+ would be doing that work
+      @visibility = value
+    end
+
+    # @return [String]
+    # @see https://github.com/samvera/hydra-head/blob/v11.0.0/hydra-access-controls/app/models/concerns/hydra/access_controls/visibility.rb#L20-L28
+    def visibility
+      if discover_groups.present? && discover_groups.include?('public') && !read_groups.include?('open')
+        'metadata'
+      else
+        super
+      end
+    end
+
+    private
+
+      # Sets discover groups to +['public']+ and read groups to +['admin']+ only
+      #
+      # @return [void]
+      def metadata_only_visibility!
+        visibility_will_change! unless visibility == 'metadata'
+        set_discover_groups([Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC], [])
+        set_read_groups(['admin'], read_groups)
+      end
+  end
+end

--- a/app/models/concerns/spot/metadata_only_visibility.rb
+++ b/app/models/concerns/spot/metadata_only_visibility.rb
@@ -33,12 +33,16 @@ module Spot
 
     private
 
+      def set_visibility_discover_groups
+        set_discover_groups([Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC], discover_groups)
+      end
+
       # Sets discover groups to +['public']+ and read groups to +['admin']+ only
       #
       # @return [void]
       def metadata_only_visibility!
         visibility_will_change! unless visibility == 'metadata'
-        set_discover_groups([Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC], discover_groups)
+        set_visibility_discover_groups
         set_read_groups([Ability.admin_group_name], read_groups)
       end
 
@@ -48,6 +52,12 @@ module Spot
       def private_visibility!
         super
         set_discover_groups([], discover_groups)
+      end
+
+      # Ensure unauthenticated users are able to view metadata of authenticated items.
+      def registered_visibility!
+        super
+        set_visibility_discover_groups
       end
   end
 end

--- a/app/models/concerns/spot/metadata_only_visibility.rb
+++ b/app/models/concerns/spot/metadata_only_visibility.rb
@@ -6,11 +6,6 @@ module Spot
   module MetadataOnlyVisibility
     extend ActiveSupport::Concern
 
-    # Can this item be discovered in the catalog?
-    def publicly_discoverable?
-      public? || discover_groups.include?(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
-    end
-
     # @return [void]
     # @see https://github.com/samvera/hydra-head/blob/v11.0.0/hydra-access-controls/app/models/concerns/hydra/access_controls/visibility.rb#L5-L18
     def visibility=(value)
@@ -26,7 +21,7 @@ module Spot
     # @return [String]
     # @see https://github.com/samvera/hydra-head/blob/v11.0.0/hydra-access-controls/app/models/concerns/hydra/access_controls/visibility.rb#L20-L28
     def visibility
-      return 'metadata' if publicly_discoverable? && !public?
+      return 'metadata' if !public? && discover_groups.include?(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
 
       super
     end

--- a/app/models/concerns/spot/metadata_only_visibility.rb
+++ b/app/models/concerns/spot/metadata_only_visibility.rb
@@ -21,11 +21,10 @@ module Spot
     # @return [String]
     # @see https://github.com/samvera/hydra-head/blob/v11.0.0/hydra-access-controls/app/models/concerns/hydra/access_controls/visibility.rb#L20-L28
     def visibility
-      if discover_groups.present? && discover_groups.include?('public') && !read_groups.include?('open')
-        'metadata'
-      else
-        super
-      end
+      return 'metadata' if discover_groups&.include?(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC) &&
+                           !read_groups.include?(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
+
+      super
     end
 
     private
@@ -36,7 +35,7 @@ module Spot
       def metadata_only_visibility!
         visibility_will_change! unless visibility == 'metadata'
         set_discover_groups([Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC], [])
-        set_read_groups(['admin'], read_groups)
+        set_read_groups([Ability.admin_group_name], read_groups)
       end
   end
 end

--- a/app/models/concerns/spot/solr_document_attributes.rb
+++ b/app/models/concerns/spot/solr_document_attributes.rb
@@ -35,6 +35,7 @@ module Spot
       attribute :date_issued,            ::Blacklight::Types::Array, 'date_issued_ssim'
       attribute :depositor,              ::Blacklight::Types::String, 'depositor_ssim'
       attribute :description,            ::Blacklight::Types::Array, 'description_tesim'
+      attribute :discover_groups,        ::Blacklight::Types::Array, ::Ability.discover_group_field
       attribute :division,               ::Blacklight::Types::Array, 'division_tesim'
       attribute :donor,                  ::Blacklight::Types::Array, 'donor_ssim'
       attribute :editor,                 ::Blacklight::Types::Array, 'editor_tesim'

--- a/app/models/concerns/spot/work_behavior.rb
+++ b/app/models/concerns/spot/work_behavior.rb
@@ -7,6 +7,7 @@ module Spot
     include ::Hyrax::WorkBehavior
     include NoidIdentifier
     include CoreMetadata
+    include MetadataOnlyVisibility
 
     included do
       # The `controlled_properties` attribute is used by the Hyrax::DeepIndexingService,

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class FileSet < ActiveFedora::Base
   include ::Hyrax::FileSetBehavior
+  include ::Spot::MetadataOnlyVisibility
 
   # using our own FileSetIndexer that doesn't index full-text content
   self.indexer = Spot::FileSetIndexer

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -73,4 +73,8 @@ class SolrDocument
     return collection_slug if collection? && collection_slug.present?
     super
   end
+
+  def visibility
+    @visibility ||= self['visibility_ssi'] == 'metadata' ? 'metadata' : super
+  end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -65,6 +65,10 @@ class SolrDocument
   # all we want to know is if the item's visibility is "metadata"
   #
   # @return [true, false]
+  def discoverable?
+    public? || discover_groups.include?(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
+  end
+
   def metadata_only?
     visibility == 'metadata'
   end
@@ -95,7 +99,7 @@ class SolrDocument
                       Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
                     elsif registered?
                       Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-                    elsif discover_groups.include?(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
+                    elsif discoverable?
                       'metadata'
                     else
                       Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -82,7 +82,23 @@ class SolrDocument
     super
   end
 
+  # Override Hyrax::SolrDocumentBehavior#visibility to add our custom metadata-only
+  # visibility as an option when discover_groups include 'public'
+  #
+  # @return [String]
   def visibility
-    @visibility ||= self['visibility_ssi'] == 'metadata' ? 'metadata' : super
+    @visibility ||= if embargo_release_date.present?
+                      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
+                    elsif lease_expiration_date.present?
+                      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE
+                    elsif public?
+                      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+                    elsif registered?
+                      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+                    elsif discover_groups.include?(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
+                      'metadata'
+                    else
+                      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+                    end
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -61,6 +61,14 @@ class SolrDocument
   end
   # rubocop:enable Metrics/MethodLength
 
+  # Less involved than the same method on WorkShowPresenters,
+  # all we want to know is if the item's visibility is "metadata"
+  #
+  # @return [true, false]
+  def metadata_only?
+    visibility == 'metadata'
+  end
+
   def sets
     Spot::OaiCollectionSolrSet.sets_for(self)
   end

--- a/app/presenters/spot/base_presenter.rb
+++ b/app/presenters/spot/base_presenter.rb
@@ -48,6 +48,8 @@ module Spot
       solr_document.location.zip(solr_document.location_label).reject(&:empty?)
     end
 
+    # Check if an item's record should include files or just display the metadata.
+    #
     # @return [true, false]
     def metadata_only?
       # admins get all-access

--- a/app/presenters/spot/base_presenter.rb
+++ b/app/presenters/spot/base_presenter.rb
@@ -48,6 +48,18 @@ module Spot
       solr_document.location.zip(solr_document.location_label).reject(&:empty?)
     end
 
+    # @return [true, false]
+    def metadata_only?
+      # admins get all-access
+      return false if current_ability.admin?
+
+      # bounce out if we've set the visibility to 'metadata'
+      return true if visibility == 'metadata'
+
+      # lafayette-only items should show the metadata for anyone who can't 'download' the item
+      solr_document.registered? && !current_ability.can?(:download, id)
+    end
+
     # @return [Array<Spot::Identifier>]
     def local_identifier
       @local_identifier ||= solr_document.local_identifier.map { |id| Spot::Identifier.from_string(id) }

--- a/app/presenters/spot/base_presenter.rb
+++ b/app/presenters/spot/base_presenter.rb
@@ -20,7 +20,7 @@ module Spot
     # to add their unique fields
     delegate :contributor, :creator, :description, :identifier, :keyword, :language,
              :language_label, :location, :note, :permalink, :physical_medium,
-             :publisher, :related_resource, :resource_type, :rights_holder, :rights_statement,
+             :publisher, :registered?, :related_resource, :resource_type, :rights_holder, :rights_statement,
              :source, :subject, :subtitle, :title_alternative, :title,
              :visibility,
              to: :solr_document

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,0 +1,8 @@
+<div class="search-results-title-row">
+  <h4 class="search-result-title"><%= link_to(document.title_or_label, document) %></h4>
+  <% if display_info_alert?(document) %>
+    <div class="alert alert-warning" style="margin:0; padding:5px;">
+      <%= document_access_display_text(document) %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -1,0 +1,79 @@
+<%# controls the display of visibility on the base hyrax form %>
+<% if f.object.embargo_release_date %>
+  <%= render 'form_permission_under_embargo', f: f %>
+<% elsif f.object.lease_expiration_date %>
+  <%= render 'form_permission_under_lease', f: f %>
+<% else %>
+    <fieldset>
+      <legend class="legend-save-work">Visibility</legend>
+      <ul class="visibility">
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, data: { 'target': '#collapsePublic' } %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) %>
+            <br />
+            <%= t('hyrax.visibility.open.note_html', type: f.object.human_readable_type) %>
+            <div class="collapse" id="collapsePublic">
+              <%= t('hyrax.visibility.open.warning_html', label: visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)) %>
+            </div>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) %>
+            <br />
+            <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO) %>
+            <br />
+            <%= t('hyrax.visibility.embargo.note_html') %>
+            <div class="collapse" id="collapseEmbargo">
+              <div class="form-inline">
+                <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+                <%= t('hyrax.works.form.visibility_until') %>
+                <%= f.date_field :embargo_release_date, wrapper: :inline, value: f.object.embargo_release_date || Date.tomorrow, class: 'datepicker form-control' %>
+                <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+              </div>
+            </div>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, data: { 'target': '#collapseLease' } %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE) %>
+            <br />
+            <%= t('hyrax.visibility.lease.note_html') %>
+            <div class="collapse" id="collapseLease">
+              <div class="form-inline">
+                <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+                <%= t('hyrax.works.form.visibility_until') %>
+                <%= f.date_field :lease_expiration_date, wrapper: :inline, value: f.object.lease_expiration_date || Date.tomorrow, class: 'datepicker form-control' %>
+                <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+              </div>
+            </div>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, 'metadata' %>
+            <%= visibility_badge('metadata') %>
+            <br />
+            <%= t('hyrax.visibility.metadata.note_html') %>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) %>
+            <br />
+            <%= t('hyrax.visibility.restricted.note_html') %>
+          </label>
+        </li>
+      </ul>
+    </fieldset>
+<% end %>

--- a/app/views/hyrax/base/_items_table.html.erb
+++ b/app/views/hyrax/base/_items_table.html.erb
@@ -1,5 +1,4 @@
-<% array_of_ids = presenter.list_of_item_ids_to_display %>
-<% members = presenter.member_presenters_for(array_of_ids) %>
+<% members = presenter.member_presenters_for(presenter.list_of_item_ids_to_display) %>
 
 <div class="panel panel-default">
   <div class="panel-heading panel-heading-slim">
@@ -15,14 +14,24 @@
         <td class="text-center">
           <span class="label label-<%= type_class %>"><%= type %></span>
         </td>
-        <td><%= link_to(member.link_name, contextual_path(member, presenter)) %></td>
-        <td>Uploaded <%= member.try(:date_uploaded) %></td>
-        <td><%= member.permission_badge %></td>
-        <td class="text-center">
-        <% if model_name == :file_set %>
-          <%= render "hyrax/file_sets/actions", file_set: member %>
-        <% end %>
+        <td>
+          <% if presenter.metadata_only? %>
+            <%= member.first_title %>
+          <% else %>
+            <%= link_to(member.link_name, contextual_path(member, presenter)) %>
+          <% end %>
         </td>
+        <td>
+          Uploaded <%= member.try(:date_uploaded) %>
+        </td>
+        <td>
+          <%= member.permission_badge %>
+        </td>
+        <% if !presenter.metadata_only? && model_name == :file_set -%>
+        <td class="text-center">
+          <%= render "hyrax/file_sets/actions", file_set: member -%>
+        </td>
+        <% end %>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/hyrax/base/_metadata_and_viewer_panel.html.erb
+++ b/app/views/hyrax/base/_metadata_and_viewer_panel.html.erb
@@ -9,14 +9,17 @@
         <%= render 'show_actions', presenter: presenter %>
       </div>
       <div class="col-sm-12 work-representative-media">
-        <%= render 'representative_media', presenter: presenter, viewer: presenter.iiif_viewer? %>
+        <% if display_info_alert?(presenter) %>
+          <%= render 'restricted_access_alert', presenter: presenter %>
+        <% end %>
+
+        <% unless presenter.metadata_only? %>
+          <%= render 'representative_media', presenter: presenter, viewer: presenter.iiif_viewer? %>
+        <% end %>
       </div>
-      <%# <div class="col-sm-3 text-center"> %>
-        <%# render 'citations', presenter: presenter %>
-        <%# render 'social_media' %>
-      <%# </div> %>
+
       <div class="col-sm-12 work-metadata">
-        <%= render 'export_tools', presenter: presenter %>
+        <%= render('export_tools', presenter: presenter) unless presenter.metadata_only? %>
         <%= render 'work_description', presenter: presenter %>
         <%= render 'metadata', presenter: presenter %>
         <%= render 'items_table', presenter: presenter %>

--- a/app/views/hyrax/base/_metadata_and_viewer_panel.html.erb
+++ b/app/views/hyrax/base/_metadata_and_viewer_panel.html.erb
@@ -5,9 +5,11 @@
   <div class="panel-body">
     <div class="row">
       <%= render 'workflow_actions_widget', presenter: presenter %>
+      <% if current_ability.can?(:edit, presenter.id) %>
       <div class="col-sm-12">
         <%= render 'show_actions', presenter: presenter %>
       </div>
+      <% end %>
       <div class="col-sm-12 work-representative-media">
         <% if display_info_alert?(presenter) %>
           <%= render 'restricted_access_alert', presenter: presenter %>

--- a/app/views/hyrax/base/_restricted_access_alert.html.erb
+++ b/app/views/hyrax/base/_restricted_access_alert.html.erb
@@ -1,0 +1,3 @@
+<div class="alert alert-warning">
+  <%= document_access_display_text(presenter.solr_document) %>
+</div>

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -114,16 +114,9 @@ Rails.application.config.to_prepare do
   end
 
   # Adding label support for metadata-only records
-  Hyrax::PermissionBadge.module_eval do
+  Hyrax::PermissionBadge.class_eval do
+    old_visibility_label_class = Hyrax::PermissionBadge::VISIBILITY_LABEL_CLASS.dup
     remove_const(:VISIBILITY_LABEL_CLASS) if const_defined?(:VISIBILITY_LABEL_CLASS)
-
-    VISIBILITY_LABEL_CLASS = {
-      authenticated: "label-primary",
-      embargo: "label-warning",
-      lease: "label-warning",
-      metadata: "label-info",
-      open: "label-success",
-      restricted: "label-danger"
-    }.freeze
+    const_set(:VISIBILITY_LABEL_CLASS, old_visibility_label_class.tap { |h| h[:metadata] = 'label-info' }.freeze)
   end
 end

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -112,4 +112,18 @@ Rails.application.config.to_prepare do
       options[:label] || I18n.t("blacklight.search.fields.#{attribute_name}", default: label_translation)
     end
   end
+
+  # Adding label support for metadata-only records
+  Hyrax::PermissionBadge.module_eval do
+    remove_const(:VISIBILITY_LABEL_CLASS) if const_defined?(:VISIBILITY_LABEL_CLASS)
+
+    VISIBILITY_LABEL_CLASS = {
+      authenticated: "label-primary",
+      embargo: "label-warning",
+      lease: "label-warning",
+      metadata: "label-info",
+      open: "label-success",
+      restricted: "label-danger"
+    }.freeze
+  end
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -51,3 +51,8 @@ en:
       form:
         q:
           label: Search LDR
+
+    visibility:
+      metadata:
+        note_html: Make metadata available to all but restrict file access
+        text: Metadata Only

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -106,6 +106,11 @@ en:
         page_title: Terms of Use // %{name}
 
     work:
+      access_message:
+        authenticated_html: File access restricted to members of the Lafayette College community.
+        embargo_html: File(s) under embargo until <strong>%{date}</strong>
+        lease_html: File(s) available until <strong>%{date}</strong>
+        private_html: This work's files are unavailable.
       export:
         additional_options: Additional options
         all_files: Download all files

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -110,7 +110,7 @@ en:
         authenticated_html: File access restricted to members of the Lafayette College community.
         embargo_html: File(s) under embargo until <strong>%{date}</strong>
         lease_html: File(s) available until <strong>%{date}</strong>
-        private_html: This work's files are unavailable.
+        metadata_html: This item's files are unavailable.
       export:
         additional_options: Additional options
         all_files: Download all files

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -110,7 +110,8 @@ en:
         authenticated_html: File access restricted to members of the Lafayette College community.
         embargo_html: File(s) under embargo until <strong>%{date}</strong>
         lease_html: File(s) available until <strong>%{date}</strong>
-        metadata_html: This item's files are unavailable.
+        metadata_html: This item's files are unavailable to access.
+        default_html: This item's files are unavailable.
       export:
         additional_options: Additional options
         all_files: Download all files

--- a/spec/helpers/spot/catalog_helper_spec.rb
+++ b/spec/helpers/spot/catalog_helper_spec.rb
@@ -23,18 +23,6 @@ RSpec.describe Spot::CatalogHelper, type: :helper do
     let(:document) { SolrDocument.new(solr_data) }
     let(:solr_data) { {} }
 
-    context 'when a public document' do
-      let(:solr_data) do
-        {
-          read_access_group_ssim: [
-            Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
-          ]
-        }
-      end
-
-      it { is_expected.to be false }
-    end
-
     context 'when the doc has an embargo release date' do
       let(:solr_data) do
         { embargo_release_date_dtsi: '2021-02-26T00:00:00Z' }

--- a/spec/helpers/spot/catalog_helper_spec.rb
+++ b/spec/helpers/spot/catalog_helper_spec.rb
@@ -16,4 +16,94 @@ RSpec.describe Spot::CatalogHelper, type: :helper do
       it { is_expected.to eq 'unparseable' }
     end
   end
+
+  describe '#display_info_alert?' do
+    subject { helper.display_info_alert?(document) }
+
+    let(:document) { SolrDocument.new(solr_data) }
+    let(:solr_data) { {} }
+
+    context 'when a public document' do
+      let(:solr_data) do
+        {
+          read_access_group_ssim: [
+            Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
+          ]
+        }
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the doc has an embargo release date' do
+      let(:solr_data) do
+        { embargo_release_date_dtsi: '2021-02-26T00:00:00Z' }
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the doc has a lease expiration date' do
+      let(:solr_data) do
+        { lease_expiration_date_dtsi: '2021-02-26T00:00:00Z' }
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the doc requires authenticated access' do
+      let(:solr_data) do
+        { read_access_group_ssim: [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED] }
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the doc is metadata only' do
+      let(:solr_data) { { visibility_ssi: 'metadata' } }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#document_access_display_text' do
+    subject { helper.document_access_display_text(document) }
+
+    let(:document) { SolrDocument.new(solr_data) }
+    let(:solr_data) { {} }
+
+    context 'when an embargo release date is present' do
+      let(:solr_data) do
+        { embargo_release_date_dtsi: '2021-02-26T00:00:00Z' }
+      end
+
+      it { is_expected.to eq I18n.t('spot.work.access_message.embargo_html', date: 'February 26, 2021') }
+    end
+
+    context 'when a lease expiration date is present' do
+      let(:solr_data) do
+        { lease_expiration_date_dtsi: '2021-02-26T00:00:00Z' }
+      end
+
+      it { is_expected.to eq I18n.t('spot.work.access_message.lease_html', date: 'February 26, 2021') }
+    end
+
+    context 'when the doc requires authenticated access' do
+      let(:solr_data) do
+        { read_access_group_ssim: [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED] }
+      end
+
+      it { is_expected.to eq I18n.t('spot.work.access_message.authenticated_html') }
+    end
+
+    context 'when the doc is metadata_only' do
+      let(:solr_data) { { visibility_ssi: 'metadata' } }
+
+      it { is_expected.to eq I18n.t('spot.work.access_message.metadata_html') }
+    end
+
+    context 'the default behavior' do
+      it { is_expected.to eq I18n.t('spot.work.access_message.default_html') }
+    end
+  end
 end

--- a/spec/jobs/clear_expired_embargoes_and_leases_job_spec.rb
+++ b/spec/jobs/clear_expired_embargoes_and_leases_job_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 RSpec.describe ClearExpiredEmbargoesAndLeasesJob do
   before do
-    allow(Spot::EmbargoLeaseService).to receive(:clear_all_expired)
+    allow(Spot::EmbargoLeaseService).to receive(:clear_all_expired).with(regenerate_thumbnails: true)
   end
 
   it 'defers to the Spot::EmbargoLeaseService' do
     described_class.perform_now
 
-    expect(Spot::EmbargoLeaseService).to have_received(:clear_all_expired).exactly(1).times
+    expect(Spot::EmbargoLeaseService).to have_received(:clear_all_expired).with(regenerate_thumbnails: true).exactly(1).times
   end
 end

--- a/spec/jobs/spot/regenerate_thumbnail_job_spec.rb
+++ b/spec/jobs/spot/regenerate_thumbnail_job_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+RSpec.describe Spot::RegenerateThumbnailJob do
+  let(:work) { instance_double(Publication, id: 'pub123abc', thumbnail_id: thumbnail_id, update_index: true) }
+  let(:file_set) { instance_double(FileSet, id: 'fst123abc', update_index: true, reload: true) }
+  let(:thumbnail_id) { file_set.id }
+  let(:thumbnail_service_double) { instance_double(Spot::Derivatives::ThumbnailService) }
+  let(:thumbnail_path) { '/path/to/thumbnail.jpg' }
+
+  before do
+    allow(Hyrax::DerivativePath)
+      .to receive(:derivative_path_for_reference)
+      .with(file_set, 'thumbnail')
+      .and_return(thumbnail_path)
+
+    allow(Spot::Derivatives::ThumbnailService)
+      .to receive(:new)
+      .with(file_set)
+      .and_return(thumbnail_service_double)
+
+    allow(FileSet).to receive(:find).with(file_set.id).and_return(file_set)
+    allow(thumbnail_service_double).to receive(:create_derivatives).with(thumbnail_path)
+  end
+
+  describe '#perform' do
+    context 'when a work does not have a thumbnail_id' do
+      let(:thumbnail_id) { nil }
+
+      it 'bails early' do
+        expect(described_class.perform_now(work)).to be nil
+
+        expect(thumbnail_service_double).not_to have_received(:create_derivatives)
+      end
+    end
+
+    it 'generates a thumbnail and updates the index' do
+      described_class.perform_now(work)
+
+      expect(thumbnail_service_double).to have_received(:create_derivatives).with(thumbnail_path)
+      expect(file_set).to have_received(:reload)
+      expect(file_set).to have_received(:update_index)
+      expect(work).to have_received(:update_index)
+    end
+  end
+end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 RSpec.describe FileSet do
   it_behaves_like 'a model with hyrax core metadata'
+  it_behaves_like 'it accepts "metadata" as a visibility'
 end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe Image do
   subject { described_class.new }
 
-  it_behaves_like 'a model with hyrax core metadata'
+  it_behaves_like 'it includes Spot::WorkBehavior'
 
   # @todo might be useful to turn this into a shared_example?
   [

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -118,11 +118,40 @@ RSpec.describe SolrDocument do
   describe '#visibility' do
     subject { document.visibility }
 
-    context 'when visibility is "metadata"' do
-      let(:metadata) { { 'visibility_ssi' => visibility } }
-      let(:visibility) { 'metadata' }
+    context 'when an embargo_release_date is present' do
+      let(:metadata) { { 'embargo_release_date_dtsi' => Time.zone.now.to_s } }
+
+      it { is_expected.to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO }
+    end
+
+    context 'when a lease_expiration_date is present' do
+      let(:metadata) { { 'lease_expiration_date_dtsi' => Time.zone.now.to_s } }
+
+      it { is_expected.to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE }
+    end
+
+    context 'when public' do
+      let(:metadata) { { Ability.read_group_field => [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC] } }
+
+      it { is_expected.to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    end
+
+    context 'when authenticated' do
+      let(:metadata) { { Ability.read_group_field => [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED] } }
+
+      it { is_expected.to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+    end
+
+    context 'when metadata only' do
+      let(:metadata) { { Ability.discover_group_field => [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC] } }
 
       it { is_expected.to eq 'metadata' }
+    end
+
+    context 'default case (private)' do
+      let(:metadata) { {} }
+
+      it { is_expected.to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
   end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -114,4 +114,15 @@ RSpec.describe SolrDocument do
       it { is_expected.to eq 'abc123' }
     end
   end
+
+  describe '#visibility' do
+    subject { document.visibility }
+
+    context 'when visibility is "metadata"' do
+      let(:metadata) { { 'visibility_ssi' => visibility } }
+      let(:visibility) { 'metadata' }
+
+      it { is_expected.to eq 'metadata' }
+    end
+  end
 end

--- a/spec/overrides/hyrax_permission_badge_spec.rb
+++ b/spec/overrides/hyrax_permission_badge_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::PermissionBadge do
+  it 'adds ":metadata" to the Hash of visibility labels' do
+    expect(Hyrax::PermissionBadge::VISIBILITY_LABEL_CLASS).to include(:metadata)
+  end
+end

--- a/spec/support/shared_examples/metadata_only_visibility.rb
+++ b/spec/support/shared_examples/metadata_only_visibility.rb
@@ -47,6 +47,15 @@ RSpec.shared_examples 'it accepts "metadata" as a visibility' do
       end
     end
 
+    context 'when authenticated' do
+      it 'sets discover_groups to public access' do
+        expect { work.visibility = ::Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+          .to change { work.discover_groups }
+          .from([])
+          .to([::Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC])
+      end
+    end
+
     context 'when invalid visibility' do
       it 'raises an ArgumentError' do
         expect { work.visibility = 'nonsense' }.to raise_error(ArgumentError)

--- a/spec/support/shared_examples/metadata_only_visibility.rb
+++ b/spec/support/shared_examples/metadata_only_visibility.rb
@@ -34,6 +34,19 @@ RSpec.shared_examples 'it accepts "metadata" as a visibility' do
       end
     end
 
+    context 'when changing to private' do
+      before { work.visibility = 'metadata' }
+
+      it 'clears out discover_groups' do
+        expect(work.discover_groups).not_to be_empty
+
+        expect { work.visibility = ::Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+          .to change { work.discover_groups }
+          .from([::Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC])
+          .to([])
+      end
+    end
+
     context 'when invalid visibility' do
       it 'raises an ArgumentError' do
         expect { work.visibility = 'nonsense' }.to raise_error(ArgumentError)

--- a/spec/support/shared_examples/metadata_only_visibility.rb
+++ b/spec/support/shared_examples/metadata_only_visibility.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'it accepts "metadata" as a visibility' do
+  let(:work) { described_class.new }
+  let(:public_group) { Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC }
+  let(:admin_group) { Ability.admin_group_name }
+
+  describe '#visibility' do
+    subject { work.visibility }
+
+    context 'when discover_groups are public and read_groups are admin' do
+      before do
+        work.discover_groups = [public_group]
+        work.read_groups = [admin_group]
+      end
+
+      it { is_expected.to eq 'metadata' }
+    end
+  end
+
+  describe '#visibility=' do
+    context 'when "metadata"' do
+      it 'sets discover_groups to public access' do
+        expect { work.visibility = 'metadata' }
+          .to change { work.discover_groups }
+          .from([])
+          .to([public_group])
+      end
+
+      it 'sets read_groups to admin access' do
+        expect { work.visibility = 'metadata' }
+          .to change { work.read_groups }
+          .from([])
+          .to([admin_group])
+      end
+    end
+
+    context 'when invalid visibility' do
+      it 'raises an ArgumentError' do
+        expect { work.visibility = 'nonsense' }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/spot_presenter.rb
+++ b/spec/support/shared_examples/spot_presenter.rb
@@ -103,29 +103,16 @@ RSpec.shared_examples 'a Spot presenter' do
     context 'when an item is restricted to authenticated users' do
       let(:_solr_data) { { 'read_access_group_ssim' => [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED] } }
 
-      before do
-        allow(ability).to receive(:can?).with(:download, solr_data[:id]).and_return(can_download_response)
-      end
-
       context 'with an unauthenticated user' do
         let(:ability) { Ability.new(build(:public_user)) }
-        let(:can_download_response) { false }
 
         it { is_expected.to be true }
       end
 
       context 'with an authenticated user' do
         let(:ability) { registered_ability }
-        let(:can_download_response) { true }
 
         it { is_expected.to eq false }
-      end
-
-      context "with an authenticated user that can't download the item" do
-        let(:ability) { registered_ability }
-        let(:can_download_response) { false }
-
-        it { is_expected.to be true }
       end
     end
   end

--- a/spec/support/shared_examples/spot_work_behavior.rb
+++ b/spec/support/shared_examples/spot_work_behavior.rb
@@ -6,6 +6,7 @@ RSpec.shared_examples 'it includes Spot::WorkBehavior' do
   it_behaves_like 'a model with hyrax core metadata'
   it_behaves_like 'it ensures the existence of a NOID identifier'
   it_behaves_like 'it includes Spot::CoreMetadata'
+  it_behaves_like 'it accepts "metadata" as a visibility'
 
   # validations
   it_behaves_like 'it validates field presence', field: :title


### PR DESCRIPTION
another approach to #701.

- adds a `"metadata"` visibility value which restricts access to just the item's metadata (files are only viewable by `"admin"` users).
- `"registered"`/`"authenticated"` items are restricted to metadata-only access for unregistered/unauthenticated users.

~wip until i port over some of the visual cues from that old pr~