### PR TITLE
workflow action updates

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,3 +31,4 @@
 //= require spot/editor/multi_auth_controlled_vocabulary
 //= require language-tagged-autocomplete-setup
 //= require multi-auth-input
+//= require workflow-action-form

--- a/app/assets/javascripts/workflow-action-form.js
+++ b/app/assets/javascripts/workflow-action-form.js
@@ -1,0 +1,22 @@
+// prevent the workflow-action form from being submitted if no action is selected
+$(document).ready(function () {
+  $('#workflow_controls form').on('submit', function (ev) {
+    var $actionName = $('#workflow_controls form input[name="workflow_action[name]"]:checked').val();
+
+    // submit the form if we have an action to take
+    if ($actionName) { return; }
+
+    // stop the submission + insert an alert for the user
+    ev.preventDefault();
+
+    var $alert = $('<div class="alert alert-danger" role="alert"></div>')
+                 .append('<button type="button" class="close" data-dismiss="alert" aria-label="Close">'
+                       +   '<span aria-hidden="true">&times;</span>'
+                       + '</button>')
+                 .append('Please select an action below');
+
+    $(this).find('.panel-body').prepend($alert);
+
+    return false;
+  });
+})

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -55,3 +55,12 @@ en:
       metadata:
         note_html: Make metadata available to all but restrict file access
         text: Metadata Only
+
+    workflow:
+      mediated_student_work_deposit:
+        advisor_approves: Approve
+        advisor_requests_changes: Request changes
+        depositor_submits_advisor_changes: Submit requested changes
+        depositor_submits_library_changes: Submit requested changes
+        library_approves: Approve
+        library_requests_changes: Request changes


### PR DESCRIPTION
- use verb language for action options via locale (`en.hyrax.workflow.mediated_student_work_deposit`)
- prevent workflow form submission if a workflow_action isn't selected (hyrax behavior returns `:unauthorized` which isn't very helpful). (see screenshot)

<img width="1126" alt="Screen Shot 2022-02-03 at 10 15 38 AM" src="https://user-images.githubusercontent.com/2744987/152371543-5d23966c-8888-48ff-8850-6b1cbf934eb8.png">

