### PR TITLE
remove toggle for contextual search results

### DIFF
--- a/app/search_builders/spot/catalog_search_builder.rb
+++ b/app/search_builders/spot/catalog_search_builder.rb
@@ -11,7 +11,7 @@ module Spot
     self.default_processor_chain -= [:show_works_or_works_that_contain_files]
     self.default_processor_chain += [
       :add_advanced_search_to_solr,
-      :conditionally_add_full_text_context
+      :add_full_text_context
     ]
 
     # Adds highlight field params if a query was passed
@@ -19,7 +19,7 @@ module Spot
     #
     # @params [Blacklight::Solr::Request] solr_parameters
     # @return [void]
-    def conditionally_add_full_text_context(params)
+    def add_full_text_context(params)
       return unless blacklight_params[:q].present?
 
       params['hl'] = true

--- a/app/search_builders/spot/catalog_search_builder.rb
+++ b/app/search_builders/spot/catalog_search_builder.rb
@@ -14,26 +14,17 @@ module Spot
       :conditionally_add_full_text_context
     ]
 
-    # Allows us to toggle highlighting on the extracted_text field,
-    # rather than defining the field within the CatalogController.
-    # This way we can preview the behavior first rather than exposing
-    # it and possibly having to remove it for performance reasons.
+    # Adds highlight field params if a query was passed
+    # to the search parameters.
     #
     # @params [Blacklight::Solr::Request] solr_parameters
     # @return [void]
     def conditionally_add_full_text_context(params)
-      return unless display_full_text_context?
+      return unless blacklight_params[:q].present?
 
       params['hl'] = true
       params['hl.fl'] ||= []
       params['hl.fl'] << 'extracted_text_tsimv'
     end
-
-    private
-
-      # @return [true, false]
-      def display_full_text_context?
-        Flipflop.enabled?(:search_result_contextual_match) && blacklight_params[:q].present?
-      end
   end
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,9 +1,3 @@
 # frozen_string_literal: true
 #
 # Add features that can be toggled within +/admin/features+
-
-Flipflop.configure do
-  feature :search_result_contextual_match,
-          default: false,
-          description: 'Show search query in the context of its match on catalog results'
-end

--- a/spec/search_builders/spot/catalog_search_builder_spec.rb
+++ b/spec/search_builders/spot/catalog_search_builder_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe Spot::CatalogSearchBuilder do
 
     it { is_expected.not_to include :show_works_or_works_that_contain_files }
     it { is_expected.to include :add_advanced_search_to_solr }
-    it { is_expected.to include :conditionally_add_full_text_context }
+    it { is_expected.to include :add_full_text_context }
   end
 
-  describe '#conditionally_add_full_text_context' do
+  describe '#add_full_text_context' do
     subject(:context_query) { builder.add_full_text_context(params) }
 
     let(:builder) { described_class.new([]).with(blacklight_params) }

--- a/spec/search_builders/spot/catalog_search_builder_spec.rb
+++ b/spec/search_builders/spot/catalog_search_builder_spec.rb
@@ -9,13 +9,7 @@ RSpec.describe Spot::CatalogSearchBuilder do
   end
 
   describe '#conditionally_add_full_text_context' do
-    subject(:context_query) { builder.conditionally_add_full_text_context(params) }
-
-    before do
-      allow(Flipflop)
-        .to receive(:enabled?)
-        .with(:search_result_contextual_match).and_return(feature_available)
-    end
+    subject(:context_query) { builder.add_full_text_context(params) }
 
     let(:builder) { described_class.new([]).with(blacklight_params) }
     let(:blacklight_params) { { q: 'a cool query' } }
@@ -31,12 +25,6 @@ RSpec.describe Spot::CatalogSearchBuilder do
 
     context 'when the query is empty' do
       let(:blacklight_params) { {} }
-
-      it { is_expected.to be_nil }
-    end
-
-    context 'when the feature is disabled' do
-      let(:feature_available) { false }
 
       it { is_expected.to be_nil }
     end


### PR DESCRIPTION
back in #298 i wanted to have the option to disable contextual search results in case they broke or something funky happened. i think it's safe to say this feature's gonna be around for a while, so let's skip the flipflop check