### PR TITLE
add flash text to work#update when workflow actions exist

### DIFF
--- a/app/controllers/concerns/spot/works_controller_behavior.rb
+++ b/app/controllers/concerns/spot/works_controller_behavior.rb
@@ -16,6 +16,7 @@ module Spot
 
     included do
       before_action :load_workflow_presenter, only: :edit
+      after_action  :update_workflow_flash, only: :update
     end
 
     private
@@ -33,6 +34,16 @@ module Spot
 
     def load_workflow_presenter
       @workflow_presenter = Hyrax::WorkflowPresenter.new(::SolrDocument.find(params[:id]), current_ability)
+    end
+
+    # When the workflow presenter has actions available, append a note to the update flash that the
+    # review form needs to be marked as completed.
+    #
+    # @return [void]
+    def update_workflow_flash
+      return unless flash[:notice].present? && presenter.workflow&.actions.present?
+
+      flash[:notice] += " <strong>Finished making edits? Be sure to mark the review form as complete.</strong>"
     end
   end
 end

--- a/app/views/hyrax/base/_workflow_actions.html.erb
+++ b/app/views/hyrax/base/_workflow_actions.html.erb
@@ -1,0 +1,39 @@
+<div id="workflow_controls" class="panel panel-workflow">
+  <div class="panel-heading">
+    <a data-toggle="collapse" href="#workflow_controls_collapse" aria-expanded="true">
+      <h2 class="panel-title">Review and Approval <i class="fa fa-chevron-right pull-right"></i></h2>
+    </a>
+  </div>
+  <%= form_tag main_app.hyrax_workflow_action_path(presenter), method: :put do %>
+    <div id="workflow_controls_collapse" class="panel-body panel-collapse collapse in" aria-expanded="true">
+      <div class="col-sm-3 workflow-actions">
+        <h3>Actions</h3>
+
+        <% presenter.workflow.actions.each do |key, label| %>
+          <div class="radio">
+            <label>
+              <%= radio_button_tag 'workflow_action[name]', key, key == 'comment_only' %>
+              <%= label %>
+            </label>
+          </div>
+        <% end %>
+      </div>
+      <div class="col-sm-9 workflow-comments">
+        <div class="form-group">
+          <label for="workflow_action_comment">Review comment:</label>
+          <textarea class="form-control" name="workflow_action[comment]" id="workflow_action_comment"></textarea>
+        </div>
+
+        <input class="btn btn-primary" type="submit" value="Submit" />
+
+        <h4>Previous Comments</h4>
+        <dl>
+          <% presenter.workflow.comments.each do |comment| %>
+            <dt><%= comment.name_of_commentor %></dt>
+            <dd><%= comment.comment %></dd>
+          <% end %>
+        </dl>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/spec/support/shared_examples/spot_works_controller.rb
+++ b/spec/support/shared_examples/spot_works_controller.rb
@@ -32,25 +32,25 @@ RSpec.shared_examples 'it includes Spot::WorksControllerBehavior' do
         expect(response.headers['Location']).to include '/users/sign_in'
       end
     end
+  end
 
-    describe 'setting workflow_presenter' do
-      context 'when editing a work' do
-        it 'sets a @workflow_presenter' do
-          get :edit, params: { id: work.id }
-          presenter = assigns(:workflow_presenter)
+  describe 'setting workflow_presenter' do
+    context 'when editing a work' do
+      it 'sets a @workflow_presenter' do
+        get :edit, params: { id: work.id }
+        presenter = assigns(:workflow_presenter)
 
-          expect(presenter).not_to be nil
-          expect(presenter).to be_a Hyrax::WorkflowPresenter
-        end
+        expect(presenter).not_to be nil
+        expect(presenter).to be_a Hyrax::WorkflowPresenter
       end
+    end
 
-      context 'when viewing a work' do
-        it 'does nothing' do
-          get :show, params: { id: work.id }
-          presenter = assigns(:workflow_presenter)
+    context 'when viewing a work' do
+      it 'does nothing' do
+        get :show, params: { id: work.id }
+        presenter = assigns(:workflow_presenter)
 
-          expect(presenter).to be nil
-        end
+        expect(presenter).to be nil
       end
     end
   end

--- a/spec/support/shared_examples/spot_works_controller.rb
+++ b/spec/support/shared_examples/spot_works_controller.rb
@@ -55,6 +55,35 @@ RSpec.shared_examples 'it includes Spot::WorksControllerBehavior' do
     end
   end
 
+  describe 'updating flash message' do
+    subject(:flash_notice) { response.request.flash[:notice] }
+
+    before do
+      allow(Hyrax::CurationConcern.actor).to receive(:update).and_return true
+      allow(Hyrax::WorkflowPresenter).to receive(:new).and_return(mock_workflow_presenter)
+
+      sign_in admin_user
+    end
+
+    let(:admin_user) { FactoryBot.create(:admin_user) }
+    let(:mock_workflow_presenter) { instance_double('Hyrax::WorkflowPresenter', actions: workflow_actions) }
+    let(:workflow_actions) { [] }
+    let(:response) { put :update, params: { id: work.id } }
+
+    it 'notifies that the work has been updated' do
+      expect(flash_notice).to include('successfully updated')
+      expect(flash_notice).not_to include('Finished making edits?')
+    end
+
+    context 'when workflow_actions exist' do
+      let(:workflow_actions) { [:workflow_action] }
+
+      it 'appends a note to flash[:notice] about the workflow_action form' do
+        expect(flash_notice).to include('Finished making edits?')
+      end
+    end
+  end
+
   describe 'additional formats' do
     context 'when requesting the metadata as csv' do
       let(:disposition)  { response.header.fetch('Content-Disposition') }


### PR DESCRIPTION
adds text to the flash confirmation for an updated work if workflow actions remain to be performed. also expands the workflow_action panel by default

<img width="1239" alt="Screen Shot 2022-04-25 at 12 54 41 PM" src="https://user-images.githubusercontent.com/2744987/165160744-f7759d41-a2eb-4193-8483-9eb714e275b0.png">