### PR TITLE
remove :clean param from some feature specs

### DIFF
--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
-RSpec.feature 'Advanced search form', :clean, :js do
-  before do
-    # add some stuff to the index
-  end
-
+RSpec.feature 'Advanced search form' do
   scenario 'the advanced search form' do
     visit '/advanced'
 

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature 'Create an Image', :clean, :js do
+RSpec.feature 'Create an Image', :js do
   before do
     stub_request(:get, subject_uri)
     # Only enqueue the ingest job, not charactarization.

--- a/spec/features/create_publication_spec.rb
+++ b/spec/features/create_publication_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.feature 'Create a Publication', :clean, :js do
+RSpec.feature 'Create a Publication', :js do
   before do
     stub_request(:get, subject_uri)
     # Only enqueue the ingest job, not charactarization.

--- a/spec/features/create_student_work_spec.rb
+++ b/spec/features/create_student_work_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.feature 'Create a StudentWork', :clean, :js do
+RSpec.feature 'Create a StudentWork', :js do
   before do
     stub_request(:get, subject_uri)
 


### PR DESCRIPTION
a refactor attempt for #794 that spread to a few more specs. we don't really need to clean the repo to test the advanced search page (what was i thinking?) or the create work features.

closes #794 