### PR TITLE
add specs to ensure we can handle multiple advisors on a StudentWork

### DIFF
--- a/spec/services/spot/workflow/changes_pending_advisor_review_notification_spec.rb
+++ b/spec/services/spot/workflow/changes_pending_advisor_review_notification_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe Spot::Workflow::ChangesPendingAdvisorReviewNotification do
       "<blockquote>#{workflow_comment_html}</blockquote>" \
       "Please review and approve or request further edits."
     end
-    let(:workflow_object) { create(:student_work, user: depositing_user, advisor: [advisor_user.email]) }
-    let(:advisor_user) { create(:user) }
-    let(:recipients) { [advisor_user] }
+    let(:workflow_object) { create(:student_work, user: depositing_user, advisor: recipients.map(&:email)) }
+    let(:recipients) { [create(:user), create(:user)] }
   end
 end

--- a/spec/services/spot/workflow/grant_read_to_advisor_spec.rb
+++ b/spec/services/spot/workflow/grant_read_to_advisor_spec.rb
@@ -1,26 +1,20 @@
 # frozen_string_literal: true
 RSpec.describe Spot::Workflow::GrantReadToAdvisor do
   let(:workflow_method) { described_class }
-  let(:advisor) { create(:user) }
+  let(:advisors) { [create(:user), create(:user)] }
+  let(:advisor_emails) { advisors.map(&:email) }
   let(:depositor) { create(:user) }
-  let(:work) { build(:student_work, id: 'abc123', advisor: [advisor_key], user: depositor) }
-
-  before do
-    stub_env('LAFAYETTE_WDS_API_KEY', 'abc123def!')
-
-    allow(Spot::LafayetteInstructorsAuthorityService)
-      .to receive(:label_for)
-      .with(email: advisor.email)
-      .and_return('Advisor, Faculty')
-  end
+  let(:work) { build(:student_work, id: 'abc123', advisor: advisor_emails, user: depositor) }
 
   it_behaves_like 'a Hyrax workflow method'
 
-  let(:advisor_key) { advisor.email }
-
   it "adds the advisor to the work's #read_users" do
+    # using #sort bc the users aren't in the same order (sent to Hyrax::GrantReadToMembersJob,
+    # which processes them last-in-first-out, i think)
     expect { described_class.call(target: work) }
-      .to change { work.read_users }.from([]).to([advisor.user_key])
+      .to change { work.read_users.sort }
+      .from([])
+      .to(advisor_emails.sort)
   end
 
   context 'when the work does not have an "advisor" field' do
@@ -34,7 +28,7 @@ RSpec.describe Spot::Workflow::GrantReadToAdvisor do
   context 'when the advisor User can not be found' do
     subject { described_class.call(target: work) }
 
-    let(:advisor_key) { 'Joe Faculty' }
+    let(:advisor_emails) { ['not-here-anymore@example.org'] }
 
     it { is_expected.to be nil }
   end

--- a/spec/services/spot/workflow/submission_pending_advisor_review_notification_spec.rb
+++ b/spec/services/spot/workflow/submission_pending_advisor_review_notification_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe Spot::Workflow::SubmissionPendingAdvisorReviewNotification do
         "was submitted and is awaiting your approval. <blockquote>#{workflow_comment_html}</blockquote>" \
         "Please approve or request changes using the form on the work's page."
     end
-    let(:advisor_user) { create(:user) }
-    let(:workflow_object) { create(:student_work, user: depositing_user, advisor: [advisor_user.email]) }
-    let(:recipients) { [advisor_user] }
+    let(:workflow_object) { create(:student_work, user: depositing_user, advisor: recipients.map(&:email)) }
+    let(:recipients) { [create(:user), create(:user)] }
   end
 end


### PR DESCRIPTION
a little refactoring to ensure that notifications/grants are being provided to all advisors within the `mediated_student_work_deposit` workflow

closes #868 