### PR TITLE
loosen dependency on cas entitlements

### DIFF
--- a/app/forms/hyrax/student_work_form.rb
+++ b/app/forms/hyrax/student_work_form.rb
@@ -49,7 +49,7 @@ module Hyrax
     # @return [Array<Symbol>]
     def primary_terms
       fields = required_fields + [:rights_holder]
-      return fields unless current_user.student?
+      return fields if current_user.admin?
 
       fields - [:rights_statement, :rights_holder]
     end
@@ -119,7 +119,7 @@ module Hyrax
     # @return [void]
     # @see https://github.com/samvera/hydra-editor/blob/v5.0.5/app/forms/hydra_editor/form.rb#L102-L109
     def initialize_field(key)
-      return super unless current_user.student?
+      return super if current_user.admin?
 
       case key.to_sym
       when :creator

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -13,7 +13,8 @@ class Ability
     :depositor_abilities,
     :admin_abilities,
     :faculty_abilities,
-    :student_abilities
+    :student_abilities,
+    :registered_abilities
   ]
 
   def self.preload_roles!
@@ -65,6 +66,14 @@ class Ability
 
     can(:read, :dashboard)
   end
+
+  def regsitered_abilities
+    return unless registered_user?
+
+    can(:create, StudentWork)
+    can(:read, :dashboard)
+  end
+
 
   # Delegates abilities for users that have the 'student' role
   #

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -67,7 +67,7 @@ class Ability
     can(:read, :dashboard)
   end
 
-  def regsitered_abilities
+  def registered_abilities
     return unless registered_user?
 
     can(:create, StudentWork)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -74,7 +74,6 @@ class Ability
     can(:read, :dashboard)
   end
 
-
   # Delegates abilities for users that have the 'student' role
   #
   # @return [void]

--- a/spec/controllers/hyrax/dashboard_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Hyrax::DashboardController do
       let(:user) { create(:registered_user) }
 
       it 'redirects to the main page' do
-        expect(response).to redirect_to(root_path)
+        expect(response).to render_template('show_user')
       end
     end
 

--- a/spec/forms/hyrax/student_work_form_spec.rb
+++ b/spec/forms/hyrax/student_work_form_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Hyrax::StudentWorkForm do
 
   describe '#initialize_field' do
     let(:form) { described_class.new(work, Ability.new(user), nil) }
-    let(:user) { create(:user) }
+    let(:user) { create(:admin_user) }
     let(:student_user) { create(:student_user) }
     let(:work) { StudentWork.new }
 
@@ -170,7 +170,7 @@ RSpec.describe Hyrax::StudentWorkForm do
     subject { described_class.new(work, Ability.new(user), nil).primary_terms }
 
     let(:work) { StudentWork.new }
-    let(:user) { create(:user) }
+    let(:user) { create(:admin_user) }
 
     it { is_expected.to include(:rights_statement, :rights_holder) }
 
@@ -188,12 +188,6 @@ RSpec.describe Hyrax::StudentWorkForm do
 
     context 'for non-admin users' do
       let(:user) { create(:user) }
-
-      it { is_expected.not_to include(:date_available, :note, :access_note) }
-    end
-
-    context 'for student users' do
-      let(:user) { create(:student_user) }
 
       it { is_expected.to include(:rights_statement, :rights_holder) }
       it { is_expected.not_to include(:date_available, :note, :access_note) }

--- a/spec/support/shared_examples/forms/spot_work_form.rb
+++ b/spec/support/shared_examples/forms/spot_work_form.rb
@@ -28,17 +28,5 @@ RSpec.shared_examples 'a Spot work form' do
         expect(rights).to be_a String
       end
     end
-
-    context 'when no rights_statement present' do
-      let(:work) { work_klass.constantize.new }
-
-      it do
-        if form.multiple?('rights_statement')
-          expect(rights).to eq []
-        else
-          expect(rights).to eq ''
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
fallbacks in the event of a cas entitlement bungle

- replaces `unless current_user.student?` guards with `if current_user.admin?`
- allows registered/authenticated users to create StudentWork objects, rather than restricting to just students.