### PR TITLE
store email addresses for StudentWork#advisor

### DIFF
--- a/app/indexers/student_work_indexer.rb
+++ b/app/indexers/student_work_indexer.rb
@@ -5,15 +5,15 @@ class StudentWorkIndexer < BaseIndexer
   def generate_solr_document
     super.tap do |solr_doc|
       solr_doc['advisor_ssim'] = object.advisor.to_a
-      solr_doc['advisor_label_ssim'] = object.advisor.map { |lnumber| advisor_label_from(lnumber: lnumber) }
+      solr_doc['advisor_label_ssim'] = object.advisor.map { |email| advisor_label_from(email: email) }
     end
   end
 
   private
 
-  def advisor_label_from(lnumber:)
-    return lnumber unless lnumber.match?(/^L\d{8}$/)
+  def advisor_label_from(email:)
+    return email unless email.match?(/^[A-Za-z0-9\-_\.]+@lafayette.edu$/)
 
-    Spot::LafayetteInstructorsAuthorityService.label_for(lnumber: lnumber)
+    Spot::LafayetteInstructorsAuthorityService.label_for(email: email)
   end
 end

--- a/app/services/spot/lafayette_instructors_authority_service.rb
+++ b/app/services/spot/lafayette_instructors_authority_service.rb
@@ -14,8 +14,8 @@ module Spot
 
     class UserNotFoundError < StandardError; end
 
-    def self.label_for(lnumber:, api_key: ENV.fetch(API_ENV_KEY))
-      new(api_key: api_key).label_for(lnumber: lnumber)
+    def self.label_for(email: nil, api_key: ENV.fetch(API_ENV_KEY))
+      new(api_key: api_key).label_for(email: email)
     end
 
     # @params [Hash] options
@@ -46,12 +46,12 @@ module Spot
       end
     end
 
-    def label_for(lnumber:)
-      stored = Qa::LocalAuthorityEntry.find_by(uri: lnumber, local_authority: local_authority)
+    def label_for(email:)
+      stored = Qa::LocalAuthorityEntry.find_by(uri: email, local_authority: local_authority)
       return stored.label unless stored.nil?
 
-      remote = wds_service.person(lnumber: lnumber)
-      raise(UserNotFoundError, "No user found with L-number: #{lnumber}") if remote == false
+      remote = wds_service.person(email: email)
+      raise(UserNotFoundError, "No user found with email address: #{email}") if remote == false
 
       find_or_create_entry(label: instructor_label(remote), value: instructor_id(remote)).label
     end
@@ -79,7 +79,7 @@ module Spot
     end
 
     def instructor_id(instructor)
-      instructor['LNUMBER']
+      instructor['EMAIL'].downcase
     end
 
     def instructor_label(instructor)

--- a/app/services/spot/workflow/grant_sipity_role_to_advisor.rb
+++ b/app/services/spot/workflow/grant_sipity_role_to_advisor.rb
@@ -11,9 +11,11 @@ module Spot
       end
 
       def grant!
-        Sipity::EntitySpecificResponsibility.find_or_create_by!(workflow_role: workflow_role,
-                                                                entity: sipity_entity,
-                                                                agent: sipity_agent)
+        sipity_agents.each do |agent|
+          Sipity::EntitySpecificResponsibility.find_or_create_by!(workflow_role: workflow_role,
+                                                                  entity: sipity_entity,
+                                                                  agent: agent)
+        end
       end
 
       private
@@ -29,8 +31,8 @@ module Spot
         end
       end
 
-      def sipity_agent
-        advisor_from_target.to_sipity_agent
+      def sipity_agents
+        @target.advisor.map { |email| User.find_by(email: email).to_sipity_agent }
       end
 
       def sipity_entity

--- a/app/services/spot/workflow/grant_sipity_role_to_advisor.rb
+++ b/app/services/spot/workflow/grant_sipity_role_to_advisor.rb
@@ -20,17 +20,6 @@ module Spot
 
       private
 
-      def advisor_from_target
-        lnumber = @target.advisor.first.to_s
-
-        case lnumber
-        when /^L\d{8}$/
-          User.find_by(lnumber: lnumber)
-        when /^[^@]+@\w+\.\w+$/
-          User.find_by(email: lnumber)
-        end
-      end
-
       def sipity_agents
         @target.advisor.map { |email| User.find_by(email: email).to_sipity_agent }
       end

--- a/spec/services/spot/workflow/grant_read_to_advisor_spec.rb
+++ b/spec/services/spot/workflow/grant_read_to_advisor_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe Spot::Workflow::GrantReadToAdvisor do
   let(:workflow_method) { described_class }
-  let(:advisor) { create(:user, lnumber: 'L12341234') }
+  let(:advisor) { create(:user) }
   let(:depositor) { create(:user) }
   let(:work) { build(:student_work, id: 'abc123', advisor: [advisor_key], user: depositor) }
 
