### PR TITLE
automatically create student work admin set

### DIFF
--- a/app/services/spot/student_work_admin_set_create_service.rb
+++ b/app/services/spot/student_work_admin_set_create_service.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+module Spot
+  class StudentWorkAdminSetCreateService
+    ADMIN_SET_ID = 'admin_set/student_work'
+    DEFAULT_TITLE = ['Student Work'].freeze
+    WORKFLOW_NAME = 'mediated_student_work_deposit'
+
+    def self.find_or_create_student_work_admin_set
+      AdminSet.find(ADMIN_SET_ID)
+    rescue ActiveFedora::ObjectNotFoundError
+      new.create_student_work_admin_set!
+    end
+
+    def create_student_work_admin_set!
+      raise "Can't create StudentWork admin_set because #{workflow_json_name} does not exist" unless File.exist?(workflow_json_path)
+
+      admin_set = create_admin_set
+      permission_template = create_permission_template!(admin_set: admin_set)
+      workflow = find_or_create_workflow(permission_template: permission_template)
+      activate_workflow!(workflow: workflow, permission_template: permission_template)
+      admin_set
+    end
+
+    private
+
+    # Admins can manage, Registered users can deposit
+    def access_grants_attributes
+      {
+        '0' => {
+          agent_type: Hyrax::PermissionTemplateAccess::GROUP,
+          agent_id: Ability.admin_group_name,
+          access: Hyrax::PermissionTemplateAccess::MANAGE
+        },
+        '1' => {
+          agent_type: Hyrax::PermissionTemplateAccess::GROUP,
+          agent_id: Ability.registered_group_name,
+          access: Hyrax::PermissionTemplateAccess::DEPOSIT
+        }
+      }
+    end
+
+    def activate_workflow!(workflow:, permission_template:)
+      Sipity::Workflow.activate!(permission_template: permission_template, workflow_id: workflow.id)
+    end
+
+    def create_admin_set
+      AdminSet.create(id: ADMIN_SET_ID, title: DEFAULT_TITLE)
+    end
+
+    def create_permission_template!(admin_set:)
+      permissions = Hyrax::PermissionTemplate.create!(source_id: admin_set.id, access_grants_attributes: access_grants_attributes)
+      admin_set.reset_access_controls!
+      permissions
+    end
+
+    def find_or_create_workflow(permission_template:)
+      workflow = Sipity::Workflow.find_by(name: WORKFLOW_NAME, permission_template: permission_template)
+      return workflow unless workflow.nil?
+
+      Hyrax::Workflow::WorkflowImporter.generate_from_json_file(path: workflow_json_path, permission_template: permission_template).first
+    end
+
+    def workflow_json_name
+      "#{WORKFLOW_NAME}_workflow.json"
+    end
+
+    def workflow_json_path
+      Rails.root.join('config', 'workflows', workflow_json_name)
+    end
+  end
+end

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -106,4 +106,6 @@ Rails.application.config.to_prepare do
     remove_const(:VISIBILITY_LABEL_CLASS) if const_defined?(:VISIBILITY_LABEL_CLASS)
     const_set(:VISIBILITY_LABEL_CLASS, old_visibility_label_class.tap { |h| h[:metadata] = 'label-info' }.freeze)
   end
+
+  AdminSet::STUDENT_WORK_ID = 'admin_set/student_work'
 end

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -107,5 +107,6 @@ Rails.application.config.to_prepare do
     const_set(:VISIBILITY_LABEL_CLASS, old_visibility_label_class.tap { |h| h[:metadata] = 'label-info' }.freeze)
   end
 
+  # Define this constant, intended to be similar to AdminSet::DEFAULT_ID
   AdminSet::STUDENT_WORK_ID = 'admin_set/student_work'
 end

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -108,5 +108,5 @@ Rails.application.config.to_prepare do
   end
 
   # Define this constant, intended to be similar to AdminSet::DEFAULT_ID
-  AdminSet::STUDENT_WORK_ID = 'admin_set/student_work'
+  AdminSet::STUDENT_WORK_ID = Spot::StudentWorkAdminSetCreateService::ADMIN_SET_ID
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,9 +4,10 @@
 Rake::Task['hyrax:default_admin_set:create'].invoke
 Rake::Task['hyrax:default_collection_types:create'].invoke
 
