### PR TITLE
put "Add new work" button on general user's dashboard (where applicable)

### DIFF
--- a/app/controllers/hyrax/dashboard_controller.rb
+++ b/app/controllers/hyrax/dashboard_controller.rb
@@ -12,6 +12,9 @@ module Hyrax
     before_action :authenticate_user!
     before_action :build_breadcrumbs, only: [:show]
 
+    class_attribute :create_work_presenter_class
+    self.create_work_presenter_class = Hyrax::SelectTypeListPresenter
+
     ##
     # @!attribute [rw] sidebar_partials
     #   @return [Hash]
@@ -20,7 +23,6 @@ module Hyrax
     #   Hyrax::DashboardController.sidebar_partials[:tasks] << "hyrax/dashboard/sidebar/custom_task"
     # class_attribute :sidebar_partials
     # self.sidebar_partials = { activity: [], configuration: [], repository_content: [], tasks: [] }
-
     def show
       if can? :read, :admin_dashboard
         @presenter = Hyrax::Admin::DashboardPresenter.new
@@ -30,6 +32,7 @@ module Hyrax
       # @see {Ability#depositor_abilities}
       elsif can? :read, :dashboard
         @presenter = Dashboard::UserPresenter.new(current_user, view_context, params[:since])
+        @create_work_presenter = create_work_presenter_class.new(current_user)
         render 'show_user'
       else
         redirect_to root_path

--- a/app/views/hyrax/dashboard/show_user.html.erb
+++ b/app/views/hyrax/dashboard/show_user.html.erb
@@ -1,0 +1,79 @@
+<% provide :page_header do %>
+  <h1><%= t("hyrax.dashboard.title") %></h1>
+<% end %>
+
+<% if current_ability.can_create_any_work? %>
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <% if @create_work_presenter.many? %>
+        <% if Flipflop.batch_upload? %>
+          <%= link_to(
+                t(:'helpers.action.batch.new'),
+                '#',
+                data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'batch' },
+                class: 'btn btn-primary'
+              ) %>
+        <% end %>
+        <%= link_to(
+              t(:'helpers.action.work.new'),
+              '#',
+              data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'single' },
+              class: 'btn btn-primary'
+            ) %>
+      <% else # simple link to the first work type %>
+        <% if Flipflop.batch_upload? %>
+          <%= link_to(
+              t(:'helpers.action.batch.new'),
+              hyrax.new_batch_upload_path(payload_concern: @create_work_presenter.first_model),
+              class: 'btn btn-primary'
+              ) %>
+        <% end %>
+        <%= link_to(
+              t(:'helpers.action.work.new'),
+              new_polymorphic_path([main_app, @create_work_presenter.first_model]),
+              class: 'btn btn-primary'
+            ) %>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<div class="panel panel-default user-activity">
+  <div class="panel-heading">
+    <h3 class="panel-title "><%= t("hyrax.dashboard.user_activity.title") %></h3>
+  </div>
+  <div class="panel-body">
+    <%= @presenter.render_recent_activity %>
+  </div>
+</div>
+
+<div class="panel panel-default" id="notifications">
+  <div class="panel-heading">
+    <h3 class="panel-title "><%= t("hyrax.dashboard.user_notifications") %></h3>
+  </div>
+  <div class="panel-body">
+    <%= @presenter.render_recent_notifications %>
+    <%= @presenter.link_to_additional_notifications %>
+  </div>
+</div>
+
+<% if Flipflop.proxy_deposit? %>
+  <div class="panel panel-default" id="proxy_management">
+    <div class="panel-heading">
+      <h3 class="panel-title "><%= t("hyrax.dashboard.current_proxies") %></h3>
+    </div>
+    <div class="panel-body">
+      <%= render 'hyrax/dashboard/_index_partials/current_proxy_rights', user: current_user %>
+      <%= @presenter.link_to_manage_proxies %>
+    </div>
+  </div>
+<% end %>
+
+<div class="panel panel-default transfers">
+  <div class="panel-heading">
+    <h3 class="panel-title "><%= t("hyrax.dashboard.transfer_of_ownership") %></h3>
+  </div>
+  <div class="panel-body">
+    <%= render 'hyrax/dashboard/_index_partials/transfers', presenter: @presenter.transfers %>
+  </div>
+</div>

--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -1,0 +1,13 @@
+  <li class="h5"><%= t('hyrax.admin.sidebar.repository_objects') %></li>
+
+  <% if current_user.can?(:manage_any?, Collection) %>
+  <%= menu.nav_link(hyrax.my_collections_path,
+                    also_active_for: hyrax.dashboard_collections_path) do %>
+    <span class="fa fa-folder-open" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collections') %></span>
+  <% end %>
+
+  <% end %>
+  <%= menu.nav_link(hyrax.my_works_path,
+                    also_active_for: hyrax.dashboard_works_path) do %>
+    <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
+  <% end %>


### PR DESCRIPTION
- adds an "Add new work" button at the top of the dashboard for non-admin users
- removes "Collections" tab from sidebar if the user can't `:manage_any` Collections