### PR TITLE
add :active flag to local_authority_entry and set flag with lafayette_instructors_authority_service

### DIFF
--- a/app/services/spot/lafayette_instructors_authority_service.rb
+++ b/app/services/spot/lafayette_instructors_authority_service.rb
@@ -41,6 +41,8 @@ module Spot
     # @return [Array<Qa::LocalAuthorityEntry>]
     # @todo how should we handle exceptions?
     def load(term:)
+      deactivate_entries
+
       instructors_for(term: term).map do |instructor|
         find_or_create_entry(label: instructor_label(instructor), value: instructor_id(instructor))
       end
@@ -67,9 +69,14 @@ module Spot
 
     attr_reader :api_key
 
+    def deactivate_entries
+      Qa::LocalAuthorityEntry.where(local_authority: local_authority).update_all(active: false)
+    end
+
     def find_or_create_entry(label:, value:)
       entry = Qa::LocalAuthorityEntry.find_or_initialize_by(local_authority: local_authority, uri: value)
       entry.label = label
+      entry.active = true
       entry.save
       entry
     end

--- a/app/services/spot/lafayette_instructors_authority_service.rb
+++ b/app/services/spot/lafayette_instructors_authority_service.rb
@@ -70,7 +70,7 @@ module Spot
     attr_reader :api_key
 
     def deactivate_entries
-      Qa::LocalAuthorityEntry.where(local_authority: local_authority).update_all(active: false)
+      Qa::LocalAuthorityEntry.where(local_authority: local_authority).update(active: false)
     end
 
     def find_local_label_for(email:)

--- a/app/services/spot/lafayette_instructors_authority_service.rb
+++ b/app/services/spot/lafayette_instructors_authority_service.rb
@@ -49,8 +49,8 @@ module Spot
     end
 
     def label_for(email:)
-      stored = Qa::LocalAuthorityEntry.find_by(uri: email, local_authority: local_authority)
-      return stored.label unless stored.nil?
+      stored = find_local_label_for(email: email)
+      return stored unless stored.nil?
 
       remote = wds_service.person(email: email)
       raise(UserNotFoundError, "No user found with email address: #{email}") if remote == false
@@ -71,6 +71,14 @@ module Spot
 
     def deactivate_entries
       Qa::LocalAuthorityEntry.where(local_authority: local_authority).update_all(active: false)
+    end
+
+    def find_local_label_for(email:)
+      qa = Qa::LocalAuthorityEntry.find_by(uri: email, local_authority: local_authority)
+      return qa.label unless qa.nil?
+
+      user = User.find_by(email: email)
+      return user.authority_name unless user.nil?
     end
 
     def find_or_create_entry(label:, value:)

--- a/app/services/spot/lafayette_instructors_authority_service.rb
+++ b/app/services/spot/lafayette_instructors_authority_service.rb
@@ -78,7 +78,7 @@ module Spot
       return qa.label unless qa.nil?
 
       user = User.find_by(email: email)
-      return user.authority_name unless user.nil?
+      user&.authority_name
     end
 
     def find_or_create_entry(label:, value:)

--- a/config/initializers/qa.rb
+++ b/config/initializers/qa.rb
@@ -24,7 +24,6 @@ end
 # see {Spot::LafayetteInstructorsAuthorityService#load}
 module Spot
   class LocalTableBasedAuthority < ::Qa::Authorities::Local::TableBasedAuthority
-
     private
 
     def base_relation

--- a/config/initializers/qa.rb
+++ b/config/initializers/qa.rb
@@ -17,4 +17,19 @@ solr_suggestion_authorities.each do |subauth|
   Qa::Authorities::Local.register_subauthority(subauth, 'Qa::Authorities::SolrSuggest')
 end
 
-Qa::Authorities::Local.register_subauthority('lafayette_instructors', 'Qa::Authorities::Local::TableBasedAuthority')
+# Subclassing QA's TableBasedAuthority to include active entries, something we're reseting
+# with each load of the authority to ensure that only currently active instructors are loaded
+# without deleting previous entries for historical purposes.
+#
+# see {Spot::LafayetteInstructorsAuthorityService#load}
+module Spot
+  class Authorities::Local::TableBasedAuthority < ::Qa::Authorities::Local::TableBasedAuthority
+    private
+
+    def base_relation
+      Qa::LocalAuthorityEntry.where(local_authority: local_authority, active: true)
+    end
+  end
+end
+
+Qa::Authorities::Local.register_subauthority('lafayette_instructors', 'Spot::Authorities::Local::TableBasedAuthority')

--- a/config/initializers/qa.rb
+++ b/config/initializers/qa.rb
@@ -23,7 +23,8 @@ end
 #
 # see {Spot::LafayetteInstructorsAuthorityService#load}
 module Spot
-  class Authorities::Local::TableBasedAuthority < ::Qa::Authorities::Local::TableBasedAuthority
+  class LocalTableBasedAuthority < ::Qa::Authorities::Local::TableBasedAuthority
+
     private
 
     def base_relation
@@ -32,4 +33,4 @@ module Spot
   end
 end
 
