### PR TITLE
get collections partials to work with admin_sets

### DIFF
--- a/app/views/hyrax/collections/_collection_description.html.erb
+++ b/app/views/hyrax/collections/_collection_description.html.erb
@@ -1,12 +1,17 @@
-<% presenter.abstract.each do |abstract| %>
-  <%= simple_format(auto_link(abstract), class: 'lead') %>
+<%# this partial is shared between collections and admin_sets, but we're using
+    the stock Hyrax::AdminSetPresenter, which inherits from Hyrax::CollectionsPresenter
+    (not Spot::CollectionsPresenter) and does not have `#abstract` or `#related_resource` methods %>
+<% if presenter.respond_to?(:abstract) %>
+  <% presenter.abstract.each do |abstract| %>
+    <%= simple_format(auto_link(abstract), class: 'lead') %>
+  <% end %>
 <% end %>
 
 <% presenter.description.each do |description| %>
   <%= simple_format(auto_link(description)) %>
 <% end %>
 
-<% unless presenter.related_resource.empty? %>
+<% if presenter.respond_to?(:related_resource) && !presenter.related_resource.empty? %>
   <hr />
   <p><%= render_related_resource_language(presenter) %></p>
 <% end %>

--- a/app/views/hyrax/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/collections/_show_descriptions.html.erb
@@ -3,8 +3,12 @@
 <div class="panel panel-default">
   <table class="table table-condensed collection-show metadata-table">
     <tbody>
-      <% presenter.terms_with_values.each do |term| %>
-        <%= presenter.attribute_to_html(term.to_sym) %>
+      <%# using the instance variable, rather than a local variable passed from the parent partial,
+          because the hyrax/admin/admin_sets/show view does not provide one, which triggers a call
+          to the blacklight helper method #presenter, which in turn requires a parameter to be
+          passed, causing an ArgumentError %>
+      <% @presenter.terms_with_values.each do |term| %>
+        <%= @presenter.attribute_to_html(term.to_sym) %>
       <% end %>
     </tbody>
   </table>


### PR DESCRIPTION
- adds guard clauses to `hyrax/collections/_collection_description` partial for custom collection_presenter fields not shared with `Hyrax::AdminSetPresenter`
- uses the `@presenter` instance variable in `hyrax/collections/_show_descriptions` partial to prevent a conflict with a similarly named blacklight helper method

closes #829 