### PR TITLE
lafayette_instructors authority for StudentWork#advisor

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -99,3 +99,8 @@ URL_HOST=
 # ex.
 #   http://ldr.lafayette.edu/iiif/2
 IIIF_BASE_URL=
+
+# Key for accessing the Lafayette Web Data Services API
+# (see app/services/spot/lafayette_wds_service.rb
+#  and app/services/spot/lafayette_instructors_authority_service.rb)
+LAFAYETTE_WDS_API_KEY=

--- a/app/assets/javascripts/hyrax/autocomplete.es6
+++ b/app/assets/javascripts/hyrax/autocomplete.es6
@@ -24,6 +24,7 @@ export default class Autocomplete {
           url)
         break
       case 'academic_department':
+      case 'advisor':
       case 'division':
       case 'language':
       case 'location':

--- a/app/forms/hyrax/student_work_form.rb
+++ b/app/forms/hyrax/student_work_form.rb
@@ -2,7 +2,7 @@
 module Hyrax
   class StudentWorkForm < ::Spot::Forms::WorkForm
     singular_form_fields :title, :description, :date, :date_available, :rights_statement, :abstract
-    transforms_nested_fields_for :academic_department, :division, :language
+    transforms_nested_fields_for :academic_department, :division, :language, :advisor
 
     self.model_class = ::StudentWork
     self.required_fields = [

--- a/app/indexers/student_work_indexer.rb
+++ b/app/indexers/student_work_indexer.rb
@@ -1,4 +1,19 @@
 # frozen_string_literal: true
 class StudentWorkIndexer < BaseIndexer
   self.sortable_date_property = :date
+
+  def generate_solr_document
+    super.tap do |solr_doc|
+      solr_doc['advisor_ssim'] = object.advisor.to_a
+      solr_doc['advisor_label_ssim'] = object.advisor.map { |lnumber| advisor_label_from(lnumber: lnumber) }
+    end
+  end
+
+  private
+
+    def advisor_label_from(lnumber:)
+      return lnumber unless lnumber =~ /^L\d{8}$/
+
+      Spot::LafayetteInstructorsAuthorityService.label_for(lnumber: lnumber)
+    end
 end

--- a/app/jobs/spot/load_lafayette_instructors_authority_job.rb
+++ b/app/jobs/spot/load_lafayette_instructors_authority_job.rb
@@ -4,7 +4,7 @@ module Spot
     # @todo We should probably query the current academic term and cache it (for a month?)
     #       before loading the instructors. For now, we'll stuff it with Winter 2021.
     def perform
-      Spot::LafayetteInstructorsAuthorityService.load(term: '202103')
+      Spot::LafayetteInstructorsAuthorityService.load(term: '202110')
     end
   end
 end

--- a/app/jobs/spot/load_lafayette_instructors_authority_job.rb
+++ b/app/jobs/spot/load_lafayette_instructors_authority_job.rb
@@ -3,8 +3,8 @@ module Spot
   class LoadLafayetteInstructorsAuthorityJob < ::ApplicationJob
     # @todo We should probably query the current academic term and cache it (for a month?)
     #       before loading the instructors. For now, we'll stuff it with Winter 2021.
-    def perform
-      Spot::LafayetteInstructorsAuthorityService.load(term: '202110')
+    def perform(term: Time.zone.today.strftime('%Y10'))
+      Spot::LafayetteInstructorsAuthorityService.load(term: term)
     end
   end
 end

--- a/app/jobs/spot/load_lafayette_instructors_authority_job.rb
+++ b/app/jobs/spot/load_lafayette_instructors_authority_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Spot
+  class LoadLafayetteInstructorsAuthorityJob < ::ApplicationJob
+    # @todo We should probably query the current academic term and cache it (for a month?)
+    #       before loading the instructors. For now, we'll stuff it with Winter 2021.
+    def perform
+      Spot::LafayetteInstructorsAuthorityService.load(term: '202103')
+    end
+  end
+end

--- a/app/models/concerns/spot/solr_document_attributes.rb
+++ b/app/models/concerns/spot/solr_document_attributes.rb
@@ -71,6 +71,7 @@ module Spot
       # StudentWork properties
       attribute :access_note,            ::Blacklight::Types::Array,  'access_note_tesim'
       attribute :advisor,                ::Blacklight::Types::Array,  'advisor_ssim'
+      attribute :advisor_label,          ::Blacklight::Types::Array,  'advisor_label_ssim'
 
       # FileSet properties
       attribute :file_set_ids,           ::Blacklight::Types::Array,  'file_set_ids_ssim'

--- a/app/presenters/hyrax/student_work_presenter.rb
+++ b/app/presenters/hyrax/student_work_presenter.rb
@@ -3,7 +3,7 @@ module Hyrax
   class StudentWorkPresenter < Spot::BasePresenter
     humanize_date_fields :date, :date_available
 
-    delegate :abstract, :access_note, :advisor, :bibliographic_citation,
+    delegate :abstract, :access_note, :advisor, :advisor_label, :bibliographic_citation,
              :academic_department, :division, :organization, to: :solr_document
   end
 end

--- a/app/services/spot/lafayette_instructors_authority_service.rb
+++ b/app/services/spot/lafayette_instructors_authority_service.rb
@@ -14,8 +14,8 @@ module Spot
 
     class UserNotFoundError < StandardError; end
 
-    def self.label_for(lnumber, api_key: ENV.fetch(API_ENV_KEY))
-      new(api_key: api_key).label_for(lnumber)
+    def self.label_for(lnumber:, api_key: ENV.fetch(API_ENV_KEY))
+      new(api_key: api_key).label_for(lnumber: lnumber)
     end
 
     # @params [Hash] options

--- a/app/services/spot/lafayette_instructors_authority_service.rb
+++ b/app/services/spot/lafayette_instructors_authority_service.rb
@@ -9,7 +9,7 @@ module Spot
   #   Spot::LafayetteInstructorsAuthorityService.load(term: '202130', api_key: ENV.fetch('LAFAYETTE_WDS_API_KEY'))
   #   # => [#<Qa::LocalAuthorityEntry id: 1, local_authority_id: 1...>...]
   class LafayetteInstructorsAuthorityService
-    API_ENV_KEY = 'LAFAYETTE_WDS_API_KEY'.freeze
+    API_ENV_KEY = 'LAFAYETTE_WDS_API_KEY'
 
     def self.label_for(lnumber, api_key: ENV.fetch(API_ENV_KEY))
       new(api_key: api_key).label_for(lnumber)
@@ -36,13 +36,11 @@ module Spot
     # @option [String] term
     #   Termcode to retrieve instructors for (ex. '202130')
     # @return [Array<Qa::LocalAuthorityEntry>]
+    # @todo how should we handle exceptions?
     def load(term:)
       instructors_for(term: term).map do |instructor|
         find_or_create_entry(label: instructor_label(instructor), value: instructor_id(instructor))
       end
-    # rescue Spot::LafayetteWdsService::SearchError => e
-    #   # do something?
-    #   []
     end
 
     def label_for(lnumber:)

--- a/app/services/spot/lafayette_instructors_authority_service.rb
+++ b/app/services/spot/lafayette_instructors_authority_service.rb
@@ -10,6 +10,9 @@ module Spot
   #   # => [#<Qa::LocalAuthorityEntry id: 1, local_authority_id: 1...>...]
   class LafayetteInstructorsAuthorityService
     API_ENV_KEY = 'LAFAYETTE_WDS_API_KEY'
+    SUBAUTHORITY_NAME = 'lafayette_instructors'
+
+    class UserNotFoundError < StandardError; end
 
     def self.label_for(lnumber, api_key: ENV.fetch(API_ENV_KEY))
       new(api_key: api_key).label_for(lnumber)
@@ -48,7 +51,7 @@ module Spot
       return stored.label unless stored.nil?
 
       remote = wds_service.person(lnumber: lnumber)
-      raise(ArgumentError, "No user found with L-number: #{lnumber}") unless remote.present?
+      raise(UserNotFoundError, "No user found with L-number: #{lnumber}") if remote == false
 
       find_or_create_entry(label: instructor_label(remote), value: instructor_id(remote)).label
     end
@@ -84,7 +87,7 @@ module Spot
       end
 
       def local_authority
-        @local_authority ||= Qa::LocalAuthority.find_or_create_by(name: 'lafayette_instructors')
+        @local_authority ||= Qa::LocalAuthority.find_or_create_by(name: SUBAUTHORITY_NAME)
       end
 
       def wds_service

--- a/app/services/spot/lafayette_instructors_authority_service.rb
+++ b/app/services/spot/lafayette_instructors_authority_service.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+module Spot
+  # Service for loading Instructors from Lafayette's Web Data Services API into
+  # a QuestioningAuthority table-based LocalAuthority. Separating this from the
+  # {Spot::LafayetteWdsService} in the event that we need to swap out querying
+  # the API for something else (maybe a regular CSV dump).
+  #
+  # @example Loading instructors for the Winter 2021 term
+  #   Spot::LafayetteInstructorsAuthorityService.load(term: '202130', api_key: ENV.fetch('LAFAYETTE_WDS_API_KEY'))
+  #   # => [#<Qa::LocalAuthorityEntry id: 1, local_authority_id: 1...>...]
+  class LafayetteInstructorsAuthorityService
+    API_ENV_KEY = 'LAFAYETTE_WDS_API_KEY'.freeze
+
+    def self.label_for(lnumber, api_key: ENV.fetch(API_ENV_KEY))
+      new(api_key: api_key).label_for(lnumber)
+    end
+
+    # @params [Hash] options
+    # @option [String] term
+    #   Termcode to retrieve instructors for (ex. '202130')
+    # @option [String] api_key
+    #   API key to use
+    # @return [Array<Qa::LocalAuthorityEntry>]
+    def self.load(term:, api_key: ENV.fetch(API_ENV_KEY))
+      new(api_key: api_key).load(term: term)
+    end
+
+    # @params [Hash] options
+    # @option [String] api_key
+    #   API key to use (defaults to LAFAYETTE_WDS_API_KEY environment variable)
+    def initialize(api_key: ENV.fetch(API_ENV_KEY))
+      @api_key = api_key
+    end
+
+    # @params [Hash] options
+    # @option [String] term
+    #   Termcode to retrieve instructors for (ex. '202130')
+    # @return [Array<Qa::LocalAuthorityEntry>]
+    def load(term:)
+      instructors_for(term: term).map do |instructor|
+        find_or_create_entry(label: instructor_label(instructor), value: instructor_id(instructor))
+      end
+    # rescue Spot::LafayetteWdsService::SearchError => e
+    #   # do something?
+    #   []
+    end
+
+    def label_for(lnumber:)
+      stored = Qa::LocalAuthorityEntry.find_by(uri: lnumber, local_authority: local_authority)
+      return stored.label unless stored.nil?
+
+      remote = wds_service.person(lnumber: lnumber)
+      raise(ArgumentError, "No user found with L-number: #{lnumber}") unless remote.present?
+
+      find_or_create_entry(label: instructor_label(remote), value: instructor_id(remote)).label
+    end
+
+    # prevent our api_key from leaking
+    #
+    # @return [String]
+    def inspect
+      "#<#{self.class.name}:#{object_id}>"
+    end
+
+    private
+
+      attr_reader :api_key
+
+      def find_or_create_entry(label:, value:)
+        entry = Qa::LocalAuthorityEntry.find_or_initialize_by(local_authority: local_authority, uri: value)
+        entry.label = label
+        entry.save
+        entry
+      end
+
+      def instructors_for(term:)
+        wds_service.instructors(term: term)
+      end
+
+      def instructor_id(instructor)
+        instructor['LNUMBER']
+      end
+
+      def instructor_label(instructor)
+        "#{instructor['LAST_NAME']}, #{instructor['FIRST_NAME']}"
+      end
+
+      def local_authority
+        @local_authority ||= Qa::LocalAuthority.find_or_create_by(name: 'lafayette_instructors')
+      end
+
+      def wds_service
+        Spot::LafayetteWdsService.new(api_key: api_key)
+      end
+  end
+end

--- a/app/services/spot/lafayette_wds_service.rb
+++ b/app/services/spot/lafayette_wds_service.rb
@@ -82,7 +82,7 @@ module Spot
       params[:term] = code unless code.nil?
       params[:year] = year unless year.nil?
 
-      fetch_and_parse('termInfo', params)
+      fetch_and_parse('/termInfo', params)
     end
 
     # prevent our api_key from leaking
@@ -113,17 +113,14 @@ module Spot
         response = client.get(path, params)
         parsed = JSON.parse(response.body)
 
-        case response.status
-        when 200
-          parsed
-        else
-          msg = parsed.fetch('message', 'An unknown error occurred')
-          raise(SearchError, msg)
-        end
+        return parsed if response.status == 200
+
+        msg = parsed.fetch('message', 'An unknown error occurred')
+        raise(SearchError, msg)
       end
 
       def web_data_services_url
-        ENV.fetch('LAFAYETTE_WDS_URL', 'https://webdataservices.lafayette.edu')
+        ENV.fetch('LAFAYETTE_WDS_URL')
       end
   end
 end

--- a/app/services/spot/lafayette_wds_service.rb
+++ b/app/services/spot/lafayette_wds_service.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+module Spot
+  # Service wrapper for interacting with Lafayette's Web Data Services API endpoint.
+  # Endpoint methods are added as needed. Currently supports:
+  #   - getInstructors (see {#instructors})
+  #   - getPerson (see {#person})
+  #   - getTermInfo (see {#term})
+  #
+  # @see https://webdataservices.lafayette.edu
+  class LafayetteWdsService
+    class SearchError < StandardError; end
+
+    # Helper class method wrapper around #instructors
+    # @see {#instructors}
+    def self.instructors(api_key:, term:)
+      new(api_key: api_key).instructors(term: term)
+    end
+
+    # Helper class method wrapper around #person
+    # @see {#person}
+    def self.person(api_key:, username: nil, email: nil, lnumber: nil)
+      new(api_key: api_key).person(username: username, email: email, lnumber: lnumber)
+    end
+
+    # Helper class method wrapper around #term
+    # @see {#term}
+    def self.term(api_key:, code: nil, year: nil)
+      new(api_key: api_key).term(code: code, year: year)
+    end
+
+    # @params [Hash] options
+    # @option [String] api_key
+    def initialize(api_key:)
+      @api_key = api_key
+    end
+
+    # Per WDS API documentation: "Returns a list of instructors teaching at least one course in the given term."
+    #
+    # @params [Hash] options
+    # @option [String] term
+    #   Code for the term to query against. Ex. `"202103"`
+    # @return [Array<Hash<String => String>>]
+    def instructors(term:)
+      fetch_and_parse('/instructors', term: term)
+    end
+
+    # Searches the Directory for a user based on their username, email, or
+    # L-number. Calling without parameters will return a list of all Directory
+    # users. When multiple results are found, an Array is returned, when
+    # a single result is found, that Hash is returned. When no matching
+    # users are found, this returns `false`.
+    #
+    # @params [Hash] options
+    # @option [String] username
+    #   A user's netid (ex. `"malantoa"`)
+    # @option [String] email
+    #   A user's email address (ex. `"malantoa@lafayette.edu")
+    # @option [String] lnumber
+    #   A user's L-number (ex. `"L00000000"`)
+    # @return [Array<Hash<String => String>>, Hash<String => String>, false]
+    def person(username: nil, email: nil, lnumber: nil)
+      params = {}
+      params[:lnumber] = lnumber unless lnumber.nil?
+      params[:email] = email unless email.nil?
+      params[:username] = username unless username.nil?
+
+      fetch_and_parse('/person', params)
+    end
+
+    # Queries WDS for information about a term by providing a termcode
+    # or an encompassing year.
+    #
+    # @params [Hash] options
+    # @option [String] code
+    #   Termcode to search for
+    # @option [String] year
+    #   Year to search for
+    # @return [Hash<String => String>, false]
+    # @todo Currently untested
+    def term(code: nil, year: nil)
+      params = {}
+      params[:term] = code unless code.nil?
+      params[:year] = year unless year.nil?
+
+      fetch_and_parse('termInfo', params)
+    end
+
+    # prevent our api_key from leaking
+    #
+    # @return [String]
+    def inspect
+      "#<#{self.class.name}:#{object_id}>"
+    end
+
+    private
+
+      attr_reader :api_key
+
+      # Faraday connection we'll use for making requests
+      def client
+        @client ||= Faraday::Connection.new(url: web_data_services_url, headers: client_headers)
+      end
+
+      def client_headers
+        {
+          'Accept' => 'application/json',
+          'apikey' => api_key,
+          'User-Agent' => 'Lafayette Digital Repository / https://github.com/LafayetteCollegeLibraries/spot'
+        }
+      end
+
+      def fetch_and_parse(path, params)
+        response = client.get(path, params)
+        parsed = JSON.parse(response.body)
+
+        case response.status
+        when 200
+          parsed
+        else
+          msg = parsed.fetch('message', 'An unknown error occurred')
+          raise(SearchError, msg)
+        end
+      end
+
+      def web_data_services_url
+        ENV.fetch('LAFAYETTE_WDS_URL', 'https://webdataservices.lafayette.edu')
+      end
+  end
+end

--- a/app/views/hyrax/student_works/_metadata.html.erb
+++ b/app/views/hyrax/student_works/_metadata.html.erb
@@ -3,7 +3,9 @@
     <tbody>
       <%= presenter.attribute_to_html(:title) %>
       <%= presenter.attribute_to_html(:creator) %>
-      <%= presenter.attribute_to_html(:advisor) %>
+      <%= presenter.attribute_to_html(:advisor_label,
+                                      render_as: :faceted,
+                                      search_field: :advisor_label_ssim) %>
       <%= presenter.attribute_to_html(:academic_department, render_as: :faceted) %>
       <%= presenter.attribute_to_html(:division, render_as: :faceted) %>
       <%= presenter.attribute_to_html(:description) %>

--- a/app/views/hyrax/student_works/_student_work.html.erb
+++ b/app/views/hyrax/student_works/_student_work.html.erb
@@ -1,0 +1,2 @@
+<%# This is a search result item view %>
+<%= render 'catalog/document', document: student_work, document_counter: student_work_counter %>

--- a/app/views/student_works/edit_fields/_advisor.html.erb
+++ b/app/views/student_works/edit_fields/_advisor.html.erb
@@ -1,0 +1,19 @@
+<%=
+  f.input :advisor,
+          as: :local_controlled_vocabulary,
+          placeholder: 'Search for a Faculty Member',
+          input_html: {
+            class: 'form-control',
+            data: {
+              'autocomplete-url' => '/authorities/search/local/lafayette_instructors',
+              'autocomplete' => 'advisor'
+            },
+          },
+          wrapper_html: {
+            data: {
+              'autocomplete-url' => '/authorities/search/local/lafayette_instructors',
+              'field-name' => 'advisor'
+            }
+          },
+          required: f.object.required?(:advisor)
+%>

--- a/config/initializers/qa.rb
+++ b/config/initializers/qa.rb
@@ -16,3 +16,5 @@ solr_suggestion_authorities = %w[
 solr_suggestion_authorities.each do |subauth|
   Qa::Authorities::Local.register_subauthority(subauth, 'Qa::Authorities::SolrSuggest')
 end
+
+Qa::Authorities::Local.register_subauthority('lafayette_instructors', 'Qa::Authorities::Local::TableBasedAuthority')

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -8,6 +8,7 @@ en:
           title: Admin Facets
       fields:
         academic_department: Academic Department
+        advisor_label: Advisor
         author: Author
         bibliographic_citation: Bibliographic Citation
         contributor: Contributor

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -17,3 +17,8 @@ update_solr_suggest_dictionaries:
   cron: '0 * * * *'
   class: Spot::UpdateSolrSuggestDictionariesJob
   queue: default
+
+load_lafayette_instructors:
+  cron: '0 0 * * 0'
+  class: Spot::LoadLafayetteInstructorsAuthorityJob
+  queue: default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,26 +15,8 @@ services:
       - uploads:/spot/uploads
     ports:
       - "3000:3000"
-    environment: &dev_environment
-      CAS_BASE_URL: ''
-      DEV_USER: dss@lafayette.edu
-      FEDORA_URL: http://fedora:8080/rest
-      FEDORA_TEST_URL: http://fedora:8080/rest
-      FITS_SERVLET_URL: http://fitsservlet:8080/fits
-      HYRAX_DERIVATIVES_PATH: "/spot/derivatives" # env key is hyrax >= 3
-      HYRAX_DERIVATIVE_PATH: "/spot/derivatives"  # env key is hyrax < 3
-      HYRAX_UPLOAD_PATH: "/spot/uploads"
-      IIIF_BASE_URL: http://localhost:8182/iiif/2
-      PSQL_PASSWORD: spot_dev_pw
-      PSQL_HOST: db
-      PSQL_USER: spot_dev_user
-      RAILS_ENV: development
-      RAILS_LOG_TO_STDOUT: 'true'
-      RAILS_SERVE_STATIC_FILES: '1'
-      REDIS_URL: redis://redis:6379
-      SOLR_URL: http://solr:8983/solr/spot-development
-      SOLR_TEST_URL: http://solr:8983/solr/spot-test
-      URL_HOST: http://localhost:3000
+    env_file:
+      - .env.local
     restart: always
     entrypoint: ["bin/spot-dev-entrypoint.sh"]
     command: ["bundle", "exec", "rails", "s", "-p", "3000", "-b", "0.0.0.0"]
@@ -82,8 +64,8 @@ services:
     build:
       context: .
       target: spot-app
-    environment:
-      <<: *dev_environment
+    env_file:
+      - .env.local
     volumes:
       - gem_storage:/spot/vendor
     entrypoint: ["sh", "-c"]
@@ -128,8 +110,8 @@ services:
     build:
       context: .
       target: spot-worker
-    environment:
-      <<: *dev_environment
+    env_file:
+      - .env.local
     ports:
       - "3003:3000"
     command: ["bundle", "exec", "sidekiq"]

--- a/lib/tasks/spot/authorities.rake
+++ b/lib/tasks/spot/authorities.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require_relative '../../../config/boot'
+namespace :spot do
+  namespace :authorities do
+    desc 'Load Instructors from Lafayette database'
+    task :load_instructors, [:termcode] => :environment do |_t, args|
+      args.with_defaults(termcode: Time.zone.today.strftime('%Y10'))
+
+      Spot::LoadLafayetteInstructorsAuthorityJob.perform_now(term: args.termcode)
+    end
+  end
+end

--- a/spec/features/create_student_work_spec.rb
+++ b/spec/features/create_student_work_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Create a StudentWork', :clean, :js do
       fill_in 'student_work_creator', with: attrs[:creator].first
       expect(page).to have_css '.student_work_creator .controls-add-text'
 
-      fill_in 'student_work_advisor', with: attrs[:advisor].first
+      fill_in_autocomplete '.student_work_advisor', with: attrs[:advisor].first
       expect(page).to have_css '.student_work_advisor .controls-add-text'
 
       fill_in_autocomplete '.student_work_academic_department', with: 'Libraries'

--- a/spec/jobs/spot/load_lafayette_instructors_authority_job_spec.rb
+++ b/spec/jobs/spot/load_lafayette_instructors_authority_job_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+RSpec.describe Spot::LoadLafayetteInstructorsAuthorityJob do
+  before do
+    allow(Spot::LafayetteInstructorsAuthorityService).to receive(:load).with(term: '202110')
+  end
+
+  it 'calls the LafayetteInstructorsAuthorityService' do
+    described_class.perform_now
+
+    expect(Spot::LafayetteInstructorsAuthorityService).to have_received(:load).with(term: '202110').exactly(1).time
+  end
+end

--- a/spec/services/spot/lafayette_instructors_authority_service_spec.rb
+++ b/spec/services/spot/lafayette_instructors_authority_service_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+RSpec.describe Spot::LafayetteInstructorsAuthorityService do
+  before do
+    stub_env(described_class::API_ENV_KEY, api_key)
+
+    allow(Spot::LafayetteWdsService).to receive(:new).with(api_key: api_key).and_return(wds_service)
+  end
+
+  after do
+    Qa::LocalAuthorityEntry.destroy_all
+  end
+
+  let(:local_auth) { Qa::LocalAuthority.find_or_create_by(name: described_class::SUBAUTHORITY_NAME) }
+  let(:api_key) { 'abc123def!' }
+  let(:wds_service) { instance_double(Spot::LafayetteWdsService) }
+
+  describe '.label_for' do
+    subject { described_class.label_for(lnumber: lnumber) }
+
+    before do
+      allow(wds_service).to receive(:person).with(lnumber: lnumber).and_return(wds_response)
+    end
+
+    let(:lnumber) { 'L00000000' }
+    let(:last_name) { 'Malantonio' }
+    let(:first_name) { 'Anna' }
+    let(:label) { "#{last_name}, #{first_name}" }
+    let(:local_entry) { Qa::LocalAuthorityEntry.find_or_create_by(local_authority: local_auth, uri: lnumber, label: label) }
+    let(:wds_response) do
+      {
+        'LNUMBER' => lnumber,
+        'LAST_NAME' => last_name,
+        'FIRST_NAME' => first_name
+      }
+    end
+
+    context 'when an entry exists in the database' do
+      before do
+        local_entry
+        described_class.label_for(lnumber: lnumber)
+      end
+
+      it { is_expected.to eq label }
+
+      it 'does not call the wds_service' do
+        expect(wds_service).not_to have_received(:person)
+      end
+    end
+
+    context 'when an entry does not exist in the database' do
+      before { described_class.label_for(lnumber: lnumber) }
+
+      it { is_expected.to eq label }
+
+      it 'calls the wds_service' do
+        described_class.label_for(lnumber: lnumber)
+        expect(wds_service).to have_received(:person).with(lnumber: lnumber).exactly(1).time
+      end
+    end
+
+    context 'when an L-number does not match' do
+      let(:wds_response) { false }
+
+      it 'raises an UserNotFoundError' do
+        expect { described_class.label_for(lnumber: lnumber) }
+          .to raise_error(described_class::UserNotFoundError, "No user found with L-number: #{lnumber}")
+      end
+    end
+  end
+
+  describe '.load' do
+    before do
+      allow(wds_service).to receive(:instructors).with(term: term).and_return(instructors)
+    end
+
+    let(:term) { '202110' }
+    let(:instructors) do
+      [
+        { 'LNUMBER' => 'L00000000', 'LAST_NAME' => 'Malantonio', 'FIRST_NAME' => 'Anna' },
+        { 'LNUMBER' => 'L10000000', 'LAST_NAME' => 'Lafayette', 'FIRST_NAME' => 'Mark' },
+        { 'LNUMBER' => 'L20000000', 'LAST_NAME' => 'Noodleman', 'FIRST_NAME' => 'Irene' }
+      ]
+    end
+
+    it 'adds Qa::LocalAuthorityEntries for each returned person' do
+      expect(described_class.load(term: term).map(&:uri)).to eq(instructors.map { |i| i['LNUMBER'] })
+    end
+
+    context 'when an entry already exists' do
+      before do
+        entry = instructors.first
+        Qa::LocalAuthorityEntry.find_or_create_by(local_authority: local_auth, uri: entry['LNUMBER'], label: "#{entry['LAST_NAME']}, #{entry['FIRST_NAME']}")
+      end
+
+      it 'leaves it be' do
+        expect(Qa::LocalAuthorityEntry.where(local_authority: local_auth).count).to eq 1
+        expect(described_class.load(term: term).count).to eq instructors.count
+      end
+    end
+  end
+
+  describe '#inspect' do
+    subject { described_class.new(api_key: api_key).inspect }
+
+    it { is_expected.not_to include(api_key) }
+  end
+end

--- a/spec/services/spot/lafayette_wds_service_spec.rb
+++ b/spec/services/spot/lafayette_wds_service_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+RSpec.describe Spot::LafayetteWdsService do
+  before do
+    stub_env('LAFAYETTE_WDS_URL', wds_host)
+
+    stub_request(:get, search_uri)
+      .with(headers: { 'Accept' => 'application/json', 'apikey' => api_key })
+      .to_return(body: JSON.dump(response_body), status: status_code)
+  end
+
+  let(:api_key) { 'abc123def!' }
+  let(:wds_host) { 'https://webdataservices.lafayette.edu' }
+  let(:response_body) { {} }
+  let(:status_code) { 200 }
+
+  describe '.instructors' do
+    subject { described_class.instructors(api_key: api_key, term: term) }
+
+    let(:search_uri) { "#{wds_host}/instructors?term=#{term}" }
+    let(:term) { '202130' }
+
+    context 'when a term is valid' do
+      let(:response_body) do
+        [
+          { 'LNUMBER' => 'L10000000', 'LAST_NAME' => 'Lafayette', 'FIRST_NAME' => 'Mark' },
+          { 'LNUMBER' => 'L20000000', 'LAST_NAME' => 'Faculty', 'FIRST_NAME' => 'Joan' }
+        ]
+      end
+
+      it { is_expected.to eq response_body }
+    end
+
+    context 'when an error occurs' do
+      let(:status_code) { 403 }
+      let(:response_body) { { 'message' => 'Username could not be found' } }
+
+      it 'raises a SearchError' do
+        expect { described_class.instructors(api_key: api_key, term: term) }
+          .to raise_error(Spot::LafayetteWdsService::SearchError, 'Username could not be found')
+      end
+    end
+  end
+
+  describe '.person' do
+    subject { described_class.person(api_key: api_key, username: username, email: email, lnumber: lnumber) }
+
+    let(:uri_base) { "#{wds_host}/person" }
+    let(:username) { nil }
+    let(:email) { nil }
+    let(:lnumber) { nil }
+    let(:response_body) do
+      { 'LNUMBER' => 'L00000000', 'LAST_NAME' => 'Malantonio', 'FIRST_NAME' => 'Anna' }
+    end
+
+    context 'without any parameters' do
+      let(:search_uri) { uri_base }
+      let(:response_body) do
+        [
+          { 'LNUMBER' => 'L10000000', 'LAST_NAME' => 'Lafayette', 'FIRST_NAME' => 'Mark' },
+          { 'LNUMBER' => 'L20000000', 'LAST_NAME' => 'Faculty', 'FIRST_NAME' => 'Joan' },
+          { 'LNUMBER' => 'L30000000', 'LAST_NAME' => 'Student', 'FIRST_NAME' => 'Al Starr' }
+        ]
+      end
+
+      it { is_expected.to eq response_body }
+    end
+
+    context 'when using :username to search' do
+      let(:username) { 'malantoa' }
+      let(:search_uri) { "#{uri_base}?username=#{username}" }
+
+      it { is_expected.to eq response_body }
+    end
+
+    context 'when using :email to search' do
+      let(:email) { 'malantoa@lafayette.edu' }
+      let(:search_uri) { "#{uri_base}?email=#{email}" }
+
+      it { is_expected.to eq response_body }
+    end
+
+    context 'when using :lnumber to search' do
+      let(:lnumber) { 'L00000000' }
+      let(:search_uri) { "#{uri_base}?lnumber=#{lnumber}" }
+
+      it { is_expected.to eq response_body }
+    end
+
+    context 'when a result is not found' do
+      let(:username) { 'nope' }
+      let(:response_body) { false }
+      let(:search_uri) { "#{uri_base}?username=#{username}" }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  # @todo - these are based on assumptions from reading the documentation.
+  #         we're going to need to actually test this endpoint or exclude
+  #         it from the service.
+  describe '.term' do
+    subject { described_class.term(api_key: api_key, code: code, year: year) }
+
+    let(:code) { nil }
+    let(:year) { nil }
+
+    context 'when using :code to search' do
+      let(:search_uri) { "#{wds_host}/termInfo?term=#{code}" }
+      let(:code) { '201710' }
+      let(:response_body) { { "TERM_CODE" => "201710", "START_DATE" => "28-AUG-17", "END_DATE" => "18-DEC-17" } }
+
+      it { is_expected.to eq response_body }
+    end
+
+    context 'when using :year to search' do
+      let(:search_uri) { "#{wds_host}/termInfo?year=#{year}" }
+      let(:year) { '2017' }
+      let(:response_body) do
+        [{ "TERM_CODE" => "201710", "START_DATE" => "28-AUG-17", "END_DATE" => "18-DEC-17" }]
+      end
+
+      it { is_expected.to eq response_body }
+    end
+  end
+end


### PR DESCRIPTION
adds a QuestioningAuthority `Local::TableBasedAuthority` for Lafayette Instructors to be used with `StudentWork#advisor`. this authority is meant to be populated by querying a Lafayette Web Data Services API endpoint for a list of instructors and adding entries to the table, using a person's L-number as the URI.

When indexed, `advisor_label_ssim` is populated with a string like `"#{instructor['LAST_NAME']}, #{instructor['FIRST_NAME']}"`. This is used on `StudentWork#show` pages.