### PR TITLE
StudentWorkForm updates

### DIFF
--- a/app/forms/hyrax/student_work_form.rb
+++ b/app/forms/hyrax/student_work_form.rb
@@ -10,7 +10,8 @@ module Hyrax
 
     self.model_class = ::StudentWork
     self.required_fields = [
-      :title, :creator, :advisor, :academic_department, :description, :date, :resource_type, :rights_statement
+      :title, :creator, :advisor, :academic_department,
+      :description, :date, :resource_type, :rights_statement
     ]
 
     self.terms = [
@@ -31,22 +32,39 @@ module Hyrax
       :abstract,
       :language,
       :related_resource,
-      :access_note,
-
-      # librarian-added fields, applied during review
       :organization,
       :subject,
       :keyword,
       :bibliographic_citation,
       :standard_identifier,
+      :access_note,
       :note
     ].concat(hyrax_form_fields)
 
+    # Fields to appear above the fold (before the "Additional fields" button).
+    # Generally, this is primarily where the required_fields will be displayed,
+    # but for student users we're pre-filling :rights_statement and :rights_holder
+    # and don't need to have those appear above the fold.
+    #
+    # @return [Array<Symbol>]
     def primary_terms
-      [
-        :title, :creator, :advisor, :academic_department, :description,
-        :date, :resource_type, :rights_statement, :rights_holder
-      ]
+      fields = required_fields
+      return fields unless current_user.student?
+
+      fields - [:rights_statement, :rights_holder]
+    end
+
+    # Fields to appear below the "Additional fields" button. For admin users,
+    # we're showing `terms - primary_fields`, but for the rest of users, we're
+    # hiding the internal note fields.
+    #
+    # @return [Array<Symbol>]
+    # @todo this might be better off in the Spot::Forms::WorkForm base?
+    def secondary_terms
+      list = super
+      return list unless current_user.admin?
+
+      list - [:note, :access_note]
     end
 
     class << self

