### PR TITLE
use https for local dev

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -104,3 +104,6 @@ IIIF_BASE_URL=
 # (see app/services/spot/lafayette_wds_service.rb
 #  and app/services/spot/lafayette_instructors_authority_service.rb)
 LAFAYETTE_WDS_API_KEY=
+
+# For local development, creates Admin accounts for each email address listed (comma separated)
+DEV_ADMIN_USERS=

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apk --no-cache upgrade && \
         yarn \
         zip \
         postgresql postgresql-dev \
-        git
+        git \
+        openssl
 
 # let's not run this as root
 # (taken from hyrax's Dockerfile)
@@ -62,6 +63,7 @@ FROM spot-base as spot-app
 COPY config/uv config/uv
 
 RUN yarn install
+CMD ["bundle", "exec", "rails", "server", "-u", "puma", "-b", "ssl://0.0.0.0:443?key=/trustee_minutes/tmp/ssl/application.key&cert=/trustee_minutes/tmp/ssl/application.crt"]
 
 # precompile assets
 # RUN DATABASE_URL="postgres://fake" SECRET_KEY_BASE="secret-shh" bundle exec rake assets:precompile

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,6 @@ class ApplicationController < ActionController::Base
   with_themed_layout '1_column'
 
   before_action :store_user_location!, if: :storable_location?
-  before_action :log_in_as_dev_user!
 
   # from Blacklight: 'Discarding flash messages on XHR requests is deprecated.'
   skip_after_action :discard_flash_if_xhr
@@ -66,16 +65,6 @@ class ApplicationController < ActionController::Base
         wants.html { redirect_to main_app.new_user_session_path }
         wants.json { render_json_response(response_type: :unauthorized, message: json_message) }
       end
-    end
-
-    # Bypasses CAS authentication (development only)
-    # :nocov:
-    #
-    # @return [void]
-    def log_in_as_dev_user!
-      return unless Rails.env.development? && (current_user || ENV.key?('DEV_USER'))
-      user = User.find_by(email: ENV['DEV_USER'])
-      sign_in(user) unless user.nil?
     end
 
     # Borrowed from the Devise wiki:

--- a/bin/spot-dev-entrypoint.sh
+++ b/bin/spot-dev-entrypoint.sh
@@ -16,6 +16,14 @@ cp "$app_root/config/uv/uv-config-development.json" "$app_root/public/uv/uv-conf
 mkdir -p "$app_root/tmp/export"
 mkdir -p "$app_root/tmp/pids"
 mkdir -p "$HYRAX_DERIVATIVES_PATH"
+mkdir -p "$app_root/tmp/ssl"
+
+# Generate a local SSL certificate so that we can run Rails on 443
+echo "generating ssl certificate"
+openssl req -x509 -nodes -newkey rsa:4096 \
+    -keyout "$app_root/tmp/ssl/application.key" \
+    -out "$app_root/tmp/ssl/application.crt" \
+    -subj "/C=US/ST=Pennsylvania/L=Easton/O=Lafayette College/OU=ITS/CN=${APPLICATION_FQDN}"
 
 rm -f tmp/pids/server.pid
 

--- a/bin/spot-entrypoint.sh
+++ b/bin/spot-entrypoint.sh
@@ -1,13 +1,25 @@
 #!/bin/sh
 set -e
 
+app_root="/spot"
+
 # we're not copying over tmp directories, so we need to ensure that
 # they exist on the the docker side, otherwise derivatives etc.
 # won't be generated.
-mkdir -p tmp/export
-mkdir -p tmp/pids
-mkdir -p "${HYRAX_CACHE_PATH:-/spot/tmp/cache}" \
-         "${HYRAX_DERIVATIVES_PATH:-/spot/tmp/derivatives}" \
-         "${HYRAX_UPLOAD_PATH:-/spot/tmp/uploads}" \
+mkdir -p "$app_root/tmp/export"
+mkdir -p "$app_root/tmp/pids"
+mkdir -p "$app_root/tmp/ssl"
+mkdir -p "${HYRAX_CACHE_PATH:-$app_root/tmp/cache}"
+mkdir -p "${HYRAX_DERIVATIVES_PATH:-$app_root/tmp/derivatives}"
+mkdir -p "${HYRAX_UPLOAD_PATH:-$app_root/tmp/uploads}"
+
+# Generate a local SSL certificate so that we can run Rails on 443
+echo "generating ssl certificate"
+openssl req -x509 -nodes -newkey rsa:4096 \
+    -keyout "$app_root/tmp/ssl/application.key" \
+    -out "$app_root/tmp/ssl/application.crt" \
+    -subj "/C=US/ST=Pennsylvania/L=Easton/O=Lafayette College/OU=ITS/CN=${APPLICATION_FQDN}"
+
+rm -f tmp/pids/server.pid
 
 exec "$@"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,14 @@ Rake::Task['hyrax:default_collection_types:create'].invoke
 # local set up: create roles + default collections + deposit user
 Rake::Task['spot:roles:default'].invoke
 Rake::Task['spot:create_deposit_user'].invoke
+
+if ENV['DEV_ADMIN_USERS'].present?
+  admin = Role.find_by(name: 'admin')
+
+  ENV['DEV_ADMIN_USERS'].split(/,\s*/).each do |email|
+    username = email.gsub(/@.+/, '')
+    admin.users << User.find_or_create_by(username: username, email: email)
+  end
+
+  admin.save
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,12 +14,18 @@ services:
       - rails_tmp:/spot/tmp
       - uploads:/spot/uploads
     ports:
-      - "3000:3000"
+      - "443:443"
     env_file:
       - .env.local
     restart: always
     entrypoint: ["bin/spot-dev-entrypoint.sh"]
-    command: ["bundle", "exec", "rails", "s", "-p", "3000", "-b", "0.0.0.0"]
+    command:
+      - "bundle"
+      - "exec"
+      - "rails"
+      - "server"
+      - "-b"
+      - "ssl://0.0.0.0:443?key=/spot/tmp/ssl/application.key&cert=/spot/tmp/ssl/application.crt"
     depends_on:
       - cantaloupe
       - db


### PR DESCRIPTION
generates a locally signed certificate to allow accessing the dev site on port 443. this allows us to spoof the stage domain locally and use the campus' CAS authentication for user accounts. during the `db:seed` task, comma-delimited email addresses found in `ENV['DEV_ADMIN_USERS']` will be added and granted the `admin` role.