### PR TITLE
add bibliographic_citation to core md

### DIFF
--- a/app/models/concerns/spot/core_metadata.rb
+++ b/app/models/concerns/spot/core_metadata.rb
@@ -118,11 +118,11 @@ module Spot
       property :title_alternative, predicate: ::RDF::Vocab::DC.alternative do |index|
         index.as :stored_searchable
       end
-      
+     
       # A bibliographic reference for the resource.
       property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation do |index|
         index.as :stored_searchable
-      end 
+      end
     end
   end
 end

--- a/app/models/concerns/spot/core_metadata.rb
+++ b/app/models/concerns/spot/core_metadata.rb
@@ -118,7 +118,7 @@ module Spot
       property :title_alternative, predicate: ::RDF::Vocab::DC.alternative do |index|
         index.as :stored_searchable
       end
-     
+
       # A bibliographic reference for the resource.
       property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation do |index|
         index.as :stored_searchable

--- a/app/models/concerns/spot/core_metadata.rb
+++ b/app/models/concerns/spot/core_metadata.rb
@@ -13,15 +13,11 @@ module Spot
 
     included do
       # Free text, use authorized version if possible.
-      #
-      # @todo metadata application profile has this as non-faceted, remove :facetable ?
       property :contributor, predicate: ::RDF::Vocab::DC11.contributor do |index|
         index.as :stored_searchable, :facetable
       end
 
       # Free text, use authorized version if possible.
-      #
-      # @todo metadata application profile has this as non-faceted, remove :facetable ?
       property :creator, predicate: ::RDF::Vocab::DC11.creator do |index|
         index.as :stored_searchable, :facetable
       end
@@ -122,6 +118,11 @@ module Spot
       property :title_alternative, predicate: ::RDF::Vocab::DC.alternative do |index|
         index.as :stored_searchable
       end
+      
+      # A bibliographic reference for the resource.
+      property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation do |index|
+        index.as :stored_searchable
+      end 
     end
   end
 end

--- a/app/models/concerns/spot/core_metadata.rb
+++ b/app/models/concerns/spot/core_metadata.rb
@@ -12,6 +12,11 @@ module Spot
     extend ActiveSupport::Concern
 
     included do
+      # A bibliographic reference for the resource.
+      property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation do |index|
+        index.as :stored_searchable
+      end
+
       # Free text, use authorized version if possible.
       property :contributor, predicate: ::RDF::Vocab::DC11.contributor do |index|
         index.as :stored_searchable, :facetable
@@ -116,11 +121,6 @@ module Spot
 
       # Other forms of the title, e.g. for versions of the title in languages other than English.
       property :title_alternative, predicate: ::RDF::Vocab::DC.alternative do |index|
-        index.as :stored_searchable
-      end
-
-      # A bibliographic reference for the resource.
-      property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation do |index|
         index.as :stored_searchable
       end
     end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -16,10 +16,6 @@ class Publication < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation do |index|
-    index.as :stored_searchable
-  end
-
   property :date_issued, predicate: ::RDF::Vocab::DC.issued do |index|
     index.as :symbol
   end

--- a/app/models/student_work.rb
+++ b/app/models/student_work.rb
@@ -19,10 +19,6 @@ class StudentWork < ActiveFedora::Base
     index.as :symbol
   end
 
-  property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation do |index|
-    index.as :stored_searchable
-  end
-
   property :date, predicate: ::RDF::Vocab::DC.date do |index|
     index.as :symbol
   end

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Publication do
   [
     [:abstract,               RDF::Vocab::DC.abstract],
     [:academic_department,    'http://vivoweb.org/ontology/core#AcademicDepartment'],
-    [:bibliographic_citation, RDF::Vocab::DC.bibliographicCitation],
     [:date_available,         RDF::Vocab::DC.available],
     [:date_issued,            RDF::Vocab::DC.issued],
     [:division,               'http://vivoweb.org/ontology/core#Division'],

--- a/spec/models/student_work_spec.rb
+++ b/spec/models/student_work_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe StudentWork do
     [:abstract,               RDF::Vocab::DC.abstract],
     [:access_note,            RDF::Vocab::DC.accessRights],
     [:advisor,                'http://id.loc.gov/vocabulary/relators/ths'],
-    [:bibliographic_citation, RDF::Vocab::DC.bibliographicCitation],
     [:date,                   RDF::Vocab::DC.date],
     [:date_available,         RDF::Vocab::DC.available]
   ].each do |(prop, uri)|