--- a/app/forms/hyrax/student_work_form.rb
+++ b/app/forms/hyrax/student_work_form.rb
@@ -6,8 +6,7 @@ module Hyrax
 
     self.model_class = ::StudentWork
     self.required_fields = [
-      :title, :creator, :advisor, :academic_department, :division,
-      :description, :date, :date_available, :rights_statement, :resource_type
+      :title, :creator, :advisor, :academic_department, :description, :date, :rights_statement, :resource_type
     ]
 
     self.terms = [
@@ -40,8 +39,8 @@ module Hyrax
 
     def primary_terms
       [
-        :title, :creator, :advisor, :academic_department, :division, :description,
-        :date, :date_available, :rights_statement, :resource_type
+        :title, :creator, :advisor, :academic_department, :description,
+        :date, :resource_type, :rights_statement
       ]
     end
 

--- a/app/forms/hyrax/student_work_form.rb
+++ b/app/forms/hyrax/student_work_form.rb
@@ -48,7 +48,7 @@ module Hyrax
     #
     # @return [Array<Symbol>]
     def primary_terms
-      fields = required_fields
+      fields = required_fields + [:rights_holder]
       return fields unless current_user.student?
 
       fields - [:rights_statement, :rights_holder]

--- a/app/forms/hyrax/student_work_form.rb
+++ b/app/forms/hyrax/student_work_form.rb
@@ -10,7 +10,7 @@ module Hyrax
 
     self.model_class = ::StudentWork
     self.required_fields = [
-      :title, :creator, :advisor, :academic_department, :description, :date, :rights_statement, :resource_type
+      :title, :creator, :advisor, :academic_department, :description, :date, :resource_type, :rights_statement
     ]
 
     self.terms = [
@@ -23,8 +23,9 @@ module Hyrax
       :description,
       :date,
       :date_available,
-      :rights_statement,
       :resource_type,
+      :rights_statement,
+      :rights_holder,
 
       # below the fold
       :abstract,
@@ -44,7 +45,7 @@ module Hyrax
     def primary_terms
       [
         :title, :creator, :advisor, :academic_department, :description,
-        :date, :resource_type, :rights_statement
+        :date, :resource_type, :rights_statement, :rights_holder
       ]
     end
 
@@ -80,6 +81,14 @@ module Hyrax
     protected
 
     # Called at the end of #initialize. We're using this to add some defaults for student users
+    # when the work is created:
+    #
+    #   - creator
+    #     - user's name, authority style ("Lastname, Firstname")
+    #   - rights_statement
+    #     - In Copyright, Educational Use Permitted (via DEFAULT_RIGHTS_STATEMENT_URI constant)
+    #   - rights_holder
+    #     - user's name, authority style
     def initialize_fields
       super
 
@@ -89,6 +98,7 @@ module Hyrax
       # but juuust in case...
       self[:creator] = [current_user.authority_name] if self[:creator].all?(&:blank?)
       self[:rights_statement] = DEFAULT_RIGHTS_STATEMENT_URI if self[:rights_statement].blank?
+      self[:rights_holder] = [current_user.authority_name] if self[:rights_holder].all?(&:blank?)
     end
   end
 end

--- a/app/forms/hyrax/student_work_form.rb
+++ b/app/forms/hyrax/student_work_form.rb
@@ -20,7 +20,6 @@ module Hyrax
       :creator,
       :advisor,
       :academic_department,
-      :division,
       :description,
       :date,
       :date_available,
@@ -29,6 +28,7 @@ module Hyrax
       :rights_holder,
 
       # below the fold
+      :division,
       :abstract,
       :language,
       :related_resource,
@@ -62,7 +62,7 @@ module Hyrax
     # @todo this might be better off in the Spot::Forms::WorkForm base?
     def secondary_terms
       list = super
-      return list unless current_user.admin?
+      return list if current_user.admin?
 
       list - [:note, :access_note]
     end

--- a/app/services/spot/student_work_admin_set_create_service.rb
+++ b/app/services/spot/student_work_admin_set_create_service.rb
@@ -40,9 +40,15 @@ module Spot
     end
 
     def create_permission_template!(admin_set:)
-      permissions = Hyrax::PermissionTemplate.create!(source_id: admin_set.id, access_grants_attributes: access_grants_attributes)
+      permissions = find_or_create_permission_template(source_id: admin_set.id)
       admin_set.reset_access_controls!
       permissions
+    end
+
+    def find_or_create_permission_template(source_id:)
+      Hyrax::PermissionTemplate.find_or_create_by(source_id: source_id) do |template|
+        template.access_grants_attributes = access_grants_attributes
+      end
     end
 
     def find_or_create_workflow(permission_template:)

--- a/spec/features/create_student_work_spec.rb
+++ b/spec/features/create_student_work_spec.rb
@@ -52,7 +52,6 @@ RSpec.feature 'Create a StudentWork', :clean, :js do
       fill_in 'student_work_date', with: attrs[:date].first
       expect(page).not_to have_css '.student_work_date .controls-add-text'
 
-
       select 'No Copyright - United States', from: 'student_work_rights_statement'
       expect(page).not_to have_css '.student_work_rights_statement .controls-add-text'
 

--- a/spec/features/create_student_work_spec.rb
+++ b/spec/features/create_student_work_spec.rb
@@ -46,17 +46,12 @@ RSpec.feature 'Create a StudentWork', :clean, :js do
       fill_in_autocomplete '.student_work_academic_department', with: 'Libraries'
       expect(page).to have_css '.student_work_academic_department .controls-add-text'
 
-      fill_in_autocomplete '.student_work_division', with: 'Humanities'
-      expect(page).to have_css '.student_work_division .controls-add-text'
-
       fill_in 'student_work_description', with: attrs[:description].first
       expect(page).not_to have_css '.student_work_description .controls-add-text'
 
       fill_in 'student_work_date', with: attrs[:date].first
       expect(page).not_to have_css '.student_work_date .controls-add-text'
 
-      fill_in 'student_work_date_available', with: attrs[:date_available].first
-      expect(page).not_to have_css '.student_work_date_available .controls-add-text'
 
       select 'No Copyright - United States', from: 'student_work_rights_statement'
       expect(page).not_to have_css '.student_work_rights_statement .controls-add-text'
@@ -68,6 +63,13 @@ RSpec.feature 'Create a StudentWork', :clean, :js do
 
       click_link 'Additional fields'
       sleep 1
+
+      fill_in_autocomplete '.student_work_division', with: 'Humanities'
+      expect(page).to have_css '.student_work_division .controls-add-text'
+
+      # @todo we might be removing this field altogether and stuffing it as part of the workflow
+      fill_in 'student_work_date_available', with: attrs[:date_available].first
+      expect(page).not_to have_css '.student_work_date_available .controls-add-text'
 
       fill_in 'student_work_abstract', with: attrs[:abstract].first
       expect(page).not_to have_css '.student_work_abstract .controls-add-text'

--- a/spec/forms/hyrax/student_work_form_spec.rb
+++ b/spec/forms/hyrax/student_work_form_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe Hyrax::StudentWorkForm do
   it_behaves_like 'a Spot work form'
 
   it_behaves_like 'it handles required fields',
-                  :title, :creator, :advisor, :academic_department, :division,
-                  :description, :date, :date_available, :rights_statement, :resource_type
+                  :title, :creator, :advisor, :academic_department,
+                  :description, :date, :rights_statement, :resource_type
 
   describe '.terms' do
     subject { described_class.terms }

--- a/spec/forms/hyrax/student_work_form_spec.rb
+++ b/spec/forms/hyrax/student_work_form_spec.rb
@@ -165,4 +165,47 @@ RSpec.describe Hyrax::StudentWorkForm do
       end
     end
   end
+
+  describe '#primary_terms' do
+    subject { described_class.new(work, Ability.new(user), nil).primary_terms }
+
+    let(:work) { StudentWork.new }
+    let(:user) { create(:user) }
+
+    it { is_expected.to include(:rights_statement, :rights_holder) }
+
+    context 'when user is a student' do
+      let(:user) { create(:student_user) }
+
+      it { is_expected.not_to include(:rights_statement, :rights_holder) }
+    end
+  end
+
+  describe '#secondary_terms' do
+    subject { described_class.new(work, Ability.new(user), nil).secondary_terms }
+
+    let(:work) { StudentWork.new }
+
+    context 'for non-admin users' do
+      let(:user) { create(:user) }
+
+      it { is_expected.not_to include(:note, :access_note) }
+    end
+
+    context 'for student users' do
+      let(:user) { create(:student_user) }
+
+      it { is_expected.to include(:rights_statement, :rights_holder) }
+      it { is_expected.not_to include(:note, :access_note) }
+    end
+
+    context 'for admin users' do
+      let(:user) { create(:admin_user) }
+
+      # these are available in #primary_terms
+      it { is_expected.not_to include(:rights_statement, :rights_holder) }
+
+      it { is_expected.to include(:note, :access_note) }
+    end
+  end
 end

--- a/spec/forms/hyrax/student_work_form_spec.rb
+++ b/spec/forms/hyrax/student_work_form_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Hyrax::StudentWorkForm do
     subject { described_class.terms }
 
     describe 'includes optional fields' do
+      it { is_expected.to include :rights_holder }
       it { is_expected.to include :abstract }
       it { is_expected.to include :language }
       it { is_expected.to include :related_resource }
@@ -35,6 +36,7 @@ RSpec.describe Hyrax::StudentWorkForm do
     it { is_expected.to include(:date) }
     it { is_expected.to include(:date_available) }
     it { is_expected.to include(:rights_statement) }
+    it { is_expected.to include(rights_holder: []) }
     it { is_expected.to include(resource_type: []) }
     it { is_expected.to include(:abstract) }
     it { is_expected.to include(language: []) }
@@ -149,6 +151,11 @@ RSpec.describe Hyrax::StudentWorkForm do
 
         it 'uses DEFAULT_RIGHTS_STATEMENT_URI for #rights_statement' do
           expect(form[:rights_statement]).to eq described_class::DEFAULT_RIGHTS_STATEMENT_URI
+        end
+
+        it 'preloads the user#authority_name for #rights_holder' do
+          expect(work.rights_holder).to be_empty
+          expect(form[:rights_holder]).to eq [user.authority_name]
         end
       end
 

--- a/spec/forms/hyrax/student_work_form_spec.rb
+++ b/spec/forms/hyrax/student_work_form_spec.rb
@@ -130,4 +130,56 @@ RSpec.describe Hyrax::StudentWorkForm do
       end
     end
   end
+
+  describe '#initialize_fields' do
+    let(:form) { described_class.new(work, Ability.new(user), nil) }
+    let(:user) { create(:user) }
+    let(:student_user) { create(:student_user) }
+
+    context 'with a new work' do
+      let(:work) { StudentWork.new }
+
+      context 'when the user is a student' do
+        let(:user) { student_user }
+
+        it 'pre-loads the user#authority_name for #creator' do
+          expect(work.creator).to be_empty
+          expect(form[:creator]).to eq [user.authority_name]
+        end
+
+        it 'uses DEFAULT_RIGHTS_STATEMENT_URI for #rights_statement' do
+          expect(form[:rights_statement]).to eq described_class::DEFAULT_RIGHTS_STATEMENT_URI
+        end
+      end
+
+      context 'when the user is not a student' do
+        it 'uses the default new form values' do
+          expect(form[:creator]).to eq ['']
+          expect(form[:rights_statement]).to eq ''
+        end
+      end
+    end
+
+    context 'with an existing work' do
+      let(:work) { build(:student_work) }
+
+      before { allow(work).to receive(:new_record?).and_return(false) }
+
+      context 'when the user is a student' do
+        let(:user) { student_user }
+
+        it 'uses the model values' do
+          expect(form[:creator]).to eq work.creator
+          expect(form[:rights_statement]).to eq work.rights_statement
+        end
+      end
+
+      context 'when the user is not a student' do
+        it 'uses the model values' do
+          expect(form[:creator]).to eq work.creator
+          expect(form[:rights_statement]).to eq work.rights_statement
+        end
+      end
+    end
+  end
 end

--- a/spec/forms/hyrax/student_work_form_spec.rb
+++ b/spec/forms/hyrax/student_work_form_spec.rb
@@ -133,59 +133,35 @@ RSpec.describe Hyrax::StudentWorkForm do
     end
   end
 
-  describe '#initialize_fields' do
+  describe '#initialize_field' do
     let(:form) { described_class.new(work, Ability.new(user), nil) }
     let(:user) { create(:user) }
     let(:student_user) { create(:student_user) }
+    let(:work) { StudentWork.new }
 
-    context 'with a new work' do
-      let(:work) { StudentWork.new }
+    context 'when the user is a student' do
+      let(:user) { student_user }
 
-      context 'when the user is a student' do
-        let(:user) { student_user }
-
-        it 'pre-loads the user#authority_name for #creator' do
-          expect(work.creator).to be_empty
-          expect(form[:creator]).to eq [user.authority_name]
-        end
-
-        it 'uses DEFAULT_RIGHTS_STATEMENT_URI for #rights_statement' do
-          expect(form[:rights_statement]).to eq described_class::DEFAULT_RIGHTS_STATEMENT_URI
-        end
-
-        it 'preloads the user#authority_name for #rights_holder' do
-          expect(work.rights_holder).to be_empty
-          expect(form[:rights_holder]).to eq [user.authority_name]
-        end
+      it 'pre-loads the user#authority_name for #creator' do
+        expect(work.creator).to be_empty
+        expect(form[:creator]).to eq [user.authority_name]
       end
 
-      context 'when the user is not a student' do
-        it 'uses the default new form values' do
-          expect(form[:creator]).to eq ['']
-          expect(form[:rights_statement]).to eq ''
-        end
+      it 'uses DEFAULT_RIGHTS_STATEMENT_URI for #rights_statement' do
+        expect(form[:rights_statement]).to eq described_class::DEFAULT_RIGHTS_STATEMENT_URI
+      end
+
+      it 'preloads the user#authority_name for #rights_holder' do
+        expect(work.rights_holder).to be_empty
+        expect(form[:rights_holder]).to eq [user.authority_name]
       end
     end
 
-    context 'with an existing work' do
-      let(:work) { build(:student_work) }
-
-      before { allow(work).to receive(:new_record?).and_return(false) }
-
-      context 'when the user is a student' do
-        let(:user) { student_user }
-
-        it 'uses the model values' do
-          expect(form[:creator]).to eq work.creator
-          expect(form[:rights_statement]).to eq work.rights_statement
-        end
-      end
-
-      context 'when the user is not a student' do
-        it 'uses the model values' do
-          expect(form[:creator]).to eq work.creator
-          expect(form[:rights_statement]).to eq work.rights_statement
-        end
+    context 'when the user is not a student' do
+      it 'uses the default new form values' do
+        expect(form[:creator]).to eq ['']
+        expect(form[:rights_statement]).to eq ''
+        expect(form[:rights_holder]).to eq ['']
       end
     end
   end

--- a/spec/support/shared_examples/forms/identifier_fields.rb
+++ b/spec/support/shared_examples/forms/identifier_fields.rb
@@ -46,7 +46,7 @@ RSpec.shared_examples 'it handles identifier form fields' do
   describe 'identifier accessors' do
     let(:work_klass) { described_class.name.split('::').last.gsub(/Form$/, '').constantize }
     let(:work) { work_klass.new(identifier: identifiers) }
-    let(:form) { described_class.new(work, nil, nil) }
+    let(:form) { described_class.new(work, Ability.new(nil), nil) }
 
     let(:identifiers) do
       [

--- a/spec/support/shared_examples/forms/primary_terms_form_hints.rb
+++ b/spec/support/shared_examples/forms/primary_terms_form_hints.rb
@@ -3,7 +3,7 @@ RSpec.shared_examples 'it has hints for all primary_terms' do
   describe '.primary_terms form hints' do
     work_klass = described_class.name.to_s.split('::').last.gsub(/Form$/, '').constantize
 
-    described_class.new(work_klass.new, nil, nil).primary_terms.each do |term|
+    described_class.new(work_klass.new, Ability.new(nil), nil).primary_terms.each do |term|
       describe "for #{term}" do
         subject do
           I18n.t("simple_form.hints.defaults.#{term}", locale: :en, default: nil)


### PR DESCRIPTION
- remove `:date_available` and `:division` from required fields
- preload `:rights_statement` (InC-Edu), `:creator`  and `:rights_holder` (user's name) values for student users

closes #861 
closes #866 