### PR TITLE
add advisor label i18n to catalog_controller

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -100,7 +100,8 @@ class CatalogController < ApplicationController
     config.add_facet_field 'has_model_ssim', label: :'blacklight.search.fields.has_model', if: false
 
     # Facets from the Work-level that aren't provided in the catalog
-    config.add_facet_field 'research_assistance_ssim', label: :'blacklight.search.facets.research_assistance', if: false
+    config.add_facet_field 'research_assistance_ssim', label: :'blacklight.search.fields.research_assistance', if: false
+    config.add_facet_field 'advisor_label_ssim', label: :'blacklight.search.fields.advisor_label', if: false
 
     # Blacklight will default a facet's limit to the +blacklight_config.default_facet_limit+ value
     # only if the field config +:limit+ entry is true. This does that.

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -2,7 +2,8 @@ en:
   blacklight:
     search:
       facets:
-        research_assistance: Research Assistance
+        # We don't want to spell out the OCM acronym on the facet labels,
+        # which have limited space available.
         subject_ocm: OCM Classification
         admin:
           title: Admin Facets


### PR DESCRIPTION
adds catalog_controller configuration to render correct label for `advisor_label_ssim` when faceting via link on work show page. also changes the label source for 'research_assistance'

closes #908 