### PR TITLE
bugfix: work.visibility = "authenticated" should result in work.visibility == "authenticated"

### DIFF
--- a/app/models/concerns/spot/metadata_only_visibility.rb
+++ b/app/models/concerns/spot/metadata_only_visibility.rb
@@ -21,9 +21,15 @@ module Spot
     # @return [String]
     # @see https://github.com/samvera/hydra-head/blob/v11.0.0/hydra-access-controls/app/models/concerns/hydra/access_controls/visibility.rb#L20-L28
     def visibility
-      return 'metadata' if !public? && discover_groups.include?(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
-
-      super
+      if read_groups.include? Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      elsif read_groups.include? Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      elsif discover_groups.include?(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
+        'metadata'
+      else
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      end
     end
 
     private

--- a/spec/support/shared_examples/metadata_only_visibility.rb
+++ b/spec/support/shared_examples/metadata_only_visibility.rb
@@ -15,6 +15,19 @@ RSpec.shared_examples 'it accepts "metadata" as a visibility' do
 
       it { is_expected.to eq 'metadata' }
     end
+
+    [
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED,
+      'metadata',
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    ].each do |viz|
+      context "when visibility is set to \"#{viz}\"" do
+        before { work.visibility = viz }
+
+        it { is_expected.to eq viz }
+      end
+    end
   end
 
   describe '#visibility=' do


### PR DESCRIPTION
fixes the following bug:

```
irb(main):001:0> work = StudentWork.new(date: ['2022']) # can be any class that includes `Spot::WorkBehavior`
=> #<StudentWork id: nil, head: [], tail: [], depositor: nil, title: [], ...>
irb(main):002:0> work.visibility = "authenticated"
=> "authenticated"
irb(main):003:0> work.visibility
=> "metadata"
```

we're not seeing this on the UI side because SolrDocument does its own checks for `#visibility` (though it seems like those checks should be done on the work model and SolrDocument should just be loading the string value?). this patch gets the work's behavior more in line with the presenter logic, which uses the hierarchy:

1. "open"
2. "authenticated"
3. "metadata"
4. "restricted"

to be honest, the metadata-only logic is kinda hairy across the app and could use some refactoring, but i think access control is overhauled in hyrax 3 and might be worthwhile holding off until the upgrade.