### PR TITLE
[wip] render thumbnails in Representative Media tab

### DIFF
--- a/app/views/hyrax/base/_form_thumbnail.html.erb
+++ b/app/views/hyrax/base/_form_thumbnail.html.erb
@@ -1,0 +1,27 @@
+  <div class="row">
+    <div class="col-md-12">
+      <fieldset id="representative-image">
+        <legend>
+          <%= t("hyrax.base.form_thumbnail.legend_html") %>
+        </legend>
+        <div class="form-group">
+          <span class="help-block"><%= t("hyrax.base.form_thumbnail.help_html") %></span>
+          <% @form.select_files.each_slice(3) do |group| %>
+          <div class="row">
+            <% group.each do |filename, fs_id| %>
+            <div class="col-md-4">
+              <div class="radio-inline">
+                <label>
+                  <img class="img-thumbnail" src="/downloads/<%= fs_id %>?file=thumbnail" role="presentation"/>
+                  <input type="radio" value="<%= fs_id %>" name="thumbnail_id" <%= 'checked' if @form.thumbnail_id == fs_id %>>
+                  <p><%= filename %></p>
+                </label>
+              </div>
+            </div>
+            <% end %>
+          </div>
+          <% end %>
+          </div>
+        </div>
+      </fieldset>
+    </div>


### PR DESCRIPTION
some late friday tinkering. adding visual thumbnails to the Representative Media tab so it's easier to see what item is being chosen.

depends on #878. ~rebase after that merges~

<img width="940" alt="Screen Shot 2022-03-25 at 4 27 22 PM" src="https://user-images.githubusercontent.com/2744987/160196582-26323501-040d-46aa-ba4d-dd65b70146c3.png">