-# local set up: create roles + default collections + deposit user
+# local set up: create roles, deposit user, + admin_sets
 Rake::Task['spot:roles:default'].invoke
 Rake::Task['spot:create_deposit_user'].invoke
+Rake::Task['spot:student_work_admin_set:create'].invoke
 
 if ENV['DEV_ADMIN_USERS'].present?
   admin = Role.find_by(name: 'admin')

--- a/lib/tasks/spot/student_work_admin_set.rake
+++ b/lib/tasks/spot/student_work_admin_set.rake
@@ -10,10 +10,15 @@ namespace :spot do
       rescue ActiveFedora::ObjectNotFoundError
         # Create the AdminSet object
         admin_set = AdminSet.create(id: id, title: ['Student Works'])
+      rescue Ldp::Gone
+        puts "AdminSet(#{id}) has been deleted. Run `AdminSet.eradicate('#{id}')` to clear the tombstone"
+        next
+      end
 
-        # Create the corresponding PermissionTemplate
-        # - admin users can manage
-        # - registered users can deposit
+      # Create the corresponding PermissionTemplate if it doesn't exist
+      # - admin users can manage
+      # - registered users can deposit
+      unless Hyrax::PermissionTemplate.exists?(source_id: id)
         permission_template = Hyrax::PermissionTemplate.create(
           source_id: admin_set.id,
           access_grants_attributes: {
@@ -29,12 +34,24 @@ namespace :spot do
             }
           }
         )
+      end
 
-        # Generate the mediated_student_work_deposit workflow and assign it to the permission template
-        Hyrax::Workflow::WorkflowImporter.generate_from_json_file(
-          path: Rails.root.join('config', 'workflows', 'mediated_student_work_deposit_workflow.json').to_s,
-          permission_template: permission_template
-        )
+      # make sure the Sipity::Workflow exists
+      workflow = Sipity::Workflow.find_by(name: 'mediated_student_work_deposit', permission_template: permission_template)
+
+      if workflow.nil?
+        # Generate the mediated_student_work_deposit workflow and assign it to the permission template.
+        # The Importer will return each workflow defined in the json file, and ours only defines one.
+        workflow = Hyrax::Workflow::WorkflowImporter.generate_from_json_file(
+                     path: Rails.root.join('config', 'workflows', 'mediated_student_work_deposit_workflow.json').to_s,
+                     permission_template: permission_template
+                   ).first
+      end
+
+      unless workflow.active
+        # activate the workflow
+        workflow.active = true
+        workflow.save
       end
 
       puts %(Successfully created "#{admin_set.title.first}" admin set)

--- a/lib/tasks/spot/student_work_admin_set.rake
+++ b/lib/tasks/spot/student_work_admin_set.rake
@@ -2,56 +2,13 @@
 namespace :spot do
   namespace :student_work_admin_set do
     task create: [:environment] do
-      id = AdminSet::STUDENT_WORK_ID
       admin_set = nil
-
       begin
-        admin_set = AdminSet.find(id)
-      rescue ActiveFedora::ObjectNotFoundError
-        # Create the AdminSet object
-        admin_set = AdminSet.create(id: id, title: ['Student Works'])
+        admin_set = Spot::StudentWorkAdminSetCreateService.find_or_create_student_work_admin_set
       rescue Ldp::Gone
+        id = Spot::StudentWorkAdminSetCreateService::ADMIN_SET_ID
         puts "AdminSet(#{id}) has been deleted. Run `AdminSet.eradicate('#{id}')` to clear the tombstone"
         next
