### PR TITLE
generate date_available during the object activation stage (where applicable)

### DIFF
--- a/app/forms/hyrax/student_work_form.rb
+++ b/app/forms/hyrax/student_work_form.rb
@@ -62,9 +62,13 @@ module Hyrax
     # @todo this might be better off in the Spot::Forms::WorkForm base?
     def secondary_terms
       list = super
-      return list if current_user.admin?
 
-      list - [:note, :access_note]
+      if current_user.admin?
+        list -= [:date_available] if model.new_record? || model.suppressed?
+        list
+      else
+        list - [:date_available, :note, :access_note]
+      end
     end
 
     class << self

--- a/app/services/spot/embargo_lease_service.rb
+++ b/app/services/spot/embargo_lease_service.rb
@@ -23,8 +23,7 @@ module Spot
         clear_expired_embargoes(regenerate_thumbnails: regenerate_thumbnails) && clear_expired_leases(regenerate_thumbnails: regenerate_thumbnails)
       end
 
-      # Clears out expired embargoes and sets the +date_available+ property
-      # to today's date.
+      # Clears out expired embargoes
       #
       # @return [void]
       def clear_expired_embargoes(regenerate_thumbnails: false)
@@ -37,7 +36,6 @@ module Spot
 
           next if item.is_a? FileSet
 
-          item.date_available = [Time.zone.now.strftime('%Y-%m-%d')] if item.respond_to?(:date_available=)
           item.copy_visibility_to_files
           item.save!
 

--- a/app/services/spot/workflow/activate_object.rb
+++ b/app/services/spot/workflow/activate_object.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module Spot
+  module Workflow
+    module ActivateObject
+      # "Inheriting" Hyrax's default actions for activation (setting target#state to active via RDF),
+      # and also setting the target's :date_available property to either:
+      #   - the work's embargo_release_date (where present)
+      #   - the date of activation (when this method was called)
+      #
+      # The value is set as a "YYYY-MM-DD" date string.
+      #
+      # @param [Hash] options
+      # @option [ActiveFedora::Base] target
+      # @option [Sipity::Comment] comment
+      # @option [User] user
+      # @return [true]
+      def self.call(target:, **kwargs)
+        # Since Hyrax::Workflow::ActivateObject is a module (and not a class)
+        # we can't really inherit it, so instead we'll call it
+        Hyrax::Workflow::ActivateObject.call(target: target, **kwargs)
+
+        if target.respond_to?(:date_available=) && target.date_available.blank?
+          date = target.embargo_release_date || Time.zone.now
+          target.date_available = [date.strftime('%Y-%m-%d')]
+        end
+
+        # Explicitly returning true because the :date_available= guard may return false
+        # for models without the property defined, which will cause the work to not be saved
+        # @see https://github.com/samvera/hyrax/blob/v2.9.6/app/services/hyrax/workflow/action_taken_service.rb#L24-L32
+        true
+      end
+    end
+  end
+end

--- a/config/workflows/default_workflow.json
+++ b/config/workflows/default_workflow.json
@@ -12,7 +12,7 @@
                     "transition_to": "deposited",
                     "methods": [
                         "Hyrax::Workflow::GrantEditToDepositor",
-                        "Hyrax::Workflow::ActivateObject"
+                        "Spot::Workflow::ActivateObject"
                     ]
                 }
             ]

--- a/config/workflows/mediated_student_work_deposit_workflow.json
+++ b/config/workflows/mediated_student_work_deposit_workflow.json
@@ -125,7 +125,7 @@
             }
           ],
           "methods": [
-            "Hyrax::Workflow::ActivateObject"
+            "Spot::Workflow::ActivateObject"
           ]
         }
       ]

--- a/spec/features/create_student_work_spec.rb
+++ b/spec/features/create_student_work_spec.rb
@@ -66,10 +66,6 @@ RSpec.feature 'Create a StudentWork', :clean, :js do
       fill_in_autocomplete '.student_work_division', with: 'Humanities'
       expect(page).to have_css '.student_work_division .controls-add-text'
 
-      # @todo we might be removing this field altogether and stuffing it as part of the workflow
-      fill_in 'student_work_date_available', with: attrs[:date_available].first
-      expect(page).not_to have_css '.student_work_date_available .controls-add-text'
-
       fill_in 'student_work_abstract', with: attrs[:abstract].first
       expect(page).not_to have_css '.student_work_abstract .controls-add-text'
 

--- a/spec/forms/hyrax/student_work_form_spec.rb
+++ b/spec/forms/hyrax/student_work_form_spec.rb
@@ -189,14 +189,14 @@ RSpec.describe Hyrax::StudentWorkForm do
     context 'for non-admin users' do
       let(:user) { create(:user) }
 
