### PR TITLE
update devise_cas_authenticatable + use active_record session storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem 'darlingtonia', '~> 3.0'
 # user management
 gem 'devise', '4.8.1'
 gem 'devise-guests', '0.7.0'
-gem 'devise_cas_authenticatable', '1.10.4'
+gem 'devise_cas_authenticatable', '2.0.2'
 
 # we're using .env files to manage our secrets
 gem 'dotenv-rails', '2.7.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
       validatable (~> 1.6)
     bcp47 (0.3.3)
       i18n
-    bcrypt (3.1.16)
+    bcrypt (3.1.17)
     bindex (0.8.1)
     bixby (1.0.0)
       rubocop (~> 0.50, <= 0.52.1)
@@ -205,7 +205,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     connection_pool (2.2.5)
     crack (0.4.5)
       rexml
@@ -229,9 +229,9 @@ GEM
       warden (~> 1.2.3)
     devise-guests (0.7.0)
       devise
-    devise_cas_authenticatable (1.10.4)
-      devise (>= 1.2.0)
-      rubycas-client (>= 2.2.1)
+    devise_cas_authenticatable (2.0.2)
+      devise (>= 4.0.0)
+      rack-cas
     diff-lcs (1.4.4)
     docile (1.3.5)
     docopt (0.5.0)
@@ -485,7 +485,7 @@ GEM
       tinymce-rails (~> 4.1)
     hyrax-spec (0.3.2)
       rspec (~> 3.6)
