### PR TITLE
force sRGB colorspace for thumbnails

### DIFF
--- a/app/services/spot/derivatives/access_master_service.rb
+++ b/app/services/spot/derivatives/access_master_service.rb
@@ -20,7 +20,8 @@ module Spot
       # @param [String,Pathname] filename the src path of the file
       # @return [void]
       def create_derivatives(filename)
-        FileUtils.mkdir_p(File.dirname(derivative_path))
+        output_dirname = File.dirname(derivative_path)
+        FileUtils.mkdir_p(output_dirname) unless File.directory?(output_dirname)
 
         MiniMagick::Tool::Convert.new do |magick|
           magick << "#{filename}[0]"

--- a/app/services/spot/derivatives/access_master_service.rb
+++ b/app/services/spot/derivatives/access_master_service.rb
@@ -20,6 +20,8 @@ module Spot
       # @param [String,Pathname] filename the src path of the file
       # @return [void]
       def create_derivatives(filename)
+        FileUtils.mkdir_p(File.dirname(derivative_path))
+
         MiniMagick::Tool::Convert.new do |magick|
           magick << "#{filename}[0]"
           # note: we need to use an array for each piece of this command;

--- a/app/services/spot/derivatives/thumbnail_service.rb
+++ b/app/services/spot/derivatives/thumbnail_service.rb
@@ -19,6 +19,8 @@ module Spot
       # @return [void]
       # @see https://github.com/LafayetteCollegeLibraries/spot/issues/831
       def create_derivatives(filename)
+        FileUtils.mkdir_p(File.dirname(derivative_path))
+
         MiniMagick::Tool::Convert.new do |convert|
           convert << "#{filename}[0]"
           convert.merge! %w[-colorspace sRGB -flatten -resize 200x150> -format jpg]

--- a/app/services/spot/derivatives/thumbnail_service.rb
+++ b/app/services/spot/derivatives/thumbnail_service.rb
@@ -19,7 +19,8 @@ module Spot
       # @return [void]
       # @see https://github.com/LafayetteCollegeLibraries/spot/issues/831
       def create_derivatives(filename)
-        FileUtils.mkdir_p(File.dirname(derivative_path))
+        output_dirname = File.dirname(derivative_path)
+        FileUtils.mkdir_p(output_dirname) unless File.directory?(output_dirname)
 
         MiniMagick::Tool::Convert.new do |convert|
           convert << "#{filename}[0]"

--- a/app/services/spot/pdf_derivatives_service.rb
+++ b/app/services/spot/pdf_derivatives_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+module Spot
+  class PdfDerivativesService
+    class_attribute :services
+    self.services = [::Spot::Derivatives::ThumbnailService]
+
+    attr_reader :file_set
+    delegate :uri, :mime_type, to: :file_set
+
+    def initialize(file_set)
+      @file_set = file_set
+    end
+
+    # Delegates cleanup to each of our services
+    #
+    # @return [void]
+    def cleanup_derivatives
+      mapped_services.each do |service|
+        service.cleanup_derivatives if service.respond_to?(:cleanup_derivatives)
+      end
+    end
+
+    # Iterates through the the provided services and runs their +#create_derivatives+
+    # method to allow us to do more than one thing with an image type
+    #
+    # @param [String, Pathname] filename
+    # @return [void]
+    def create_derivatives(filename)
+      mapped_services.each do |service|
+        service.create_derivatives(filename) if service.respond_to?(:create_derivatives)
+      end
+    end
+
+    # Does the file_set we're processing have an image-esque mime-type?
+    #
+    # @return [true, false]
+    def valid?
+      file_set.class.pdf_mime_types.include?(mime_type)
+    end
+
+    private
+
+    # @return [Array<Spot::Derivatives::BaseDerivativesService>]
+    def mapped_services
+      @mapped_services ||= services.map { |service| service.new(file_set) }
+    end
+  end
+end

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -13,6 +13,7 @@ Rails.application.config.to_prepare do
   Hyrax::CollectionsController.include Spot::CollectionsControllerBehavior
 
   Hyrax::DerivativeService.services = [
+    ::Spot::PdfDerivativesService,
     ::Spot::ImageDerivativesService,
     ::Hyrax::FileSetDerivativesService
   ]

--- a/spec/services/spot/derivatives/access_master_service_spec.rb
+++ b/spec/services/spot/derivatives/access_master_service_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
   describe '#create_derivatives' do
     before do
       allow(MiniMagick::Tool::Convert).to receive(:new).and_yield(magick_commands)
+      allow(FileUtils).to receive(:mkdir_p).with('/path/to/a')
     end
 
     let(:magick_commands) do

--- a/spec/services/spot/derivatives/thumbnail_service_spec.rb
+++ b/spec/services/spot/derivatives/thumbnail_service_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Spot::Derivatives::ThumbnailService do
   describe '#create_derivatives' do
     before do
       allow(MiniMagick::Tool::Convert).to receive(:new).and_yield(magick_commands)
+      allow(FileUtils).to receive(:mkdir_p).with(File.dirname(derivative_path))
     end
 
     let(:magick_commands) do