-      it { is_expected.not_to include(:note, :access_note) }
+      it { is_expected.not_to include(:date_available, :note, :access_note) }
     end
 
     context 'for student users' do
       let(:user) { create(:student_user) }
 
       it { is_expected.to include(:rights_statement, :rights_holder) }
-      it { is_expected.not_to include(:note, :access_note) }
+      it { is_expected.not_to include(:date_available, :note, :access_note) }
     end
 
     context 'for admin users' do
@@ -206,6 +206,28 @@ RSpec.describe Hyrax::StudentWorkForm do
       it { is_expected.not_to include(:rights_statement, :rights_holder) }
 
       it { is_expected.to include(:note, :access_note) }
+
+      context 'when the work is new' do
+        it { is_expected.not_to include(:date_available) }
+      end
+
+      context 'when the work is suppressed (in a workflow)' do
+        before do
+          allow(work).to receive(:new_record?).and_return false
+          allow(work).to receive(:suppressed?).and_return true
+        end
+
+        it { is_expected.not_to include(:date_available) }
+      end
+
+      context 'when the work is not new or suppressed (edit)' do
+        before do
+          allow(work).to receive(:new_record?).and_return false
+          allow(work).to receive(:suppressed?).and_return false
+        end
+
+        it { is_expected.to include(:date_available) }
+      end
     end
   end
 end

--- a/spec/services/spot/embargo_lease_service_spec.rb
+++ b/spec/services/spot/embargo_lease_service_spec.rb
@@ -125,14 +125,11 @@ RSpec.describe Spot::EmbargoLeaseService do
         .to receive(:new)
         .with(publication_double)
         .and_return(leased_actor_double)
-
-      allow(publication_double).to receive(:date_available=)
     end
 
     it 'calls destroy on both the embargo + lease actors' do
       described_class.clear_all_expired
 
-      expect(publication_double).to have_received(:date_available=).with([todays_date])
       expect(embargoed_actor_double).to have_received(:destroy).exactly(1).time
       expect(leased_actor_double).to have_received(:destroy).exactly(1).time
     end

--- a/spec/services/spot/workflow/activate_object_spec.rb
+++ b/spec/services/spot/workflow/activate_object_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Spot::Workflow::ActivateObject do
 
     context 'when no embargo is set' do
       before do
-        allow(Time.zone).to receive(:now).and_return(Time.new(2022, 3, 25))
+        allow(Time.zone).to receive(:now).and_return(Time.zone.local(2022, 3, 25))
       end
 
       it 'sets :date_available to Time.zone.now, formatted as YYYY-MM-DD' do

--- a/spec/services/spot/workflow/activate_object_spec.rb
+++ b/spec/services/spot/workflow/activate_object_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+RSpec.describe Spot::Workflow::ActivateObject do
+  subject { described_class.call(target: work) }
+
+  before do
+    allow(Hyrax::Workflow::ActivateObject).to receive(:call).with(target: work).and_return true
+  end
+
+  let(:work) { build(:student_work) }
+
+  it 'calls Hyrax::Workflow::ActivateObject' do
+    described_class.call(target: work)
+    expect(Hyrax::Workflow::ActivateObject).to have_received(:call).with(target: work)
+  end
+
+  # truthy values will result in a saved `target`
+  it { is_expected.to be_truthy }
+
+  context 'when a model has a :date_available property' do
+    let(:work) { build(:student_work, date_available: [], embargo_release_date: date) }
+    let(:date) { nil }
+
+    context 'when an embargo is set' do
+      let(:date) { Date.new(2125, 2, 11) }
+
+      it 'sets :date_available to the date formatted as YYYY-MM-DD' do
+        expect { described_class.call(target: work) }
+          .to change { work.date_available.to_a }
+          .from([])
+          .to(['2125-02-11'])
+      end
+    end
+
+    context 'when no embargo is set' do
+      before do
+        allow(Time.zone).to receive(:now).and_return(Time.new(2022, 3, 25))
+      end
+
+      it 'sets :date_available to Time.zone.now, formatted as YYYY-MM-DD' do
+        expect { described_class.call(target: work) }
+          .to change { work.date_available.to_a }
+          .from([])
+          .to(['2022-03-25'])
+      end
+    end
+
+    context 'when a value already exists' do
+      let(:work) { build(:student_work, date_available: ['1986-02-11']) }
+
+      it 'retains the value' do
+        described_class.call(target: work)
+
+        expect(work.date_available).to eq ['1986-02-11']
+      end
+    end
+  end
+
+  context 'when a model does not have a :date_available property' do
+    let(:work) { build(:image) }
+
+    it { is_expected.to be_truthy }
+  end
+end


### PR DESCRIPTION
adds our own "subclass" (ish) of `Hyrax::Workflow::ActivateObject` that sets a work's `:date_available` property to either its embargo release date, or the date of activation, but leaves the property alone if a value has already been set. this allows us to not require students to fill out the property, which we felt could be confusing alongside a required `:date`.