### PR TITLE
add empty alt tags for decorative link images

### DIFF
--- a/app/views/hyrax/base/_relationships.html.erb
+++ b/app/views/hyrax/base/_relationships.html.erb
@@ -25,8 +25,7 @@
         <% url = polymorphic_url([item_type], id: item.id) %>
         <div class="col-md-3">
           <div class="thumbnail">
-            <%# TODO: add alt text (i believe it's indexed/stored?) %>
-            <img src="<%= item.thumbnail_path %>" />
+            <img src="<%= item.thumbnail_path %>" alt="" />
             <div class="caption">
               <h3><%= item.title.first %></h3>
               <% if item.description.present? %>

--- a/app/views/hyrax/base/_relationships.html.erb
+++ b/app/views/hyrax/base/_relationships.html.erb
@@ -25,7 +25,7 @@
         <% url = polymorphic_url([item_type], id: item.id) %>
         <div class="col-md-3">
           <div class="thumbnail">
-            <img src="<%= item.thumbnail_path %>" alt="" />
+            <%= image_tag(item.thumbnail_path, alt: '') %>
             <div class="caption">
               <h3><%= item.title.first %></h3>
               <% if item.description.present? %>

--- a/app/views/spot/page/about.html.erb
+++ b/app/views/spot/page/about.html.erb
@@ -2,7 +2,7 @@
   <h1><%= t('.header', name: application_name) %></h1>
 </div>
 
-<%= image_tag('about-splash.jpg', class: 'splash-image img-responsive') %>
+<%= image_tag('about-splash.jpg', class: 'splash-image img-responsive', alt: '') %>
 
 <p>
   The Lafayette Digital Repository (LDR) is both an institutional repository and


### PR DESCRIPTION
affects:
- member of collections links at the bottom of work-show pages
- about page splash image

closes #852
closes #854