### PR TITLE
add a workflow comments panel to work-edit form

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,8 @@ RUN mkdir -p /spot/config /spot/public && \
     mkdir -p /spot/derivatives /spot/uploads
 
 # c) install dependencies
-ARG BUNDLE_WITHOUT="development test"
-RUN bundle install --jobs "$(nproc)"
+RUN bundle config set --local without "development test" && \
+    bundle install --jobs "$(nproc)"
 
 # d) copy the application files
 # COPY --chown=1001:101 . /spot
@@ -66,8 +66,9 @@ COPY config/uv config/uv
 # run yarn install first so we don't need to always rerun when updating gems
 RUN yarn install
 
-ARG BUNDLE_WITHOUT=""
-RUN bundle install --jobs "$(nproc)"
+RUN bundle config unset --local without && \
+    bundle config set --local with "development test" && \
+    bundle install --jobs "$(nproc)"
 
 CMD ["bundle", "exec", "rails", "server", "-u", "puma", "-b", "ssl://0.0.0.0:443?key=/trustee_minutes/tmp/ssl/application.key&cert=/trustee_minutes/tmp/ssl/application.crt"]
 
@@ -82,6 +83,7 @@ RUN apk --no-cache upgrade && \
         ghostscript
 
 # USER app
-ARG BUNDLE_WITHOUT=""
-RUN bundle install --jobs "$(nproc)"
+RUN bundle config unset --local without && \
+    bundle install --jobs "$(nproc)"
+
 CMD ["bundle", "exec", "sidekiq"]

--- a/Gemfile
+++ b/Gemfile
@@ -172,7 +172,7 @@ end
 # things used for development + testing (again, not as
 # necessary to lock down versions)
 group :development, :test do
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', '~> 11.1.3'
   gem 'capybara-screenshot', '~> 1.0.25'
   gem 'database_cleaner', '~> 2.0.1'
   gem 'equivalent-xml', '~> 0.6.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -993,7 +993,7 @@ DEPENDENCIES
   blacklight_range_limit (= 6.3.3)
   bootsnap (= 1.11.1)
   bootstrap_form (~> 4.4.0)
-  byebug
+  byebug (~> 11.1.3)
   capistrano (~> 3.17)
   capistrano-bundler (~> 2.0)
   capistrano-ext (~> 1.2.1)

--- a/app/controllers/concerns/spot/works_controller_behavior.rb
+++ b/app/controllers/concerns/spot/works_controller_behavior.rb
@@ -14,6 +14,10 @@ module Spot
     include ::Hyrax::BreadcrumbsForWorks
     include AdditionalFormatsForController
 
+    included do
+      before_action :load_workflow_presenter, only: :edit
+    end
+
     private
 
     # Overrides Hyrax behavior by using our own IIIF presenter that relies on Blacklight locales
@@ -25,6 +29,10 @@ module Spot
         p.hostname = request.hostname
         p.ability = current_ability
       end
+    end
+
+    def load_workflow_presenter
+      @workflow_presenter = Hyrax::WorkflowPresenter.new(::SolrDocument.find(params[:id]), current_ability)
     end
   end
 end

--- a/app/helpers/spot/work_form_helper.rb
+++ b/app/helpers/spot/work_form_helper.rb
@@ -35,6 +35,16 @@ module Spot
       fields
     end
 
+    def workflow_comment_attribution(comment)
+      commenter = comment.agent.proxy_for
+      commenter_display = current_user == commenter ? 'You' : "#{commenter.display_name} (#{commenter.email})"
+      "#{commenter_display} commented on #{comment.created_at.strftime('%B %-d, %Y')}"
+    end
+
+    def workflow_comment_content(comment)
+      comment.comment.gsub(/\r?\n/, '<br>').html_safe
+    end
+
     # @api private
     def student_work_form_tabs_for(form:)
       %w[metadata files].tap do |fields|

--- a/app/helpers/spot/work_form_helper.rb
+++ b/app/helpers/spot/work_form_helper.rb
@@ -15,41 +15,51 @@ module Spot
     #
     # @see https://github.com/samvera/hyrax/blob/v2.9.6/app/helpers/hyrax/work_form_helper.rb#L5-L27
     def form_tabs_for(form:)
-      return student_work_form_tabs_for(form: form) if form.instance_of?(Hyrax::StudentWorkForm) && !current_user.admin?
-
       # `super` handles BatchUploadForm's special case, and since we aren't
       # concerned with representative_media in that case, return the results
       fields = super
       return fields if form.instance_of?(Hyrax::Forms::BatchUploadForm)
 
