### PR TITLE
index / grant read on all lafayette student_work#advisor values

### DIFF
--- a/app/indexers/student_work_indexer.rb
+++ b/app/indexers/student_work_indexer.rb
@@ -12,7 +12,7 @@ class StudentWorkIndexer < BaseIndexer
   private
 
   def advisor_label_from(email:)
-    return email unless email.match?(/^[A-Za-z0-9\-_\.]+@lafayette.edu$/)
+    return email unless email.end_with?('@lafayette.edu')
 
     Spot::LafayetteInstructorsAuthorityService.label_for(email: email)
   end

--- a/app/services/spot/workflow/grant_read_to_advisor.rb
+++ b/app/services/spot/workflow/grant_read_to_advisor.rb
@@ -6,7 +6,7 @@ module Spot
       def self.call(target:, **)
         return unless target.respond_to?(:advisor)
 
-        advisor_emails = target.advisor.select { |advisor| advisor =~ /^[A-Za-z0-9\-_\.]+@lafayette.edu$/ }
+        advisor_emails = target.advisor.select { |advisor| advisor.end_with?('@lafayette.edu') }
         return if advisor_emails.empty?
 
         target.read_users += advisor_emails


### PR DESCRIPTION
loosens up some regex checking for indexing/granting-read on student_works by just ensuring they end in `"@lafayette.edu"`