### PR TITLE
use a can? check for the metadata_only flag

### DIFF
--- a/app/presenters/spot/base_presenter.rb
+++ b/app/presenters/spot/base_presenter.rb
@@ -107,9 +107,13 @@ module Spot
     private
 
     def metadata_only_flag
+      # exit early if the work is public or the user is an admin
       return false if public? || current_ability.admin?
-      return false if registered? && current_ability.user_groups.include?(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED)
 
+      # check if the user can read the solr_document (checks read_users and _groups)
+      return false if current_ability.can?(:read, solr_document)
+
+      # otherwise, only display the metadata
       true
     end
   end

--- a/spec/support/shared_examples/spot_presenter.rb
+++ b/spec/support/shared_examples/spot_presenter.rb
@@ -2,10 +2,10 @@
 RSpec.shared_examples 'a Spot presenter' do
   subject(:presenter) { described_class.new(solr_doc, ability) }
 
-  let(:factory) { described_class.name.split('::').last.gsub(/Presenter/, '').underscore.to_sym }
   let(:solr_doc) { SolrDocument.new(solr_data) }
   let(:solr_data) { object.to_solr }
   let(:object) { build(factory) }
+  let(:factory) { described_class.name.split('::').last.gsub(/Presenter/, '').underscore.to_sym }
   let(:ability) { Ability.new(build(:user)) }
 
   it_behaves_like 'it renders an attribute to HTML'
@@ -85,8 +85,13 @@ RSpec.shared_examples 'a Spot presenter' do
 
     let(:admin_ability) { Ability.new(build(:admin_user)) }
     let(:registered_ability) { Ability.new(build(:registered_user)) }
-    let(:solr_data) { { id: 'abc123def' }.merge(_solr_data) }
+    let(:has_model_string) { factory.to_s.camelcase.constantize.to_s }
+    let(:solr_data) { { id: 'abc123def', has_model_ssim: [has_model_string] }.merge(_solr_data) }
     let(:_solr_data) { {} }
+
+    # `metadata_only?` calls `can?(:read, solr_document)` so the data needs to be persisted
+    before { ActiveFedora::SolrService.add(solr_data, commit: true) }
+    after { ActiveFedora::SolrService.delete(solr_data[:id]) }
 
     context 'when the ability is admin' do
       let(:ability) { admin_ability }

--- a/spec/support/shared_examples/spot_presenter.rb
+++ b/spec/support/shared_examples/spot_presenter.rb
@@ -85,8 +85,7 @@ RSpec.shared_examples 'a Spot presenter' do
 
     let(:admin_ability) { Ability.new(build(:admin_user)) }
     let(:registered_ability) { Ability.new(build(:registered_user)) }
-    let(:has_model_string) { factory.to_s.camelcase.constantize.to_s }
-    let(:solr_data) { { id: 'abc123def', has_model_ssim: [has_model_string] }.merge(_solr_data) }
+    let(:solr_data) { { id: 'abc123def' }.merge(_solr_data) }
     let(:_solr_data) { {} }
 
     # `metadata_only?` calls `can?(:read, solr_document)` so the data needs to be persisted


### PR DESCRIPTION
we were only checking for authenticated users/permissions in `Spot::BasePresenter#metadata_only_flag` which was excluding users/groups added to a work's `read_users`/`read_groups`. this replaces that check with a broader `can?(:read, solr_document)` call that should be more extensive

closes #845 