### PR TITLE
allow read_users to view works in progress 

### DIFF
--- a/app/controllers/hyrax/student_works_controller.rb
+++ b/app/controllers/hyrax/student_works_controller.rb
@@ -5,6 +5,32 @@ module Hyrax
 
     self.curation_concern_type = ::StudentWork
     self.show_presenter = Hyrax::StudentWorkPresenter
+
+    # Modifying the search_builder_class to allow users whose user_keys
+    # are stored as a StudentWork#advisor value to view works currently
+    # in a workflow, that would normally be suppressed. We were finding
+    # that when an advisor submitted a request for changes to a work,
+    # their ability to view the work was recinded, as their "advising"
+    # workflow role wasn't eligible at the next stage. This would (for
+    # some reason) kick the user to CAS to re-authenticate, redirect them
+    # back to the :unauthorized work page, and then spiral into a redirect loop.
+    #
+    # This comes into play at Hyrax::WorksControllerBehavior#search_result_document,
+    # which uses Blacklight results to find the first valid document.
+    # With the default search_builder (Hyrax::WorkSearchBuilder), the
+    # work would not be returned after the advisor fell out of scope
+    # in the workflow. Our custom StudentWorkSearchBuilder checks a work's
+    # "advisor_ssim" field for the current_user to determine whether the
+    # "suppressed?" flag should be enabled or disabled.
+    #
+    # I don't fully understand the reasoning behind raising a WorkflowAuthorizationException
+    # if a doc is suppressed but the current_user has :read access to it
+    # (see Hyrax::WorksControllerBehavior#document_not_found!), but in order to
+    # avoid that being thrown, we need to have search_result_document return the
+    # document for valid users.
+    #
+    # @see https://github.com/samvera/hyrax/blob/v2.9.6/app/controllers/concerns/hyrax/works_controller_behavior.rb#L216-L221
+    # @see https://github.com/samvera/hyrax/blob/v2.9.6/app/controllers/concerns/hyrax/works_controller_behavior.rb#L223-L227
     self.search_builder_class = ::Spot::StudentWorkSearchBuilder
   end
 end

--- a/app/controllers/hyrax/student_works_controller.rb
+++ b/app/controllers/hyrax/student_works_controller.rb
@@ -5,5 +5,6 @@ module Hyrax
 
     self.curation_concern_type = ::StudentWork
     self.show_presenter = Hyrax::StudentWorkPresenter
+    self.search_builder_class = ::Spot::StudentWorkSearchBuilder
   end
 end

--- a/app/search_builders/spot/student_work_search_builder.rb
+++ b/app/search_builders/spot/student_work_search_builder.rb
@@ -8,6 +8,16 @@ module Spot
     # Also moves `#user_has_active_workflow_role?` method to after checking `#depositor?`
     # and `#advisor?`, as those methods don't require database lookups.
     #
+    # Fixes an issue where advisors would submit a request for changes on a work in progress
+    # using the `mediated_student_work_deposit` workflow, which would advance the work to
+    # the next workflow step, removing their ability view the work (checked via Hyrax::Workflow::PermissionQuery,
+    # via Hyrax::FilteredSuppressedWithRoles search_builder mixin). This would send the user
+    # into a redirect spiral, as the work controller would register the user as :unauthorized
+    # to view the work, send them to CAS to authorize, and then redirect back to the :unauthorized
+    # item.
+    #
+    # @see https://github.com/samvera/hyrax/blob/v2.9.6/app/services/hyrax/workflow/permission_query.rb#L35-L58
+    # @see https://github.com/samvera/hyrax/blob/v2.9.6/app/search_builders/hyrax/filter_suppressed_with_roles.rb#L26-L31
     # @see https://github.com/samvera/hyrax/blob/v2.9.6/app/search_builders/hyrax/filter_suppressed.rb#L10-L13
     def only_active_works(solr_parameters)
       return if depositor? || advisor? || user_has_active_workflow_role?

--- a/app/search_builders/spot/student_work_search_builder.rb
+++ b/app/search_builders/spot/student_work_search_builder.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+module Spot
+  class StudentWorkSearchBuilder < ::Hyrax::WorkSearchBuilder
+    # Modified from Hyrax::FilteredSuppressedWithRoles search_builder method to
+    # allow users specified in the StudentWork#advisor property to be able to view
+    # the work while it's currently in the workflow process.
+    #
+    # Also moves `#user_has_active_workflow_role?` method to after checking `#depositor?`
+    # and `#advisor?`, as those methods don't require database lookups.
+    #
+    # @see https://github.com/samvera/hyrax/blob/v2.9.6/app/search_builders/hyrax/filter_suppressed.rb#L10-L13
+    def only_active_works(solr_parameters)
+      return if depositor? || advisor? || user_has_active_workflow_role?
+
+      solr_parameters[:fq] ||= []
+      solr_parameters[:fq] << '-suppressed_bsi:true'
+    end
+
+    private
+
+    # Is the user_key (email) of the currently logged in user found in the work's "advisor_ssim" field?
+    #
+    # @return [true, false]
+    def advisor?
+      user_key = current_ability&.current_user&.user_key
+      return false unless user_key && current_work['advisor_ssim'].present?
+
+      current_work.fetch('advisor_ssim', []).any? { |advisor| advisor == user_key }
+    end
+  end
+end

