### PR TITLE
2022.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # changelog
 
+## [2022.5] - 2022-09-29
+
+### updates ✨ 
+- prioritize CollectionPresenter#abstract for collection descriptions on work views (#950)
+- rename "Foreign Languages and Literatures" department to "Languages and Literary Studies" (#954)
+
+### bug fixes 🐞 
+- setting `work.visibility = "authenticated"` will now result in `work.visibility == "authenticated"`, instead of "metadata" (#951)
+
+### notes 🎶 
+after deploying to production, you'll want to update all objects in the "Foreign Languages and Literatures" department to use the new name:
+
+```ruby
+old_dept = 'Foreign Languages & Literatures'
+new_dept = 'Languages and Literary Studies'
+ActiveFedora::Base.where(academic_department_sim: [old_dept]).each do |work|
+  work.academic_department = work.academic_department.map { |department| department == old_dept ? new_dept : department }
+  work.save
+end
+```
+
+
+## [2022.4] - 2022-08-01
+
+### updates 📰 
+- removes solr_suggest autocomplete from StudentWork fields "advisor" and "bibliographic_citation" (#930)
+- add Darlingtonia-based service for ingesting objects via CSV sheet (#932, #944)
+- add link to accessibility remediation request in footer (#945)
+- add `keyword_tesim` and `date_associated_tesim` to all_fields search (see notes) (#946)
+
+### deprecations 💀  
+- removes BagIt ingest infrastructure used for initial migration (#934)
+
+### bug fixes 🐞 
+- add catalog_controller configuration to display "advisor_label_ssim" facets properly (#928)
+- add permalink display to student_work show page (#927)
+- use `String#underscore` to build the parameter key for works in the HandleController (#943)
+
+### notes 📓 
+- requires a reindex of Image works for `date_associated` fields (see #946)
+
+
 ## [2022.3] - 2022-05-01
 
 ### updates
@@ -751,6 +793,8 @@ fixes:
 
 Initial pre-release (live on ldr.stage.lafayette.edu)
 
+[2022.5]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2022.5
+[2022.4]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2022.4
 [2022.3]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2022.3
 [2022.2]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2022.2
 [2022.1]: https://github.com/LafayetteCollegeLibraries/spot/releases/tag/2022.1

--- a/app/models/concerns/spot/metadata_only_visibility.rb
+++ b/app/models/concerns/spot/metadata_only_visibility.rb
@@ -21,9 +21,15 @@ module Spot
     # @return [String]
     # @see https://github.com/samvera/hydra-head/blob/v11.0.0/hydra-access-controls/app/models/concerns/hydra/access_controls/visibility.rb#L20-L28
     def visibility
-      return 'metadata' if !public? && discover_groups.include?(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
-
-      super
+      if read_groups.include? Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      elsif read_groups.include? Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      elsif discover_groups.include?(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
+        'metadata'
+      else
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      end
     end
 
     private

--- a/app/views/hyrax/base/_relationships.html.erb
+++ b/app/views/hyrax/base/_relationships.html.erb
@@ -23,13 +23,14 @@
       <% batch.each do |item| %>
         <% item_type = item.model_name.human.underscore.to_sym %>
         <% url = polymorphic_url([item_type], id: item.id) %>
+        <% text = (item.try(:abstract) || item.try(:description) || []).first %>
         <div class="col-md-3">
           <div class="thumbnail">
             <%= image_tag(item.thumbnail_path, alt: '') %>
             <div class="caption">
               <h3><%= item.title.first %></h3>
-              <% if item.description.present? %>
-              <p><%= item.description.first %></p>
+              <% if text.present? %>
+              <p><%= text %></p>
               <% end %>
               <p>
                 <a href="<%= url %>" class="btn btn-info btn-block">

--- a/config/authorities/lafayette_departments.yml
+++ b/config/authorities/lafayette_departments.yml
@@ -16,11 +16,11 @@ terms:
   - English
   - Environmental Science & Studies
   - Film & Media Studies
-  - Foreign Languages & Literatures
   - Geology & Environmental Geosciences
   - Government & Law
   - History
   - International Affairs
+  - Languages and Literary Studies
   - Libraries
   - Mathematics
   - Mechanical Engineering

--- a/spec/support/shared_examples/metadata_only_visibility.rb
+++ b/spec/support/shared_examples/metadata_only_visibility.rb
@@ -15,6 +15,19 @@ RSpec.shared_examples 'it accepts "metadata" as a visibility' do
 
       it { is_expected.to eq 'metadata' }
     end
+
+    [
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED,
+      'metadata',
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    ].each do |viz|
+      context "when visibility is set to \"#{viz}\"" do
+        before { work.visibility = viz }
+
+        it { is_expected.to eq viz }
+      end
+    end
   end
 
   describe '#visibility=' do


### PR DESCRIPTION
## updates ✨ 
- prioritize CollectionPresenter#abstract for collection descriptions on work views (#950)
- rename "Foreign Languages and Literatures" department to "Languages and Literary Studies" (#954)

## bug fixes 🐞 
- setting `work.visibility = "authenticated"` will now result in `work.visibility == "authenticated"`, instead of "metadata" (#951)
  - requires some testing, but might fix #933 

## notes 🎶 
after deploying to production, you'll want to update all objects in the "Foreign Languages and Literatures" department to use the new name:

```ruby
old_dept = 'Foreign Languages & Literatures'
new_dept = 'Languages and Literary Studies'
ActiveFedora::Base.where(academic_department_sim: [old_dept]).each do |work|
  work.academic_department = work.academic_department.map { |department| department == old_dept ? new_dept : department }
  work.save
end
```

-----

closes #935 
closes #949 