### PR TITLE
force StudentWorks into mediated_student_work_deposit admin_set for all users but admins

### DIFF
--- a/app/forms/hyrax/student_work_form.rb
+++ b/app/forms/hyrax/student_work_form.rb
@@ -65,7 +65,7 @@ module Hyrax
 
       def workflow_admin_set_id
         workflow = Sipity::Workflow.where(name: 'mediated_student_work_deposit').order(updated_at: :desc).first
-        return AdminSet::find_or_create_default_admin_set_id if workflow.nil?
+        return AdminSet.find_or_create_default_admin_set_id if workflow.nil?
 
         workflow.permission_template.admin_set.id
       end

--- a/app/helpers/spot/student_work_form_helper.rb
+++ b/app/helpers/spot/student_work_form_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Spot
+  module StudentWorkFormHelper
+    # Limit tabs on StudentWorkForm to just metadata and files unless the user is an admin
+    def form_tabs_for(form:)
+      return super unless form.is_a?(Hyrax::StudentWorkForm)
+      return super if current_user.admin?
+
+      %w[metadata files]
+    end
+  end
+end

--- a/spec/forms/hyrax/student_work_form_spec.rb
+++ b/spec/forms/hyrax/student_work_form_spec.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::StudentWorkForm do
+  before do
+    allow(AdminSet).to receive(:find_or_create_default_admin_set_id).and_return(AdminSet::DEFAULT_ID)
+    allow(Sipity::Workflow)
+      .to receive(:where)
+      .with(name: anything)
+      .and_return(workflow_relation)
+    allow(workflow_relation)
+      .to receive(:order)
+      .with(anything)
+      .and_return(workflow_results)
+  end
+
+  let(:workflow_relation) { instance_double('Sipity::Workflow::ActiveRecord_Relation') }
+  let(:workflow_results) { [] }
+
   it_behaves_like 'a Spot work form'
 
   it_behaves_like 'it handles required fields',
@@ -60,8 +75,9 @@ RSpec.describe Hyrax::StudentWorkForm do
     subject(:attributes) { described_class.model_attributes(raw_params) }
 
     let(:raw_params) { ActionController::Parameters.new(params) }
+    let(:params) { {} }
 
-    context 'handles nested attributes' do
+    describe 'handles nested attributes' do
       describe 'language' do
         let(:field) { 'language' }
 
@@ -78,6 +94,52 @@ RSpec.describe Hyrax::StudentWorkForm do
         let(:field) { 'division' }
 
         it_behaves_like 'it transforms a local vocabulary attribute'
+      end
+    end
+
+    describe 'admin_set_id' do
+      before do
+        allow(Hyrax::PermissionTemplate)
+          .to receive(:find_by)
+          .with(source_id: admin_set_id)
+          .and_return(permission_template)
+        allow(permission_template)
+          .to receive(:active_workflow)
+          .and_return(workflow)
+      end
+
+      let(:workflow_results) { [workflow] }
+      let(:workflow) { instance_double('Sipity::Workflow', permission_template: permission_template, allows_access_grant?: false) }
+      let(:permission_template) { instance_double('Hyrax::PermissionTemplate', admin_set: admin_set) }
+      let(:admin_set) { instance_double('AdminSet', id: admin_set_id) }
+      let(:admin_set_id) { 'abc123def' }
+
+      context 'when a value is present' do
+        let(:params) { { 'admin_set_id' => admin_set_id } }
+        let(:admin_set_id) { 'admin_set_id_value' }
+
+        it 'retains the value' do
+          # { 'admin_set_id' => 'admin_set_id_value' }
+          expect(attributes[:admin_set_id]).to eq admin_set_id
+        end
+      end
+
+      context 'when a value is not present' do
+        context 'when the expected workflow exists' do
+          it 'uses the admin_set assigned to the workflow' do
+            # { 'admin_set_id' => 'abc123def' }
+            expect(attributes[:admin_set_id]).to eq admin_set.id
+          end
+        end
+
+        context 'when the workflow does not exist' do
+          let(:workflow_results) { [] }
+
+          it 'uses the default admin_set id' do
+            # { 'admin_set_id' => 'admin_set/default' }
+            expect(attributes[:admin_set_id]).to eq AdminSet::DEFAULT_ID
+          end
+        end
       end
     end
   end

--- a/spec/helpers/spot/student_work_form_helper_spec.rb
+++ b/spec/helpers/spot/student_work_form_helper_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+RSpec.describe Spot::StudentWorkFormHelper do
+  describe '#form_tabs_for' do
+    subject { helper.form_tabs_for(form: form) }
+
+    let(:form_klass) { 'Hyrax::StudentWorkForm' }
+    let(:form) { instance_double(form_klass) }
+    let(:user) { create(:user) }
+
+    before do
+      allow(helper).to receive(:current_user).and_return(user)
+
+      # instance_double(form_klass).is_a?(Hyrax::StudentWorkForm) will always fail
+      # because the double's class is RSpec::Mocks::InstanceVerifyingDouble, so we
+      # need to tell the double how to do this
+      allow(form)
+        .to receive(:is_a?)
+        .with(Hyrax::StudentWorkForm)
+        .and_return(form_klass == 'Hyrax::StudentWorkForm')
+    end
+
+    context 'when the form is not a StudentWorkForm' do
+      let(:form_klass) { 'Hyrax::PublicationForm' }
+
+      it { is_expected.to eq %w[metadata files relationships] }
+    end
+
+    context 'when the user is an admin' do
+      let(:user) { create(:admin_user) }
+
+      it { is_expected.to eq %w[metadata files relationships] }
+    end
+
+    context 'when the user is not an admin' do
+      it { is_expected.to eq %w[metadata files] }
+    end
+  end
+end


### PR DESCRIPTION
there may be a better way to do this, but for non-admin users, we want StudentWork objects to always go through the mediated deposit workflow. this hides the "relationships" tab for those users and populates the form's `admin_set_id` property with the correct id after submission

closes #825