### PR TITLE
remove socials from profile edit/show pages

### DIFF
--- a/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
+++ b/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
@@ -1,0 +1,38 @@
+<%# form for editing user info, modified from hyrax to remove socials %>
+<%= form_for @user,
+             url: hyrax.dashboard_profile_path(@user.to_param),
+             html: { multipart: true, class: 'form-horizontal' } do |f| %>
+  <div class="form-group">
+    <%= f.label :avatar, '<i class="glyphicon glyphicon-camera"></i> Change picture'.html_safe, class: "col-xs-4 control-label" %>
+    <div class="col-xs-8">
+      <%= image_tag @user.avatar.url(:thumb) if @user.avatar? %>
+      <%= f.file_field :avatar %>
+      <%= f.hidden_field :avatar_cache %>
+      <span class="help-block">JPG, GIF, or PNG (less than 2MB)</span>
+
+      <div class="checkbox">
+        <%= f.label :remove_avatar do %>
+          <%= f.check_box :remove_avatar %>
+          Delete picture
+          <a href="#" id="delete_picture_help" data-toggle="popover" data-content="If you would like to remove your picture entirely, check the box and save your profile." data-original-title="Delete Picture"><i class="glyphicon glyphicon-question-sign"></i></a>
+        <% end %>
+      </div>
+    </div>
+  </div><!-- .form-group -->
+
+  <% if Hyrax.config.arkivo_api? %>
+    <%= render partial: 'zotero', locals: { f: f, user: @user } %>
+  <% end %>
+
+  <div class="form-group">
+    <%= f.label :orcid, class: 'col-xs-4 control-label' do %>
+      <%= orcid_label %>
+    <% end %>
+    <div class="col-xs-8">
+       <%= f.text_field :orcid, class: "form-control" %>
+    </div>
+  </div><!-- .form-group -->
+
+  <%= render 'trophy_edit', trophies: @trophies %>
+  <%= f.button '<i class="glyphicon glyphicon-save"></i> Save Profile'.html_safe, type: 'submit', class: "btn btn-primary" %>
+<% end %>

--- a/app/views/hyrax/users/_user_info.html.erb
+++ b/app/views/hyrax/users/_user_info.html.erb
@@ -1,0 +1,62 @@
+<%# displays user fields as a profile#show page
+    (edited from hyrax to remove social profiles) %>
+<dl id="user_info">
+
+<% if user.orcid.present? %>
+  <dt><%= orcid_label('profile') %></dt>
+  <dd><%= link_to user.orcid, user.orcid, { target: '_blank' } %></dd>
+<% end %>
+
+<% if Hyrax.config.arkivo_api? && user.zotero_userid.present? %>
+  <dt><%= zotero_label(html_class: 'profile') %></dt>
+  <dd><%= link_to zotero_profile_url(user.zotero_userid), zotero_profile_url(user.zotero_userid), { target: '_blank' } %></dd>
+<% end %>
+
+  <dt><i class="fa fa-envelope" aria-hidden="true"></i> Email</dt>
+  <dd><%= mail_to user.email %></dd>
+
+  <% if user.chat_id %>
+    <dt><i class="glyphicon glyphicon-bullhorn" aria-hidden="true"></i> Chat ID</dt>
+    <dd><%= user.chat_id %></dd>
+  <% end %>
+
+  <% if user.website %>
+    <dt><i class="glyphicon glyphicon-globe" aria-hidden="true"></i> Website(s)</dt>
+    <dd><%= iconify_auto_link(user.website) %></dd>
+  <% end %>
+
+  <% if user.title %>
+    <dt>Title</dt>
+    <dd><%= user.title %></dd>
+  <% end %>
+
+  <% if user.admin_area %>
+    <dt>Administrative Area</dt>
+    <dd><%= user.admin_area %></dd>
+  <% end %>
+
+  <% if user.department %>
+    <dt>Department</dt>
+    <dd><%= user.department %></dd>
+  <% end %>
+
+  <% if user.office %>
+    <dt>Office</dt>
+    <dd><%= user.office %></dd>
+  <% end %>
+
+  <% if user.address %>
+    <dt><i class="glyphicon glyphicon-map-marker" aria-hidden="true"></i> Address</dt>
+    <dd><%= user.address %></dd>
+  <% end %>
+
+  <% if user.affiliation %>
+    <dt>Affiliation</dt>
+    <dd><%= user.affiliation %></dd>
+  <% end %>
+
+  <% if user.telephone %>
+    <dt><i class="glyphicon glyphicon-earphone" aria-hidden="true"></i> Telephone</dt>
+    <dd><%= link_to_telephone(user) %></dd>
+  <% end %>
+</dl>


### PR DESCRIPTION
follow-up to #783, which removed social media fields from the Users table. pulls those fields out of the edit/show pages