### PR TITLE
revert back to rails cookies for sessions

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module Spot
     config.rack_cas.server_url = ENV.fetch('CAS_BASE_URL')
     config.rack_cas.service = '/users/service'
     config.rack_cas.extra_attributes_filter = %w[uid email givenName surname lnumber eduPersonEntitlement]
-    config.rack_cas.session_store = RackCAS::ActiveRecordStore
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-require 'rack-cas/session_store/rails/active_record'
-Rails.application.config.session_store ActionDispatch::Session::RackCasActiveRecordStore


### PR DESCRIPTION
back in #877 i was encountering cookie overflow issues with devise_cas_authenticatable and switched to ActiveRecord for sessions, but soon after we ran into issues with form submissions getting caught in redirection loops (and cas "ticket" querystrings appended at the end of urls :red_flag:). so this is trying to fix the problem my reverting back to using rails cookies for session management.

the only reason we were using active_record for session storage was because we were storing the entire cas extra_attributes hash (encrypted) in the cookie, but we're only keeping a small portion of the attributes (via `Rails.application.config.rack_cas.extra_attributes_filter`, which should help prevent size issues.