--- a/spec/controllers/hyrax/student_works_controller.rb
+++ b/spec/controllers/hyrax/student_works_controller.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-RSpec.describe Hyrax::StudentWorksController do
-  it_behaves_like 'it includes Spot::WorksControllerBehavior'
-end

--- a/spec/controllers/hyrax/student_works_controller_spec.rb
+++ b/spec/controllers/hyrax/student_works_controller_spec.rb
@@ -75,5 +75,15 @@ RSpec.describe Hyrax::StudentWorksController do
         expect(response).to be_ok
       end
     end
+
+    context 'when the current_user is an admin' do
+      let(:current_user) { FactoryBot.create(:admin_user) }
+
+      it 'displays the work' do
+        get :show, params: { id: solr_doc['id'] }
+
+        expect(response).to be_ok
+      end
+    end
   end
 end

--- a/spec/controllers/hyrax/student_works_controller_spec.rb
+++ b/spec/controllers/hyrax/student_works_controller_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::StudentWorksController do
+  it_behaves_like 'it includes Spot::WorksControllerBehavior'
+
+  describe 'viewing a work-in-progress' do
+    let(:solr_doc) do
+      {
+        'id' => 'abc123def',
+        'has_model_ssim' => ['StudentWork'],
+        'title_tesim' => ['Title of Work'],
+        'advisor_ssim' => [advisor.user_key],
+        'depositor_ssim' => [depositor.user_key],
+        'visibility_ssi' => 'public',
+        'workflow_state_name_ssim' => 'advisor_requests_changes',
+        'read_access_person_ssim' => [depositor.user_key, advisor.user_key],
+        'edit_access_person_ssim' => [depositor.user_key],
+        'suppressed_bsi' => true
+      }
+    end
+
+    let(:advisor) { FactoryBot.create(:user) }
+    let(:depositor) { FactoryBot.create(:user) }
+    let(:current_user) { nil }
+
+    before do
+      ActiveFedora::SolrService.add(solr_doc, commit: true)
+
+      sign_in(current_user) unless current_user.nil?
+    end
+
+    after do
+      ActiveFedora::SolrService.instance.conn.delete_by_query("id:#{solr_doc['id']}", commit: true)
+    end
+
+    context 'when the current_user is a general one' do
+      it 'redirects the user to log in' do
+        get :show, params: { id: solr_doc['id'] }
+
+        expect(response.code).to eq('302')
+      end
+    end
+
+    context 'when the current_user has no relation to the work' do
+      let(:current_user) { FactoryBot.create(:user) }
+
+      it 'renders 401 Unauthorized' do
+        get :show, params: { id: solr_doc['id'] }
+
+        expect(response.code).to eq('401')
+      end
+    end
+
+    context 'when the current_user is the depositor' do
+      let(:current_user) { depositor }
+
+      it 'displays the work' do
+        get :show, params: { id: solr_doc['id'] }
+
+        expect(response).to be_ok
+      end
+    end
+
+    context 'when the current_user is the advisor' do
+      let(:current_user) { advisor }
+
+      before do
+        allow(Hyrax::Workflow::PermissionQuery)
+          .to receive(:scope_permitted_workflow_actions_available_for_current_state)
+          .and_return([])
+      end
+
+      it 'displays the work' do
+        get :show, params: { id: solr_doc['id'] }
+
+        expect(response).to be_ok
+      end
+    end
+  end
+end

