### PR TITLE
remove LoadLafayetteInstructorAuthority cron job (for now)

### DIFF
--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -17,8 +17,3 @@ update_solr_suggest_dictionaries:
   cron: '0 * * * *'
   class: Spot::UpdateSolrSuggestDictionariesJob
   queue: default
-
-load_lafayette_instructors:
-  cron: '0 0 * * 0'
-  class: Spot::LoadLafayetteInstructorsAuthorityJob
-  queue: default


### PR DESCRIPTION
until we're actually ready to use this, we shouldn't be populating the local authority with entries

- on stage, we can manually load in users who are testing
- on prod, someone stumbling onto the work form won't be able to submit it (as the authority should be empty)