### PR TITLE
use locales for page titles

### DIFF
--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -3,4 +3,12 @@ module HyraxHelper
   include ::BlacklightHelper
   include Hyrax::BlacklightOverride
   include Hyrax::HyraxHelperBehavior
+
+  # @see https://github.com/samvera/hyrax/blob/v2.9.6/app/helpers/hyrax/title_helper.rb#L18-L22
+  def default_page_title
+    i18n_key = "spot.#{controller_name.underscore}"
+    i18n_key = "#{i18n_key}.#{action_name.downcase}" if action_name
+
+    construct_page_title(t("#{i18n_key}.page_title", default: controller_name.titleize))
+  end
 end

--- a/app/views/spot/page/about.html.erb
+++ b/app/views/spot/page/about.html.erb
@@ -1,5 +1,3 @@
-<% provide(:page_title) { t('.page_title', name: application_name) } %>
-
 <div class="page-header">
   <h1><%= t('.header', name: application_name) %></h1>
 </div>

--- a/app/views/spot/page/help.html.erb
+++ b/app/views/spot/page/help.html.erb
@@ -1,5 +1,3 @@
-<% provide(:page_title) { t('.page_title', name: application_name) } %>
-
 <div class="page-header">
   <h1><%= t('.header', name: application_name) %></h1>
 </div>

--- a/app/views/spot/page/terms_of_use.html.erb
+++ b/app/views/spot/page/terms_of_use.html.erb
@@ -1,5 +1,3 @@
-<% provide(:page_title) { t('.page_title', name: application_name) } %>
-
 <div class="page-header">
   <h1>Terms of Use</h1>
 </div>

--- a/config/locales/spot.en.yml
+++ b/config/locales/spot.en.yml
@@ -42,6 +42,10 @@ en:
         sidebar: System Status
         title: System Status
 
+    embargoes:
+      index:
+        page_title: 'Manage Embargoes'
+
     error:
       404:
         page_title: 'Page not found // %{name}'
@@ -82,6 +86,10 @@ en:
         issn: ISSN
         isbn: ISBN
 
+    leases:
+      index:
+        page_title: 'Manage Leases'
+
     links:
       department:
         name: Digital Scholarship Services
@@ -100,13 +108,13 @@ en:
     page:
       about:
         header: About %{name}
-        page_title: About // %{name}
+        page_title: About
       help:
         header: Help using %{name}
-        page_title: Help // %{name}
+        page_title: Help
       terms_of_use:
         header: Terms of Use
-        page_title: Terms of Use // %{name}
+        page_title: Terms of Use
 
     work:
       access_message:
@@ -137,3 +145,7 @@ en:
           jsonld: View metadata as JSON-LD
           nt: View metadata as NTriples
           ttl: View metadata as TTL
+
+    workflows:
+      index:
+        page_title: 'Review Submissions'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,9 @@ Rails.application.routes.draw do
   get '/help', to: 'spot/page#help', as: 'help'
   get '/terms-of-use', to: 'spot/page#terms_of_use', as: 'terms_of_use'
 
+  # Hyrax's terms of use page is found at /terms, so we'll just redirect to ours
+  get '/terms', to: redirect('/terms-of-use')
+
   # collections landing page
   get '/collections', to: 'spot/collections#index', as: 'collections'
 


### PR DESCRIPTION
on most pages, the only way to override the hyrax defaults ("<action_name> <controller_name> // <site_name>") is to copy the view partial locally. this overrides hyrax's [default page title](https://github.com/samvera/hyrax/blob/v2.9.6/app/helpers/hyrax/title_helper.rb#L18-L22) helper method to allow us define page titles per controller via locales, and removes the "action_name" from the default so we don't have titles like "Index Workflow Roles // Lafayette Digital Repository"