-    i18n (1.8.11)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     iiif_manifest (0.5.0)
@@ -590,7 +590,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.4.4)
-    loofah (2.13.0)
+    loofah (2.15.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -668,6 +668,10 @@ GEM
       rdf
     raabro (1.4.0)
     rack (2.2.3)
+    rack-cas (0.16.1)
+      addressable (~> 2.3)
+      nokogiri (~> 1.5)
+      rack (>= 1.3)
     rack-protection (2.1.0)
       rack
     rack-test (1.1.0)
@@ -829,8 +833,6 @@ GEM
       oauth2
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    rubycas-client (2.3.9)
-      activesupport
     rubyzip (2.3.2)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
@@ -1005,7 +1007,7 @@ DEPENDENCIES
   database_cleaner (~> 2.0.1)
   devise (= 4.8.1)
   devise-guests (= 0.7.0)
-  devise_cas_authenticatable (= 1.10.4)
+  devise_cas_authenticatable (= 2.0.2)
   docile (~> 1.3.5)
   dotenv-rails (= 2.7.6)
   dry-container (= 0.7.2)

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module Spot
 
     config.rack_cas.server_url = ENV.fetch('CAS_BASE_URL')
     config.rack_cas.service = '/users/service'
-    config.rack_cas.extra_attributes_filter = %w(uid email givenName surname lnumber eduPersonEntitlement)
+    config.rack_cas.extra_attributes_filter = %w[uid email givenName surname lnumber eduPersonEntitlement]
     config.rack_cas.session_store = RackCAS::ActiveRecordStore
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,8 @@ module Spot
     config.action_mailer.preview_path = Rails.root.join('lib', 'mailer_previews')
 
     config.rack_cas.server_url = ENV.fetch('CAS_BASE_URL')
-
+    config.rack_cas.service = '/users/service'
+    config.rack_cas.session_store = RackCAS::ActiveRecordStore
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,7 @@ module Spot
 
     config.rack_cas.server_url = ENV.fetch('CAS_BASE_URL')
     config.rack_cas.service = '/users/service'
+    config.rack_cas.extra_attributes_filter = %w(uid email givenName surname lnumber eduPersonEntitlement)
     config.rack_cas.session_store = RackCAS::ActiveRecordStore
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,8 @@ module Spot
     config.action_mailer.default_url_options = { host: ENV['URL_HOST'] }
     config.action_mailer.preview_path = Rails.root.join('lib', 'mailer_previews')
 
+    config.rack_cas.server_url = ENV.fetch('CAS_BASE_URL')
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,6 +3,7 @@ require_relative 'boot'
 
 require 'rails/all'
 require 'sprockets/es6'
+require 'rack-cas/session_store/active_record'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -70,13 +70,6 @@ Devise.setup do |config|
   config.sign_out_via = :get
 
   # ==> Configuration for :cas_authenticatable
-  config.cas_base_url = ENV.fetch('CAS_BASE_URL')
-
-  # you can override these if you need to, but cas_base_url is usually enough
-  # config.cas_login_url = "https://cas.myorganization.com/login"
-  # config.cas_logout_url = "https://cas.myorganization.com/logout"
-  # config.cas_validate_url = "https://cas.myorganization.com/serviceValidate"
-
   # The CAS specification allows for the passing of a follow URL to be displayed when
   # a user logs out on the CAS server. RubyCAS-Server also supports redirecting to a
   # URL via the destination param. Set either of these urls and specify either nil,
@@ -94,9 +87,6 @@ Devise.setup do |config|
   # require user records to already exist locally before they can authenticate via
   # CAS, uncomment the following line.
   # config.cas_create_user = false
-
-  # You can enable Single Sign Out, which by default is disabled.
-  # config.cas_enable_single_sign_out = true
 
   # If you don't want to use the username returned from your CAS server as the unique
   # identifier, but some other field passed in cas_extra_attributes, you can specify

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+require 'rack-cas/session_store/rails/active_record'
+Rails.application.config.session_store ActionDispatch::Session::RackCasActiveRecordStore

--- a/db/migrate/20220322165644_create_rack_cas_sessions.rb
+++ b/db/migrate/20220322165644_create_rack_cas_sessions.rb
@@ -1,0 +1,18 @@
+class CreateRackCasSessions < ActiveRecord::Migration[5.2]
+  def self.up
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.string :cas_ticket
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id
+    add_index :sessions, :cas_ticket
+    add_index :sessions, :updated_at
+  end
+
+  def self.down
+    drop_table :sessions
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -856,7 +856,8 @@ CREATE TABLE public.qa_local_authority_entries (
     label character varying,
     uri character varying,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    active boolean DEFAULT true
 );
 
 
@@ -990,6 +991,39 @@ CREATE SEQUENCE public.searches_id_seq
 --
 
 ALTER SEQUENCE public.searches_id_seq OWNED BY public.searches.id;
+
+
+--
+-- Name: sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sessions (
+    id bigint NOT NULL,
+    session_id character varying NOT NULL,
+    cas_ticket character varying,
+    data text,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: sessions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.sessions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sessions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.sessions_id_seq OWNED BY public.sessions.id;
 
 
 --
@@ -2000,6 +2034,13 @@ ALTER TABLE ONLY public.searches ALTER COLUMN id SET DEFAULT nextval('public.sea
 
 
 --
+-- Name: sessions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sessions ALTER COLUMN id SET DEFAULT nextval('public.sessions_id_seq'::regclass);
+
+
+--
 -- Name: single_use_links id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2397,6 +2438,14 @@ ALTER TABLE ONLY public.schema_migrations
 
 ALTER TABLE ONLY public.searches
     ADD CONSTRAINT searches_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sessions sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sessions
+    ADD CONSTRAINT sessions_pkey PRIMARY KEY (id);
 
 
 --
@@ -2879,6 +2928,27 @@ CREATE INDEX index_searches_on_user_id ON public.searches USING btree (user_id);
 
 
 --
+-- Name: index_sessions_on_cas_ticket; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sessions_on_cas_ticket ON public.sessions USING btree (cas_ticket);
+
+
+--
+-- Name: index_sessions_on_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sessions_on_session_id ON public.sessions USING btree (session_id);
+
+
+--
+-- Name: index_sessions_on_updated_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sessions_on_updated_at ON public.sessions USING btree (updated_at);
+
+
+--
 -- Name: index_sipity_comments_on_agent_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3313,6 +3383,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190327194742'),
 ('20200128221650'),
 ('20211206185043'),
-('20220317170657');
+('20220317170657'),
+('20220318162758'),
+('20220322165644');
 
 


### PR DESCRIPTION
updates devise_cas_authenticatable gem to 2.0.2 and implements changes necessary for it to work. part of this work required using active_record for session storage, as we were encountering a CookieOverflow error without it. 

this allows us to receive more than one value for a cas extra_attribute field (which was previously only passing the last one instead of an array)