### PR TITLE
subject_label fallback for reindex

### DIFF
--- a/app/models/concerns/spot/solr_document_attributes.rb
+++ b/app/models/concerns/spot/solr_document_attributes.rb
@@ -89,7 +89,21 @@ module Spot
 
       # dates
       attribute :date_modified,          ::Blacklight::Types::Date,   'date_modified_dtsi'
+
+      # Helper while we reindex the collection to use the new `subject_label_tesim` property
+      # but falling back to the old `subject_label_ssim` if those values aren't present.
+      # If both fields are defined (which shouldn't happen), the newer "_tesim" field will be
+      # used if content exists.
+      #
+      # Placed in the `included` block to overwrite the `attribute :subject_label` definition
+      # above (defining this outside of the `included` block will cause the `attribute` definition to override)
+      #
+      # @todo remove this after reindexing, 2022-01-10
+      def subject_label
+        Array.wrap(self['subject_label_tesim'] || self['subject_label_ssim'])
+      end
     end
+
 
     module ClassMethods
       def attribute(name, type, field)

--- a/app/models/concerns/spot/solr_document_attributes.rb
+++ b/app/models/concerns/spot/solr_document_attributes.rb
@@ -104,7 +104,6 @@ module Spot
       end
     end
 
-
     module ClassMethods
       def attribute(name, type, field)
         define_method name do

--- a/app/views/hyrax/student_works/_metadata.html.erb
+++ b/app/views/hyrax/student_works/_metadata.html.erb
@@ -21,7 +21,7 @@
       <%= presenter.attribute_to_html(:organization, render_as: :faceted) %>
       <%= presenter.attribute_to_html(:subject,
                                       render_as: :external_authority,
-                                      search_field: :subject_label_ssim) %>
+                                      search_field: :subject_label_sim) %>
       <%= presenter.attribute_to_html(:keyword, render_as: :faceted) %>
       <%= presenter.attribute_to_html(:bibliographic_citation) %>
       <%= presenter.attribute_to_html(:standard_identifier, render_as: :identifier) %>

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -154,4 +154,24 @@ RSpec.describe SolrDocument do
       it { is_expected.to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
   end
+
+  describe '#subject_label patch' do
+    subject { document.subject_label }
+
+    context 'when subject_label stored as string (_ssim)' do
+      let(:metadata) do
+        { 'subject_label_ssim' => ['Subject Label'] }
+      end
+
+      it { is_expected.to eq ['Subject Label'] }
+    end
+
+    context 'when subject_label stored as text (_tesim)' do
+      let(:metadata) do
+        { 'subject_label_tesim' => ['Subject Label'] }
+      end
+
+      it { is_expected.to eq ['Subject Label'] }
+    end
+  end
 end


### PR DESCRIPTION
- adds correct `:subject_label_sim` search_field in metadata view
- patches `SolrDocument#subject_label` to prefer `subject_label_tesim` but fallback to `subject_label_ssim` so that labels will still appear while we reindex the repository