### PR TITLE
fix redirection to collections

### DIFF
--- a/app/controllers/concerns/spot/redirection_helpers.rb
+++ b/app/controllers/concerns/spot/redirection_helpers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+module Spot
+  module RedirectionHelpers
+    def redirect_params_for(solr_document:)
+      controller = solr_document['has_model_ssim'].first.downcase.pluralize
+      params = { controller: "hyrax/#{controller}", action: 'show', id: solr_document['id'] }
+
+      return Hyrax::Engine.routes.url_for(**params, only_path: true) if controller == 'collections'
+
+      params
+    end
+  end
+end

--- a/app/controllers/concerns/spot/redirection_helpers.rb
+++ b/app/controllers/concerns/spot/redirection_helpers.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 module Spot
+  # Helper methods for common redirection tasks.
   module RedirectionHelpers
+    # Solves a problem where passing a params hash including +{ controller: 'hyrax/collections', action: 'show' }+ would
+    # result in a No Route Matches error. Passing these params to +Hyrax::Engine.routes.url_for+ will work for
+    # collections but not other work types. There's probably something I'm missing, but this will at least
+    # allow us to resolve Handles and legacy URLs for collections.
     def redirect_params_for(solr_document:)
       controller = solr_document['has_model_ssim'].first.downcase.pluralize
       params = { controller: "hyrax/#{controller}", action: 'show', id: solr_document['id'] }

--- a/app/controllers/handle_controller.rb
+++ b/app/controllers/handle_controller.rb
@@ -3,6 +3,7 @@
 # Responsible for redirecting Handle requests to their associated items
 class HandleController < ApplicationController
   include Hydra::Catalog
+  include ::Spot::RedirectionHelpers
 
   # Searches for a Handle based on an +hdl:+ identifier.
   # Displays a 404 (via raised +Blacklight::Exceptions::RecordNotFound+
@@ -12,13 +13,9 @@ class HandleController < ApplicationController
     result, _documents = repository.search(query)
 
     raise Blacklight::Exceptions::RecordNotFound if result.response['numFound'].zero?
-
     document = result.response['docs'].first
-    controller = document['has_model_ssim'].first.downcase.pluralize
 
-    redirect_to controller: "hyrax/#{controller}",
-                action: 'show',
-                id: document['id']
+    redirect_to redirect_params_for(solr_document: document)
   end
 
   private

--- a/app/controllers/spot/redirect_controller.rb
+++ b/app/controllers/spot/redirect_controller.rb
@@ -16,6 +16,7 @@ module Spot
   #       (soon to be HandleController) follows (almost) the same  logic.
   class RedirectController < ApplicationController
     include ::Hydra::Catalog
+    include ::Spot::RedirectionHelpers
 
     def show
       # all that we need for this controller are the object's ID + Hydra Model
@@ -25,9 +26,8 @@ module Spot
       raise Blacklight::Exceptions::RecordNotFound if result.response['numFound'].zero?
 
       document = result.response['docs'].first
-      controller = document['has_model_ssim'].first.downcase.pluralize
 
-      redirect_to controller: "hyrax/#{controller}", action: 'show', id: document['id']
+      redirect_to redirect_params_for(solr_document: document)
     end
 
     private

--- a/spec/controllers/handle_controller_spec.rb
+++ b/spec/controllers/handle_controller_spec.rb
@@ -4,17 +4,61 @@ RSpec.describe HandleController do
   describe '#show' do
     subject { get :show, params: { id: handle } }
 
-    context 'when a handle exists for an item' do
-      let(:handle) { '1234/5678' }
-      let(:work) { build(:publication, identifier: ["hdl:#{handle}"]) }
+    let(:solr_service) { ActiveFedora::SolrService }
 
-      before { work.save }
+    before do
+      solr_service.add(solr_data)
+      solr_service.commit
+    end
 
-      it { is_expected.to redirect_to hyrax_publication_path(work.id) }
+    after do
+      solr_service.delete(id: solr_data[:id])
+      solr_service.commit
+    end
+
+    context 'when a Handle exists for a Publication' do
+      let(:handle) { '10385/1234' }
+      let(:solr_data) do
+        {
+          id: 'existing-pub',
+          has_model_ssim: ['Publication'],
+          identifier_ssim: ["hdl:#{handle}"]
+        }
+      end
+
+      it { is_expected.to redirect_to hyrax_publication_path(solr_data[:id]) }
+    end
+
+    context 'when a Handle exists for an Image' do
+      let(:handle) { '10385/5678' }
+      let(:solr_data) do
+        {
+          id: 'existing-img',
+          has_model_ssim: ['Image'],
+          identifier_ssim: ["hdl:#{handle}"]
+        }
+      end
+
+      it { is_expected.to redirect_to hyrax_image_path(solr_data[:id]) }
+    end
+
+    context 'when a Handle exists for a Collection' do
+      let(:handle) { '10385/9012' }
+      let(:solr_data) do
+        {
+          id: 'existing-col',
+          has_model_ssim: ['Collection'],
+          identifier_ssim: ["hdl:#{handle}"]
+        }
+      end
+
+      it { is_expected.to redirect_to Hyrax::Engine.routes.url_helpers.collection_path(solr_data[:id]) }
     end
 
     context 'when a handle does not exist for an item' do
       let(:handle) { '1234/nothere' }
+
+      let(:solr_data) { { id: 'unrelated' } }
 
       it { is_expected.to have_http_status :not_found }
     end

--- a/spec/controllers/spot/redirect_controller_spec.rb
+++ b/spec/controllers/spot/redirect_controller_spec.rb
@@ -28,5 +28,30 @@ RSpec.describe Spot::RedirectController do
 
       it { is_expected.to have_http_status :not_found }
     end
+
+    context 'when the item is a collection' do
+      let(:collection_id) { 'colabc123' }
+      let(:collection_solr_data) do
+        {
+          id: collection_id,
+          has_model_ssim: ['Collection'],
+          identifier_ssim: ["url:#{url}"]
+        }
+      end
+
+      let(:url) { 'http://cool.website.org' }
+
+      # collections require a lot more setup, so we'll just fake it by putting the data in solr
+      before do
+        ActiveFedora::SolrService.add(collection_solr_data)
+        ActiveFedora::SolrService.commit
+      end
+
+      after do
+        ActiveFedora::SolrService.delete_by_id(collection_id)
+      end
+
+      it { is_expected.to redirect_to hyrax_collection_path(collection_id)}
+    end
   end
 end

--- a/spec/controllers/spot/redirect_controller_spec.rb
+++ b/spec/controllers/spot/redirect_controller_spec.rb
@@ -5,14 +5,16 @@ RSpec.describe Spot::RedirectController do
   describe '#show' do
     subject { get :show, params: { url: url } }
 
+    let(:solr_service) { ActiveFedora::SolrService }
+
     before do
-      ActiveFedora::SolrService.add(solr_data)
-      ActiveFedora::SolrService.commit
+      solr_service.add(solr_data)
+      solr_service.commit
     end
 
     after do
-      ActiveFedora::SolrService.delete(id: solr_data[:id])
-      ActiveFedora::SolrService.commit
+      solr_service.delete(id: solr_data[:id])
+      solr_service.commit
     end
 
     context 'when a matching URL exists' do


### PR DESCRIPTION
abstracts out redirection logic from spot/redirect_controller and spot/handle_controller so that Collection urls are being called from `Hyrax::Engine` and the rest are called from the app (fixes a bug where sending 'hyrax/collections' controller params would result in "no route matched" errors)

## todo

- [x] needs tests

-----

closes #403 