-Qa::Authorities::Local.register_subauthority('lafayette_instructors', 'Spot::Authorities::Local::TableBasedAuthority')
+Qa::Authorities::Local.register_subauthority('lafayette_instructors', 'Spot::LocalTableBasedAuthority')

--- a/db/migrate/20220318162758_add_active_flag_to_local_authority_entry.rb
+++ b/db/migrate/20220318162758_add_active_flag_to_local_authority_entry.rb
@@ -1,0 +1,9 @@
+class AddActiveFlagToLocalAuthorityEntry < ActiveRecord::Migration[5.2]
+  def up
+    add_column :qa_local_authority_entries, :active, :boolean, default: true
+  end
+
+  def down
+    remove_column :qa_local_authority_entries, :active
+  end
+end

--- a/spec/services/spot/lafayette_instructors_authority_service_spec.rb
+++ b/spec/services/spot/lafayette_instructors_authority_service_spec.rb
@@ -107,12 +107,10 @@ RSpec.describe Spot::LafayetteInstructorsAuthorityService do
     end
 
     context 'when an entry no longer is returned by the api' do
-
       it 'does not mark it as active' do
         entry = Qa::LocalAuthorityEntry.find_or_create_by(local_authority: local_auth,
                                                           uri: 'deactivated@lafayette.edu',
                                                           label: 'Faculty, Retired')
-
         described_class.load(term: term)
 
         expect(entry.reload).not_to be_active

--- a/spec/services/spot/lafayette_instructors_authority_service_spec.rb
+++ b/spec/services/spot/lafayette_instructors_authority_service_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe Spot::LafayetteInstructorsAuthorityService do
     allow(Spot::LafayetteWdsService).to receive(:new).with(api_key: api_key).and_return(wds_service)
   end
 
-  after do
-    Qa::LocalAuthorityEntry.destroy_all
-  end
-
   let(:local_auth) { Qa::LocalAuthority.find_or_create_by(name: described_class::SUBAUTHORITY_NAME) }
   let(:api_key) { 'abc123def!' }
   let(:wds_service) { instance_double(Spot::LafayetteWdsService) }
@@ -34,13 +30,25 @@ RSpec.describe Spot::LafayetteInstructorsAuthorityService do
       }
     end
 
-    context 'when an entry exists in the database' do
+    context 'when a QA entry exists in the database' do
       before do
         local_entry
         described_class.label_for(email: email)
       end
 
       it { is_expected.to eq label }
+
+      it 'does not call the wds_service' do
+        expect(wds_service).not_to have_received(:person)
+      end
+    end
+
+    context 'when a QA entry exists in the database' do
+      before { described_class.label_for(email: user.email) }
+
+      let(:user) { create(:user, given_name: first_name, surname: last_name, email: email) }
+
+      it { is_expected.to eq user.authority_name }
 
       it 'does not call the wds_service' do
         expect(wds_service).not_to have_received(:person)
@@ -94,6 +102,20 @@ RSpec.describe Spot::LafayetteInstructorsAuthorityService do
       it 'leaves it be' do
         expect(Qa::LocalAuthorityEntry.where(local_authority: local_auth).count).to eq 1
         expect(described_class.load(term: term).count).to eq instructors.count
+        expect(Qa::LocalAuthorityEntry.where(local_authority: local_auth).count).to eq instructors.count
+      end
+    end
+
+    context 'when an entry no longer is returned by the api' do
+
+      it 'does not mark it as active' do
+        entry = Qa::LocalAuthorityEntry.find_or_create_by(local_authority: local_auth,
+                                                          uri: 'deactivated@lafayette.edu',
+                                                          label: 'Faculty, Retired')
+
+        described_class.load(term: term)
+
+        expect(entry.reload).not_to be_active
       end
     end
   end

--- a/spec/services/spot/lafayette_instructors_authority_service_spec.rb
+++ b/spec/services/spot/lafayette_instructors_authority_service_spec.rb
@@ -107,12 +107,15 @@ RSpec.describe Spot::LafayetteInstructorsAuthorityService do
     end
 
     context 'when an entry no longer is returned by the api' do
-      it 'does not mark it as active' do
-        entry = Qa::LocalAuthorityEntry.find_or_create_by(local_authority: local_auth,
-                                                          uri: 'deactivated@lafayette.edu',
-                                                          label: 'Faculty, Retired')
-        described_class.load(term: term)
+      let!(:entry) do
+        Qa::LocalAuthorityEntry.find_or_create_by(local_authority: local_auth,
+                                                  uri: 'deactivated@lafayette.edu',
+                                                  label: 'Faculty, Retired',
+                                                  active: true)
+      end
 
+      it 'does not mark it as active' do
+        described_class.load(term: term)
         expect(entry.reload).not_to be_active
       end
     end


### PR DESCRIPTION
adds a boolean `:active` field to the Qa::LocalAuthorityEntry table (default: `true`) and resets `lafayette_instructors` authority entries to false before loading and setting, allowing us to retain previous entries when they're removed from the wds authority.

closes #870 