--- a/spec/search_builders/spot/student_work_search_builder_spec.rb
+++ b/spec/search_builders/spot/student_work_search_builder_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+RSpec.describe Spot::StudentWorkSearchBuilder do
+  describe '#only_active_works' do
+    subject(:active_work_query) { builder.only_active_works(params) }
+
+    let(:builder) { described_class.new(scope).with(blacklight_params) }
+    let(:params) { {} }
+    let(:scope) { OpenStruct.new(current_ability: current_ability) }
+    let(:blacklight_params) { { id: 'abc123def' } }
+    let(:current_ability) { Ability.new(current_user) }
+    let(:depositor) { FactoryBot.build(:user) }
+    let(:advisor) { FactoryBot.build(:user) }
+    let(:solr_document) { SolrDocument.new(solr_parameters) }
+    let(:solr_parameters) { _solr_params }
+    let(:_solr_params) do
+      {
+        'depositor_ssim' => [depositor.user_key],
+        'title_tesim' => ['A Fabulous Thesis'],
+        'advisor_ssim' => [advisor.user_key],
+        'suppressed_bsi' => true
+      }
+    end
+
+    before do
+      allow(SolrDocument)
+        .to receive(:find)
+        .with(blacklight_params[:id])
+        .and_return(solr_document)
+
+      allow(Hyrax::Workflow::PermissionQuery)
+        .to receive(:scope_permitted_workflow_actions_available_for_current_state)
+        .and_return([])
+
+      # @todo this is added as a part of Blacklight::AccessControls, which is deprecated.
+      #       in the future, while upgrading to hyrax v3, this will have to be removed in
+      #       favor of assigning the ability via `builder#with_ability(ability)`
+      builder.current_ability = current_ability
+    end
+
+    shared_examples 'it adds the hide-suppressed parameter' do
+      it do
+        active_work_query
+        expect(params.fetch(:fq, [])).to eq ['-suppressed_bsi:true']
+      end
+    end
+
+    shared_examples 'it does not add the hide-suppressed parameter' do
+      it do
+        active_work_query
+        expect(params.fetch(:fq, [])).to eq []
+      end
+    end
+
+    context 'with a logged-in user' do
+      let(:current_user) { FactoryBot.build(:user) }
+
+      it_behaves_like 'it adds the hide-suppressed parameter'
+    end
+
+    context 'with an anonymous user' do
+      let(:current_user) { nil }
+
+      it_behaves_like 'it adds the hide-suppressed parameter'
+    end
+
+    context 'when current_user is depositor' do
+      let(:current_user) { depositor }
+
+      it_behaves_like 'it does not add the hide-suppressed parameter'
+    end
+
+    context 'when current_user is an advisor' do
+      let(:current_user) { advisor }
+
+      it_behaves_like 'it does not add the hide-suppressed parameter'
+    end
+  end
+end

--- a/spec/search_builders/spot/student_work_search_builder_spec.rb
+++ b/spec/search_builders/spot/student_work_search_builder_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Spot::StudentWorkSearchBuilder do
       {
         'depositor_ssim' => [depositor.user_key],
         'title_tesim' => ['A Fabulous Thesis'],
-        'advisor_ssim' => [advisor.user_key],
-        'suppressed_bsi' => true
+        'suppressed_bsi' => true,
+        'read_access_person_ssim' => [depositor.user_key, advisor.user_key]
       }
     end
 
@@ -71,6 +71,12 @@ RSpec.describe Spot::StudentWorkSearchBuilder do
 
     context 'when current_user is an advisor' do
       let(:current_user) { advisor }
+
+      it_behaves_like 'it does not add the hide-suppressed parameter'
+    end
+
+    context 'when current_user is an admin' do
+      let(:current_user) { FactoryBot.create(:admin_user) }
 
       it_behaves_like 'it does not add the hide-suppressed parameter'
     end


### PR DESCRIPTION
replacement for #916 that allows read_users to view works in a workflow state that may not involve the user. (modified a little) from `app/controllers/hyrax/student_works_controller.rb`

> Modifying the search_builder_class `Hyrax::StudentWorkController` which allows users within a work's #read_users collection to view a work that is currently in the middle of a deposit workflow.
> 
> We were encountering an issue where an advisor on a work would request changes from the Review form, which would send them into a redirection loop with the CAS server. From the best I could deduce, this is being caused by:
>   - advisor user advancing the workflow to a new step where they have no active role (see [`Hyrax::FilteredSuppressedWithRoles#user_has_active_workflow_role?`] which performs a permission query)
>   - this causes the controller's search_builder to exclude it from results (by setting an fq value of "-suppressed_bsi:true")
>   - because the work is `#suppressed?` and the user can :read the work, they're thrown a WorkflowAuthorizationException...
>   - ... which is rescued and served as :not_authorized
>   - devise_cas_authenticatable (via rack-cas internals) then intercepts the :not_authorized (401) response and then falls into a redirection loop with the CAS server.
> 
> A good fix seems to be to modify [`#render_unavailable`] to render with a status of :forbidden (403), which seems like the most technically sound solution, as 401 Unauthorized indicates that the user has not been authenticated yet, whereas 403 Forbiden indicates that the user explicitly is not allowed to access the request subject). But we want users assigned read_user access to be able to view the work as it's in progress, rather than bouncing them after completing their role in the workflow action. So instead, I'm modifying the search_builder to allow read_users access in cases where their workflow role may not.
> 

----

closes #910 

[`#render_unavailable`]: https://github.com/samvera/hyrax/blob/v2.9.6/app/controllers/concerns/hyrax/works_controller_behavior.rb#L229-L251
[`Hyrax::FilteredSuppressedWithRoles#user_has_active_workflow_role?`]: https://github.com/samvera/hyrax/blob/v2.9.6/app/services/hyrax/workflow/permission_query.rb#L35-L58