### PR TITLE
maybe a fix for flaky oai_provider_spec

### DIFF
--- a/spec/features/oai_provider_spec.rb
+++ b/spec/features/oai_provider_spec.rb
@@ -1,21 +1,15 @@
 # frozen_string_literal: true
-RSpec.feature 'OAI-PMH provider (via Blacklight)' do
+RSpec.feature 'OAI-PMH provider (via Blacklight)', clean: true do
   before do
-    ActiveFedora::SolrService.instance.conn.tap do |conn|
-      query = Hyrax.config.curation_concerns.map { |m| "has_model_ssim:#{m}" }.join(' OR ')
-      conn.delete_by_query("(#{query})", params: { 'softCommit' => true })
-    end
-
     objects.each { |obj| ActiveFedora::SolrService.add(obj) }
     ActiveFedora::SolrService.commit
   end
 
   # clear out the objects
   after do
-    ActiveFedora::SolrService.instance.conn.tap do |conn|
-      obj_query = objects.map { |o| "id:#{o[:id]}" }.join(' OR ')
-      conn.delete_by_query("(#{obj_query})", params: { 'softCommit' => true })
-    end
+    obj_query = objects.map { |o| "id:#{o[:id]}" }.join(' OR ')
+    ActiveFedora::SolrService.instance.conn.delete_by_query("(#{obj_query})")
+    ActiveFedora::SolrService.commit
   end
 
   let(:xml) { Nokogiri::XML(page.body) }


### PR DESCRIPTION
so the flaky test (see #795) in question is `describe 'verb=ListIdentifiers'`, which is returning objects that should have been deleted (in particular `describe 'verb=ListSets'`). this runs the spec as `:clean` and modifies how the solr changes are committed. maybe that'll help?