-      end
-
-      # Create the corresponding PermissionTemplate if it doesn't exist
-      # - admin users can manage
-      # - registered users can deposit
-      unless Hyrax::PermissionTemplate.exists?(source_id: id)
-        permission_template = Hyrax::PermissionTemplate.create(
-          source_id: admin_set.id,
-          access_grants_attributes: {
-            '0' => {
-              agent_type: Hyrax::PermissionTemplateAccess::GROUP,
-              agent_id: Ability.admin_group_name,
-              access: Hyrax::PermissionTemplateAccess::MANAGE
-            },
-            '1' => {
-              agent_type: Hyrax::PermissionTemplateAccess::GROUP,
-              agent_id: Ability.registered_group_name,
-              access: Hyrax::PermissionTemplateAccess::DEPOSIT
-            }
-          }
-        )
-      end
-
-      # make sure the Sipity::Workflow exists
-      workflow = Sipity::Workflow.find_by(name: 'mediated_student_work_deposit', permission_template: permission_template)
-
-      if workflow.nil?
-        # Generate the mediated_student_work_deposit workflow and assign it to the permission template.
-        # The Importer will return each workflow defined in the json file, and ours only defines one.
-        workflow = Hyrax::Workflow::WorkflowImporter.generate_from_json_file(
-                     path: Rails.root.join('config', 'workflows', 'mediated_student_work_deposit_workflow.json').to_s,
-                     permission_template: permission_template
-                   ).first
-      end
-
-      unless workflow.active
-        # activate the workflow
-        workflow.active = true
-        workflow.save
       end
 
       puts %(Successfully created "#{admin_set.title.first}" admin set)

--- a/lib/tasks/spot/student_work_admin_set.rake
+++ b/lib/tasks/spot/student_work_admin_set.rake
@@ -3,11 +3,11 @@ namespace :spot do
   namespace :student_work_admin_set do
     task create: [:environment] do
       admin_set = nil
+
       begin
-        admin_set = Spot::StudentWorkAdminSetCreateService.find_or_create_student_work_admin_set
+        admin_set = AdminSet.find(Spot::StudentWorkAdminSetCreateService.find_or_create_student_work_admin_set_id)
       rescue Ldp::Gone
-        id = Spot::StudentWorkAdminSetCreateService::ADMIN_SET_ID
-        puts "AdminSet(#{id}) has been deleted. Run `AdminSet.eradicate('#{id}')` to clear the tombstone"
+        puts "AdminSet(ID=#{Spot::StudentWorkAdminSetCreateService::ADMIN_SET_ID}) has been deleted."
         next
       end
 

--- a/lib/tasks/spot/student_work_admin_set.rake
+++ b/lib/tasks/spot/student_work_admin_set.rake
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+namespace :spot do
+  namespace :student_work_admin_set do
+    task create: [:environment] do
+      id = AdminSet::STUDENT_WORK_ID
+      admin_set = nil
+
+      begin
+        admin_set = AdminSet.find(id)
+      rescue ActiveFedora::ObjectNotFoundError
+        # Create the AdminSet object
+        admin_set = AdminSet.create(id: id, title: ['Student Works'])
+
+        # Create the corresponding PermissionTemplate
+        # - admin users can manage
+        # - registered users can deposit
+        permission_template = Hyrax::PermissionTemplate.create(
+          source_id: admin_set.id,
+          access_grants_attributes: {
+            '0' => {
+              agent_type: Hyrax::PermissionTemplateAccess::GROUP,
+              agent_id: Ability.admin_group_name,
+              access: Hyrax::PermissionTemplateAccess::MANAGE
+            },
+            '1' => {
+              agent_type: Hyrax::PermissionTemplateAccess::GROUP,
+              agent_id: Ability.registered_group_name,
+              access: Hyrax::PermissionTemplateAccess::DEPOSIT
+            }
+          }
+        )
+
+        # Generate the mediated_student_work_deposit workflow and assign it to the permission template
+        Hyrax::Workflow::WorkflowImporter.generate_from_json_file(
+          path: Rails.root.join('config', 'workflows', 'mediated_student_work_deposit_workflow.json').to_s,
+          permission_template: permission_template
+        )
+      end
+
+      puts %(Successfully created "#{admin_set.title.first}" admin set)
+    end
+  end
+end

--- a/spec/forms/hyrax/student_work_form_spec.rb
+++ b/spec/forms/hyrax/student_work_form_spec.rb
@@ -98,25 +98,19 @@ RSpec.describe Hyrax::StudentWorkForm do
     end
 
     describe 'admin_set_id' do