--- a/spec/support/shared_examples/spot_core_metadata.rb
+++ b/spec/support/shared_examples/spot_core_metadata.rb
@@ -3,7 +3,7 @@ RSpec.shared_examples 'it includes Spot::CoreMetadata' do
   subject { described_class.new }
 
   [
-    [:bibliographic_citation, RDF::Vocab::DC.bibliographicCitation]
+    [:bibliographic_citation, RDF::Vocab::DC.bibliographicCitation],
     [:contributor,            RDF::Vocab::DC11.contributor],
     [:creator,                RDF::Vocab::DC11.creator],
     [:description,            RDF::Vocab::DC11.description],

--- a/spec/support/shared_examples/spot_core_metadata.rb
+++ b/spec/support/shared_examples/spot_core_metadata.rb
@@ -3,24 +3,25 @@ RSpec.shared_examples 'it includes Spot::CoreMetadata' do
   subject { described_class.new }
 
   [
-    [:contributor,       RDF::Vocab::DC11.contributor],
-    [:creator,           RDF::Vocab::DC11.creator],
-    [:description,       RDF::Vocab::DC11.description],
-    [:identifier,        RDF::Vocab::DC.identifier],
-    [:keyword,           RDF::Vocab::SCHEMA.keywords],
-    [:language,          RDF::Vocab::DC11.language],
-    [:location,          RDF::Vocab::DC.spatial],
-    [:note,              RDF::Vocab::SKOS.note],
-    [:physical_medium,   RDF::Vocab::DC.PhysicalMedium],
-    [:publisher,         RDF::Vocab::DC11.publisher],
-    [:related_resource,  RDF::RDFS.seeAlso],
-    [:resource_type,     RDF::Vocab::DC.type],
-    [:rights_holder,     RDF::Vocab::DC.rightsHolder],
-    [:rights_statement,  RDF::Vocab::EDM.rights],
-    [:source,            RDF::Vocab::DC.source],
-    [:subject,           RDF::Vocab::DC11.subject],
-    [:subtitle,          RDF::URI.new('http://purl.org/spar/doco/Subtitle')],
-    [:title_alternative, RDF::Vocab::DC.alternative]
+    [:bibliographic_citation, RDF::Vocab::DC.bibliographicCitation]
+    [:contributor,            RDF::Vocab::DC11.contributor],
+    [:creator,                RDF::Vocab::DC11.creator],
+    [:description,            RDF::Vocab::DC11.description],
+    [:identifier,             RDF::Vocab::DC.identifier],
+    [:keyword,                RDF::Vocab::SCHEMA.keywords],
+    [:language,               RDF::Vocab::DC11.language],
+    [:location,               RDF::Vocab::DC.spatial],
+    [:note,                   RDF::Vocab::SKOS.note],
+    [:physical_medium,        RDF::Vocab::DC.PhysicalMedium],
+    [:publisher,              RDF::Vocab::DC11.publisher],
+    [:related_resource,       RDF::RDFS.seeAlso],
+    [:resource_type,          RDF::Vocab::DC.type],
+    [:rights_holder,          RDF::Vocab::DC.rightsHolder],
+    [:rights_statement,       RDF::Vocab::EDM.rights],
+    [:source,                 RDF::Vocab::DC.source],
+    [:subject,                RDF::Vocab::DC11.subject],
+    [:subtitle,               RDF::URI.new('http://purl.org/spar/doco/Subtitle')],
+    [:title_alternative,      RDF::Vocab::DC.alternative]
   ].each do |(property, predicate)|
     it { is_expected.to have_editable_property(property).with_predicate(predicate) }
   end


### PR DESCRIPTION
rationale:  there are plenty of use cases where worktypes other than publication would wish to include preferred citation information in descriptive metadata. 

also removed some resolved to-do comments since we are going to leave creator and contributor as facetable.