### PR TITLE
add Darlingtonia mapper for Image objects

### DIFF
--- a/app/services/spot/mappers/image_mapper.rb
+++ b/app/services/spot/mappers/image_mapper.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+module Spot::Mappers
+  class ImageMapper < BaseMapper
+    # since we're expecting a CSV with headers matching our property names,
+    # we'll save ourselves the hassle of writing out the key/val twice and
+    # generate a Hash from an Array of properties (save for the ones that
+    # require processing)
+    self.fields_map = %i[
+      contributor
+      creator
+      date
+      date_associated
+      date_scope_note
+      description
+      donor
+      inscription
+      language
+      keyword
+      note
+      original_item_extent
+      physical_medium
+      publisher
+      related_resource
+      repository_location
+      requested_by
+      research_assistance
+      resource_type
+      rights_holder
+      source
+      subject_ocm
+      subtitle
+      title
+      title_alternative
+    ].map { |k| [k, k.to_s] }.to_h
+
+    def fields
+      super + [
+        :location,
+        :rights_statement,
+        :subject
+      ]
+    end
+
+    def location
+      convert_uri_strings(metadata.fetch('location', []))
+    end
+
+    def rights_statement
+      convert_uri_strings(metadata.fetch('rights_statement', []))
+    end
+
+    def subject
+      convert_uri_strings(metadata.fetch('subject', []))
+    end
+  end
+end

--- a/spec/services/spot/mappers/image_mapper_spec.rb
+++ b/spec/services/spot/mappers/image_mapper_spec.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+RSpec.describe Spot::Mappers::ImageMapper do
+  let(:mapper) { described_class.new }
+  let(:metadata) { {} }
+
+  before { mapper.metadata = metadata }
+
+  describe '#contributor' do
+    subject { mapper.contributor }
+
+    let(:field) { 'contributor' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#creator' do
+    subject { mapper.creator }
+
+    let(:field) { 'creator' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#date' do
+    subject { mapper.date }
+
+    let(:field) { 'date' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#date_associated' do
+    subject { mapper.date_associated }
+
+    let(:field) { 'date_associated' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#date_scope_note' do
+    subject { mapper.date_scope_note }
+
+    let(:field) { 'date_scope_note' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#description' do
+    subject { mapper.description }
+
+    let(:field) { 'description' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#donor' do
+    subject { mapper.donor }
+
+    let(:field) { 'donor' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#inscription' do
+    subject { mapper.inscription }
+
+    let(:field) { 'inscription' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#language' do
+    subject { mapper.language }
+
+    let(:field) { 'language' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#location' do
+    subject { mapper.location }
+
+    let(:metadata) { { 'location' => ['http://id.worldcat.org/fast/1898429'] } }
+
+    it { is_expected.to all be_a(RDF::URI) }
+  end
+
+  describe '#keyword' do
+    subject { mapper.keyword }
+
+    let(:field) { 'keyword' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#note' do
+    subject { mapper.note }
+
+    let(:field) { 'note' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#original_item_extent' do
+    subject { mapper.original_item_extent }
+
+    let(:field) { 'original_item_extent' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#physical_medium' do
+    subject { mapper.physical_medium }
+
+    let(:field) { 'physical_medium' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#publisher' do
+    subject { mapper.publisher }
+
+    let(:field) { 'publisher' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#related_resource' do
+    subject { mapper.related_resource }
+
+    let(:field) { 'related_resource' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#repository_location' do
+    subject { mapper.repository_location }
+
+    let(:field) { 'repository_location' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#requested_by' do
+    subject { mapper.requested_by }
+
+    let(:field) { 'requested_by' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#research_assistance' do
+    subject { mapper.research_assistance }
+
+    let(:field) { 'research_assistance' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#resource_type' do
+    subject { mapper.resource_type }
+
+    let(:field) { 'resource_type' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#rights_holder' do
+    subject { mapper.rights_holder }
+
+    let(:field) { 'rights_holder' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#rights_statement' do
+    subject { mapper.rights_statement }
+
+    let(:metadata) { { 'rights_statement' => ['http://creativecommons.org/licenses/by-nc-sa/4.0/'] } }
+
+    it { is_expected.to all be_a(RDF::URI) }
+  end
+
+
+  describe '#source' do
+    subject { mapper.source }
+
+    let(:field) { 'source' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#subject' do
+    subject { mapper.subject }
+
+    let(:metadata) { { 'subject' => ['http://id.worldcat.org/fast/967482'] } }
+
+    it { is_expected.to all be_a(RDF::URI) }
+  end
+
+  describe '#subject_ocm' do
+    subject { mapper.subject_ocm }
+
+    let(:field) { 'subject_ocm' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#subtitle' do
+    subject { mapper.subtitle }
+
+    let(:field) { 'subtitle' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#title' do
+    subject { mapper.title }
+
+    let(:field) { 'title' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+  describe '#title_alternative' do
+    subject { mapper.title_alternative }
+
+    let(:field) { 'title_alternative' }
+
+    it_behaves_like 'a mapped field'
+  end
+
+end


### PR DESCRIPTION
since implementing Bulkrax continues to be bumped in priority, this should allow us to batch ingest works using CSV files whose headers match `Image`'s properties

- may need its own Parser/RecordImporter
- should we build out Publication/StudentWork mappers even if we don't have immediate plans to need them?