-      before do
-        allow(Hyrax::PermissionTemplate)
-          .to receive(:find_by)
-          .with(source_id: admin_set_id)
-          .and_return(permission_template)
-        allow(permission_template)
-          .to receive(:active_workflow)
-          .and_return(workflow)
-      end
-
-      let(:workflow_results) { [workflow] }
-      let(:workflow) { instance_double('Sipity::Workflow', permission_template: permission_template, allows_access_grant?: false) }
-      let(:permission_template) { instance_double('Hyrax::PermissionTemplate', admin_set: admin_set) }
-      let(:admin_set) { instance_double('AdminSet', id: admin_set_id) }
-      let(:admin_set_id) { 'abc123def' }
-
       context 'when a value is present' do
         let(:params) { { 'admin_set_id' => admin_set_id } }
         let(:admin_set_id) { 'admin_set_id_value' }
+        let(:permission_template) { instance_double(Hyrax::PermissionTemplate, active_workflow: workflow) }
+        let(:workflow) { instance_double(Sipity::Workflow, allows_access_grant?: false) }
+
+        # @see https://github.com/samvera/hyrax/blob/v2.9.6/app/forms/hyrax/forms/work_form.rb#L183-L194
+        before do
+          allow(Hyrax::PermissionTemplate)
+            .to receive(:find_by!)
+            .with(source_id: admin_set_id)
+            .and_return(permission_template)
+        end
 
         it 'retains the value' do
           # { 'admin_set_id' => 'admin_set_id_value' }
@@ -125,18 +119,26 @@ RSpec.describe Hyrax::StudentWorkForm do
       end
 
       context 'when a value is not present' do
-        context 'when the expected workflow exists' do
-          it 'uses the admin_set assigned to the workflow' do
-            # { 'admin_set_id' => 'abc123def' }
-            expect(attributes[:admin_set_id]).to eq admin_set.id
+        context 'the StudentWorkAdminSetCreateService is invoked' do
+          before do
+            allow(Spot::StudentWorkAdminSetCreateService)
+              .to receive(:find_or_create_student_work_admin_set_id)
+              .and_return(Spot::StudentWorkAdminSetCreateService::ADMIN_SET_ID)
+          end
+
+          it 'uses the StudentWork AdminSet id' do
+            expect(attributes[:admin_set_id]).to eq Spot::StudentWorkAdminSetCreateService::ADMIN_SET_ID
           end
         end
 
-        context 'when the workflow does not exist' do
-          let(:workflow_results) { [] }
+        context 'when the StudentWork AdminSet no longer exists' do
+          before do
+            allow(Spot::StudentWorkAdminSetCreateService)
+              .to receive(:find_or_create_student_work_admin_set_id)
+              .and_raise(Ldp::Gone)
+          end
 
           it 'uses the default admin_set id' do
-            # { 'admin_set_id' => 'admin_set/default' }
             expect(attributes[:admin_set_id]).to eq AdminSet::DEFAULT_ID
           end
         end

--- a/spec/forms/hyrax/student_work_form_spec.rb
+++ b/spec/forms/hyrax/student_work_form_spec.rb
@@ -1,20 +1,5 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::StudentWorkForm do
-  before do
-    allow(AdminSet).to receive(:find_or_create_default_admin_set_id).and_return(AdminSet::DEFAULT_ID)
-    allow(Sipity::Workflow)
-      .to receive(:where)
-      .with(name: anything)
-      .and_return(workflow_relation)
-    allow(workflow_relation)
-      .to receive(:order)
-      .with(anything)
-      .and_return(workflow_results)
-  end
-
-  let(:workflow_relation) { instance_double('Sipity::Workflow::ActiveRecord_Relation') }
-  let(:workflow_results) { [] }
-
   it_behaves_like 'a Spot work form'
 
   it_behaves_like 'it handles required fields',