--- a/spec/services/spot/derivatives/thumbnail_service_spec.rb
+++ b/spec/services/spot/derivatives/thumbnail_service_spec.rb
@@ -27,29 +27,34 @@ RSpec.describe Spot::Derivatives::ThumbnailService do
 
   describe '#create_derivatives' do
     before do
-      allow(Hydra::Derivatives::ImageDerivatives).to receive(:create)
+      allow(MiniMagick::Tool::Convert).to receive(:new).and_yield(magick_commands)
+    end
+
+    let(:magick_commands) do
+      [].tap do |arr|
+        arr.define_singleton_method(:merge!) do |args|
+          args.each { |arg| self << arg }
+        end
+      end
     end
 
     let(:filename) { '/path/to/a/source/file.tif' }
 
-    let(:expected_outputs) do
+    let(:expected_commands) do
       [
-        {
-          label: :thumbnail,
-          format: 'jpg',
-          size: '200x150>',
-          url: 'file:/path/to/a/fs-thumbnail.jpg',
-          layer: 0
-        }
+        "#{filename}[0]",
+        '-colorspace', 'sRGB',
+        '-flatten',
+        '-resize', '200x150>',
+        '-format', 'jpg',
+        derivative_path
       ]
     end
 
-    it 'calls Hydra::Derivatives::ImageDerivatives with outputs' do
+    it 'sends imagemagick commands to MiniMagick' do
       service.create_derivatives(filename)
 
-      expect(Hydra::Derivatives::ImageDerivatives)
-        .to have_received(:create)
-        .with(filename, outputs: expected_outputs)
+      expect(magick_commands).to eq(expected_commands)
     end
   end
 end

--- a/spec/services/spot/image_derivatives_service_spec.rb
+++ b/spec/services/spot/image_derivatives_service_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Spot::ImageDerivativesService do
     before do
       allow(thumbnail_service).to receive(:create_derivatives)
       allow(access_master_service).to receive(:create_derivatives)
+      allow(FileUtils).to receive(:mkdir_p).with(File.dirname(filename))
     end
 
     it 'calls +#create_derivatives+ on both of the services' do

--- a/spec/services/spot/pdf_derivatives_service_spec.rb
+++ b/spec/services/spot/pdf_derivatives_service_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Spot::PdfDerivativesService do
 
   before do
     allow(valid_file_set).to receive(:mime_type).and_return('application/pdf')
-
     allow(::Spot::Derivatives::ThumbnailService).to receive(:new).and_return(thumbnail_service)
   end
 
@@ -44,6 +43,7 @@ RSpec.describe Spot::PdfDerivativesService do
 
     before do
       allow(thumbnail_service).to receive(:create_derivatives)
+      allow(FileUtils).to receive(:mkdir_p).with(File.dirname(filename))
     end
 
     it 'calls +#create_derivatives+ on the thumbnail services' do

--- a/spec/services/spot/pdf_derivatives_service_spec.rb
+++ b/spec/services/spot/pdf_derivatives_service_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+RSpec.describe Spot::PdfDerivativesService do
+  subject(:service) { described_class.new(valid_file_set) }
+
+  before do
+    allow(valid_file_set).to receive(:mime_type).and_return('application/pdf')
+
+    allow(::Spot::Derivatives::ThumbnailService).to receive(:new).and_return(thumbnail_service)
+  end
+
+  let(:valid_file_set) { FileSet.new }
+  let(:thumbnail_service) { instance_double(::Spot::Derivatives::ThumbnailService) }
+
+  # since we're delegating +:derivative_url+ to the individual
+  # derivative services, and not defining one in this service,
+  # using the +it_behaves_like 'a Hyrax::DerivativeService'+
+  # shared_spec will fail. instead, we'll spell out those tasks here
+
+  describe 'behaves like a Hyrax::DerivativeService (sort of)' do
+    it { is_expected.to respond_to(:cleanup_derivatives).with(0).arguments }
+    it { is_expected.to respond_to(:create_derivatives).with(1).arguments }
+    it { is_expected.to respond_to(:file_set) }
+    it { is_expected.to respond_to(:mime_type) }
+  end
+
+  it 'is the service for PDFs' do
+    expect(Hyrax::DerivativeService.for(valid_file_set).class).to eq described_class
+  end
+
+  describe '#cleanup_derivatives' do
+    before do
+      allow(thumbnail_service).to receive(:cleanup_derivatives)
+    end
+
+    it 'calls +#cleanup_derivatives+ on both of the services' do
+      service.cleanup_derivatives
+
+      expect(thumbnail_service).to have_received(:cleanup_derivatives)
+    end
+  end
+
+  describe '#create_derivatives' do
+    let(:filename) { '/path/to/an/asset.pdf' }
+
+    before do
+      allow(thumbnail_service).to receive(:create_derivatives)
+    end
+
+    it 'calls +#create_derivatives+ on the thumbnail services' do
+      service.create_derivatives(filename)
+
+      expect(thumbnail_service).to have_received(:create_derivatives).with(filename)
+    end
+  end
+
+  describe '#valid?' do
+    subject { service.valid? }
+
+    it { is_expected.to be true }
+  end
+end


### PR DESCRIPTION
see linked issue for details. patches our derivatives service to ensure pdf thumbnails are generated properly.

closes #831