-      # if the model has been persisted, load the 'media' partial (if the object has members)
-      # and load the new "comments" panel to display any workflow comments that may exist.
+      persisted = form.model.persisted?
+      return student_work_form_tabs(persisted: persisted) if form.instance_of?(Hyrax::StudentWorkForm) && !current_user.admin?
+
+      # if the model has been persisted, load the "media" partial and the new "comments" panel
+      # to display any workflow comments that may exist.
       #
       # @see https://github.com/samvera/hyrax/blob/v2.9.6/app/views/hyrax/base/_form_media.html.erb
       # @todo maybe take this check out of the partial?
-      if form.model.persisted?
-        fields << 'media' if form.model.member_ids.present?
-        fields << 'comments'
-      end
+      fields += ['media', 'comments'] if persisted
 
       fields
     end
 
+    # Adds text to the footer of the comment's panel: "FirstName LastName commented on April 22, 2022"
+    # or "You commented on April 22, 2022" if the current_user made the comment.
+    #
+    # @param [Sipity::Comment] comment
+    # @return [String]
     def workflow_comment_attribution(comment)
       commenter = comment.agent.proxy_for
       commenter_display = current_user == commenter ? 'You' : "#{commenter.display_name} (#{commenter.email})"
       "#{commenter_display} commented on #{comment.created_at.strftime('%B %-d, %Y')}"
     end
 
+    # Formats the workflow comment content to display line breaks properly.
+    #
+    # @param [Sipity::Comment] comment
+    # @return [String]
     def workflow_comment_content(comment)
       comment.comment.gsub(/\r?\n/, '<br>').html_safe
     end
 
+    # Form fields specifically for student users (removes "relationship" tab)
+    #
+    # @param [Hash] options
+    # @option [true, false] persisted
+    # @return [Array<String>]
     # @api private
-    def student_work_form_tabs_for(form:)
-      %w[metadata files].tap do |fields|
-        fields << 'comments' if form.model.persisted?
-      end
+    def student_work_form_tabs(persisted: false)
+      persisted ? %w[metadata files comments] : %w[metadata files]
     end
   end
 end

--- a/app/views/hyrax/base/_form_comments.html.erb
+++ b/app/views/hyrax/base/_form_comments.html.erb
@@ -1,0 +1,22 @@
+<% if @workflow_presenter&.comments.empty? || @workflow_presenter.nil? %>
+  <div class="panel panel-info">
+    <div class="panel-body">
+      <em><%= f.object.title %></em> has no comments to display.
+    </div>
+  </div>
+<% else %>
+  <% @workflow_presenter.comments.includes(:agent).order(created_at: :desc).each do |comment| %>
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <%= comment.comment.gsub(/\r?\n/, '<br>').html_safe %>
+    </div>
+
+    <div class="panel-footer">
+      <% commenter = comment.agent.proxy_for %>
+      <em>
+        Commented by <%= commenter.display_name %> (<%= commenter.email %>)
+        on <%= comment.created_at.strftime('%B %-d, %Y') %></em>
+    </div>
+  </div>
+  <% end %>
+<% end %>

--- a/app/views/hyrax/base/_form_comments.html.erb
+++ b/app/views/hyrax/base/_form_comments.html.erb
@@ -8,14 +8,13 @@
   <% @workflow_presenter.comments.includes(:agent).order(created_at: :desc).each do |comment| %>
   <div class="panel panel-default">
     <div class="panel-body">
-      <%= comment.comment.gsub(/\r?\n/, '<br>').html_safe %>
+      <%= workflow_comment_content(comment) %>
     </div>
 
     <div class="panel-footer">
-      <% commenter = comment.agent.proxy_for %>
       <em>
-        Commented by <%= commenter.display_name %> (<%= commenter.email %>)
-        on <%= comment.created_at.strftime('%B %-d, %Y') %></em>
+        <%= workflow_comment_attribution(comment) %>
+      </em>
     </div>
   </div>
   <% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -68,5 +68,6 @@ en:
     works:
       form:
         tab:
+          comments: Comments
           files: Add Files
           media: Representative Media

--- a/spec/helpers/spot/work_form_helper_spec.rb
+++ b/spec/helpers/spot/work_form_helper_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Spot::WorkFormHelper do
         let(:work_persisted) { true }
         let(:work_member_ids) { ['abc123'] }
 
-        it { is_expected.to eq %w[metadata files relationships media] }
+        it { is_expected.to eq %w[metadata files relationships media comments] }
       end
     end
 
@@ -36,7 +36,15 @@ RSpec.describe Spot::WorkFormHelper do
       let(:form_klass) { 'Hyrax::StudentWorkForm' }
 
       context 'when the user is not an admin' do
-        it { is_expected.to eq %w[metadata files] }
+        context 'when the form is New' do
+          it { is_expected.to eq %w[metadata files] }
+        end
+
+        context 'when the form is Edit' do
+          let(:work_persisted) { true }
+
+          it { is_expected.to eq %w[metadata files comments] }
+        end
       end
 
       context 'when the user is an admin' do