--- a/spec/services/spot/student_work_admin_set_create_service_spec.rb
+++ b/spec/services/spot/student_work_admin_set_create_service_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+RSpec.describe Spot::StudentWorkAdminSetCreateService do
+  describe '.find_or_create_student_work_admin_set', clean: true do
+    subject { described_class.find_or_create_student_work_admin_set }
+
+    let(:admin_set) { instance_double('AdminSet') }
+
+    context 'when the admin_set exists' do
+      before do
+        allow(AdminSet).to receive(:find).with(described_class::ADMIN_SET_ID).and_return(admin_set)
+      end
+
+      it { is_expected.to eq admin_set }
+    end
+
+    context 'when the admin_set does not exist' do
+      let(:admin_set) { AdminSet.find(described_class::ADMIN_SET_ID) }
+
+      # This is going to be expensive, so I'm just going to test everything in the one block
+      it 'creates an AdminSet, Hyrax::PermissionTemplates, Sipity::Workflow and activates the workflow' do
+        described_class.find_or_create_student_work_admin_set
+
+        # Test the permission_template is persisted and includes 2 access grants:
+        # - 1 provides manage access to admin users
+        # - 1 provides deposit access to registered users
+        expect(admin_set.permission_template).to be_persisted
+        expect(admin_set.permission_template.access_grants.count).to eq(2)
+
+        # We're only loading the 'mediated_student_work_deposit' workflow,
+        # but we need to make sure it's activated.
+        expect(admin_set.active_workflow).to be_persisted
+        expect(admin_set.active_workflow.name).to eq described_class::WORKFLOW_NAME
+
+        expect(admin_set.read_groups).not_to include('public')
+        expect(admin_set.edit_groups).to eq ['admin']
+      end
+    end
+
+    context 'when the workflow configuration file does not exist' do
+      before do
+        allow(File)
+          .to receive(:exist?)
+          .with(Rails.root.join('config', 'workflows', "#{described_class::WORKFLOW_NAME}_workflow.json"))
+          .and_return(false)
+      end
+
+      it 'raises an error' do
+        expect { described_class.find_or_create_student_work_admin_set }
+          .to raise_error(RuntimeError)
+      end
+    end
+  end
+end

--- a/spec/services/spot/student_work_admin_set_create_service_spec.rb
+++ b/spec/services/spot/student_work_admin_set_create_service_spec.rb
@@ -1,24 +1,22 @@
 # frozen_string_literal: true
 RSpec.describe Spot::StudentWorkAdminSetCreateService do
-  describe '.find_or_create_student_work_admin_set', clean: true do
-    subject { described_class.find_or_create_student_work_admin_set }
-
-    let(:admin_set) { instance_double('AdminSet') }
+  describe '.find_or_create_student_work_admin_set_id', clean: true do
+    subject { described_class.find_or_create_student_work_admin_set_id }
 
     context 'when the admin_set exists' do
       before do
-        allow(AdminSet).to receive(:find).with(described_class::ADMIN_SET_ID).and_return(admin_set)
+        allow(AdminSet).to receive(:exists?).with(described_class::ADMIN_SET_ID).and_return(true)
       end
 
-      it { is_expected.to eq admin_set }
+      it { is_expected.to eq described_class::ADMIN_SET_ID }
     end
 
     context 'when the admin_set does not exist' do
-      let(:admin_set) { AdminSet.find(described_class::ADMIN_SET_ID) }
+      let(:admin_set) { AdminSet.find(described_class.find_or_create_student_work_admin_set_id) }
 
       # This is going to be expensive, so I'm just going to test everything in the one block
       it 'creates an AdminSet, Hyrax::PermissionTemplates, Sipity::Workflow and activates the workflow' do
-        described_class.find_or_create_student_work_admin_set
+        # described_class.find_or_create_student_work_admin_set_id
 
         # Test the permission_template is persisted and includes 2 access grants:
         # - 1 provides manage access to admin users
@@ -45,7 +43,7 @@ RSpec.describe Spot::StudentWorkAdminSetCreateService do
       end
 
       it 'raises an error' do
-        expect { described_class.find_or_create_student_work_admin_set }
+        expect { described_class.find_or_create_student_work_admin_set_id }
           .to raise_error(RuntimeError)
       end
     end


### PR DESCRIPTION
since we have a workflow and model type that are closely tied with student submissions, we should also create an admin_set dedicated to those objects as well. this should only need to be run once to create the admin_set (performed during the db/seeds stage) and will return the results of `AdminSet.find('admin_set/student_work')` otherwise.

i originally built it out as just a rake task, but upgrading to Hyrax 3 will require some changes, so we might be better off with it as a service.