### PR TITLE
fix StudentWorkForm#rights_statement not reappearing in form

### DIFF
--- a/app/forms/hyrax/student_work_form.rb
+++ b/app/forms/hyrax/student_work_form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Hyrax
   class StudentWorkForm < ::Spot::Forms::WorkForm
-    singular_form_fields :title, :description, :date, :date_available, :rights_statement, :abstract
+    singular_form_fields :title, :description, :date, :date_available, :abstract
     transforms_nested_fields_for :academic_department, :division, :language, :advisor
 
     self.model_class = ::StudentWork

--- a/spec/forms/hyrax/student_work_form_spec.rb
+++ b/spec/forms/hyrax/student_work_form_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Hyrax::StudentWorkForm do
 
   describe '.multiple?' do
     it 'marks singular fields as false' do
-      [:title, :description, :date, :date_available, :rights_statement, :abstract].each do |f|
+      [:title, :description, :date, :date_available, :abstract].each do |f|
         expect(described_class.multiple?(f)).to be false
       end
     end


### PR DESCRIPTION
annoyingly, the way to correctly display rights_statement is to _not_ declare it as a singular_form_field, even though the view renders it as a single form field. 

closes #817 