### PR TITLE
use String#underscore to generate a redirection route from model

### DIFF
--- a/app/controllers/concerns/spot/redirection_helpers.rb
+++ b/app/controllers/concerns/spot/redirection_helpers.rb
@@ -7,7 +7,7 @@ module Spot
     # collections but not other work types. There's probably something I'm missing, but this will at least
     # allow us to resolve Handles and legacy URLs for collections.
     def redirect_params_for(solr_document:)
-      controller = solr_document['has_model_ssim'].first.downcase.pluralize
+      controller = solr_document['has_model_ssim'].first.underscore.pluralize
       params = { controller: "hyrax/#{controller}", action: 'show', id: solr_document['id'] }
 
       return Hyrax::Engine.routes.url_for(**params, only_path: true) if controller == 'collections'

--- a/spec/controllers/handle_controller_spec.rb
+++ b/spec/controllers/handle_controller_spec.rb
@@ -42,6 +42,32 @@ RSpec.describe HandleController do
       it { is_expected.to redirect_to hyrax_image_path(solr_data[:id]) }
     end
 
+    context 'when a Handle exists for an Image' do
+      let(:handle) { '10385/5678' }
+      let(:solr_data) do
+        {
+          id: 'existing-img',
+          has_model_ssim: ['Image'],
+          identifier_ssim: ["hdl:#{handle}"]
+        }
+      end
+
+      it { is_expected.to redirect_to hyrax_image_path(solr_data[:id]) }
+    end
+
+    context 'when a Handle exists for a StudentWork' do
+      let(:handle) { '10385/9012' }
+      let(:solr_data) do
+        {
+          id: 'existing-student_work',
+          has_model_ssim: ['StudentWork'],
+          identifier_ssim: ["hdl:#{handle}"]
+        }
+      end
+
+      it { is_expected.to redirect_to hyrax_student_work_path(solr_data[:id]) }
+    end
+
     context 'when a Handle exists for a Collection' do
       let(:handle) { '10385/9012' }
       let(:solr_data) do


### PR DESCRIPTION
rather than `String#downcase`, which will fail for models with multiple words (eg. `StudentWork` should become `student_work`)

closes #942 