@@ -10,28 +10,17 @@ RSpec.describe Spot::Workflow::GrantReadToAdvisor do
 
     allow(Spot::LafayetteInstructorsAuthorityService)
       .to receive(:label_for)
-      .with(lnumber: advisor.lnumber)
+      .with(email: advisor.email)
       .and_return('Advisor, Faculty')
   end
 
   it_behaves_like 'a Hyrax workflow method'
 
-  context 'when "advisor" is an L-number' do
-    let(:advisor_key) { advisor.lnumber }
+  let(:advisor_key) { advisor.email }
 
-    it "adds the advisor to the work's #read_users" do
-      expect { described_class.call(target: work) }
-        .to change { work.read_users }.from([]).to([advisor.user_key])
-    end
-  end
-
-  context 'when "advisor" is an email address' do
-    let(:advisor_key) { advisor.email }
-
-    it "adds the advisor to the work's #read_users" do
-      expect { described_class.call(target: work) }
-        .to change { work.read_users }.from([]).to([advisor.user_key])
-    end
+  it "adds the advisor to the work's #read_users" do
+    expect { described_class.call(target: work) }
+      .to change { work.read_users }.from([]).to([advisor.user_key])
   end
 
   context 'when the work does not have an "advisor" field' do

--- a/spec/services/spot/workflow/grant_sipity_role_to_advisor_spec.rb
+++ b/spec/services/spot/workflow/grant_sipity_role_to_advisor_spec.rb
@@ -2,8 +2,7 @@
 RSpec.describe Spot::Workflow::GrantSipityRoleToAdvisor do
   # let(:depositor) { create(:user) }
   let(:workflow_role) { Sipity::WorkflowRole.find_or_create_by!(role: Sipity::Role[:advising], workflow: permission_template.active_workflow) }
-  let(:advisor) { create(:user, lnumber: 'L12341234') }
-  let(:advisor_key) { advisor.lnumber }
+  let(:advisor) { create(:user) }
   let(:admin_set) { AdminSet.find(AdminSet.find_or_create_default_admin_set_id) }
   let(:default_access_grants) do
     [{ agent_type: 'group', agent_id: ::Ability.admin_group_name, access: Hyrax::PermissionTemplateAccess::MANAGE }]
@@ -12,7 +11,7 @@ RSpec.describe Spot::Workflow::GrantSipityRoleToAdvisor do
     build(:student_work,
           id: 'abc123',
           admin_set: admin_set,
-          advisor: [advisor_key])
+          advisor: [advisor.email])
   end
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set.id) }
   let(:sipity_agent) { advisor.to_sipity_agent }
@@ -38,27 +37,11 @@ RSpec.describe Spot::Workflow::GrantSipityRoleToAdvisor do
 
   it_behaves_like 'a Hyrax workflow method'
 
-  context 'when "advisor" is an L-number' do
-    let(:advisor_key) { advisor.lnumber }
+  it "grants a Sipity::Role to the user" do
+    described_class.call(target: work)
 
-    it "grants a Sipity::Role to the user" do
-      described_class.call(target: work)
-
-      expect(Sipity::EntitySpecificResponsibility)
-        .to have_received(:find_or_create_by!)
-        .with(workflow_role: workflow_role, entity: sipity_entity, agent: sipity_agent)
-    end
-  end
-
-  context 'when "advisor" is an email' do
-    let(:advisor_key) { advisor.email }
-
-    it "grants a Sipity::Role to the user" do
-      described_class.call(target: work)
-
-      expect(Sipity::EntitySpecificResponsibility)
-        .to have_received(:find_or_create_by!)
-        .with(workflow_role: workflow_role, entity: sipity_entity, agent: sipity_agent)
-    end
+    expect(Sipity::EntitySpecificResponsibility)
+      .to have_received(:find_or_create_by!)
+      .with(workflow_role: workflow_role, entity: sipity_entity, agent: sipity_agent)
   end
 end

--- a/spec/services/spot/workflow/pending_advisor_review_notification_spec.rb
+++ b/spec/services/spot/workflow/pending_advisor_review_notification_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Spot::Workflow::PendingAdvisorReviewNotification do
     stub_env('LAFAYETTE_WDS_API_KEY', 'abc123def!')
 
     allow(Spot::LafayetteInstructorsAuthorityService)
-      .to receive(:label_for).with(lnumber: advisor.lnumber)
+      .to receive(:label_for).with(email: advisor.email)
       .and_return('Advisor, Faculty')
   end
 


### PR DESCRIPTION
i initially had set up StudentWork#advisor to store L-numbers of faculty advisors because they're more flexible than email addresses (as emails are based on names and names can change). but for now (at least) let's just use email addresses, as they're what Hyrax uses as a user's primary key. in the event that we need to update an email for a user, we should be able to do something like:

```ruby
ActiveFedora::Base.where(advisor_tesim: email_address).each do |obj|
  obj.advisor = obj.advisor.map { |u| u == email_address ? new_email_address : u }
  obj.save
end
```