--- a/spec/helpers/spot/work_form_helper_spec.rb
+++ b/spec/helpers/spot/work_form_helper_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Spot::WorkFormHelper do
 
     let(:form_klass) { 'Hyrax::PublicationForm' }
     let(:form) { form_klass.constantize.new(work, Ability.new(user), nil) }
-    let(:user) { create(:user) }
+    let(:user) { FactoryBot.create(:user) }
     let(:factory_klass) { form_klass.constantize.model_class.to_s.underscore.to_sym }
-    let(:work) { build(factory_klass) }
+    let(:work) { FactoryBot.build(factory_klass) }
     let(:mocked_methods) { { new_record?: !work_persisted, persisted?: work_persisted, member_ids: work_member_ids } }
     let(:work_persisted) { false }
     let(:work_member_ids) { [] }
@@ -26,7 +26,6 @@ RSpec.describe Spot::WorkFormHelper do
 
       context 'when the form is Edit' do
         let(:work_persisted) { true }
-        let(:work_member_ids) { ['abc123'] }
 
         it { is_expected.to eq %w[metadata files relationships media comments] }
       end
@@ -66,6 +65,37 @@ RSpec.describe Spot::WorkFormHelper do
       let(:form_klass) { 'Hyrax::PublicationForm' }
 
       it_behaves_like 'it presents the standard form tabs'
+    end
+  end
+
+  describe 'workflow_comment methods' do
+    let(:comment) { Sipity::Comment.new(agent: sipity_agent, comment: comment_text, created_at: Time.zone.local(2022, 4, 22)) }
+    let(:comment_text) { "Looks good.\r\n\r\nGreat work!" }
+    let(:sipity_agent) { Sipity::Agent.new }
+    let(:current_user) { FactoryBot.build(:user) }
+    let(:user) { FactoryBot.build(:user) }
+
+    before do
+      allow(helper).to receive(:current_user).and_return(current_user)
+      allow(sipity_agent).to receive(:proxy_for).and_return(user)
+    end
+
+    describe '#workflow_comment_content' do
+      subject { helper.workflow_comment_content(comment) }
+
+      it { is_expected.to eq 'Looks good.<br><br>Great work!' }
+    end
+
+    describe '#workflow_comment_attribution' do
+      subject { helper.workflow_comment_attribution(comment) }
+
+      it { is_expected.to eq "#{user.display_name} (#{user.email}) commented on April 22, 2022" }
+
+      context 'when current_user is the commenter' do
+        let(:user) { current_user }
+
+        it { is_expected.to eq 'You commented on April 22, 2022' }
+      end
     end
   end
 end

--- a/spec/support/shared_examples/spot_works_controller.rb
+++ b/spec/support/shared_examples/spot_works_controller.rb
@@ -32,6 +32,16 @@ RSpec.shared_examples 'it includes Spot::WorksControllerBehavior' do
         expect(response.headers['Location']).to include '/users/sign_in'
       end
     end
+
+    context 'when editing a work' do
+      it 'sets a @workflow_presenter' do
+        get :edit, params: { id: work.id }
+        presenter = assigns(:workflow_presenter)
+
+        expect(presenter).not_to be nil
+        expect(presenter).to be_a Hyrax::WorkflowPresenter
+      end
+    end
   end
 
   describe 'additional formats' do

--- a/spec/support/shared_examples/spot_works_controller.rb
+++ b/spec/support/shared_examples/spot_works_controller.rb
@@ -33,13 +33,24 @@ RSpec.shared_examples 'it includes Spot::WorksControllerBehavior' do
       end
     end
 
-    context 'when editing a work' do
-      it 'sets a @workflow_presenter' do
-        get :edit, params: { id: work.id }
-        presenter = assigns(:workflow_presenter)
+    describe 'setting workflow_presenter' do
+      context 'when editing a work' do
+        it 'sets a @workflow_presenter' do
+          get :edit, params: { id: work.id }
+          presenter = assigns(:workflow_presenter)
 
-        expect(presenter).not_to be nil
-        expect(presenter).to be_a Hyrax::WorkflowPresenter
+          expect(presenter).not_to be nil
+          expect(presenter).to be_a Hyrax::WorkflowPresenter
+        end
+      end
+
+      context 'when viewing a work' do
+        it 'does nothing' do
+          get :show, params: { id: work.id }
+          presenter = assigns(:workflow_presenter)
+
+          expect(presenter).to be nil
+        end
       end
     end
   end


### PR DESCRIPTION
adds a tab/panel to the work-edit form to display workflow comments, where applicable.

<img width="951" alt="Screen Shot 2022-04-20 at 2 55 24 PM" src="https://user-images.githubusercontent.com/2744987/164302682-0a2bd519-3d78-47f2-88a5-a5d84f33af24.png">

note that the attribution at the bottom will display the user's name if it's not the currently logged in one.