### PR TITLE
don't generate a default term for Spot::LoadLafayetteInstructorsAuthorityJob

### DIFF
--- a/app/jobs/spot/load_lafayette_instructors_authority_job.rb
+++ b/app/jobs/spot/load_lafayette_instructors_authority_job.rb
@@ -3,7 +3,7 @@ module Spot
   class LoadLafayetteInstructorsAuthorityJob < ::ApplicationJob
     # @todo We should probably query the current academic term and cache it (for a month?)
     #       before loading the instructors. For now, we'll stuff it with Winter 2021.
-    def perform(term: Time.zone.today.strftime('%Y10'))
+    def perform(term: '202110')
       Spot::LafayetteInstructorsAuthorityService.load(term: term)
     end
   end


### PR DESCRIPTION
using `Time.zone.today` as a default started breaking tests as soon as the new year started 🙃 