### PR TITLE
use cimg containers in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,9 @@ jobs:
 
       - run:
           name: Make sure dependencies are valid
-          command: bundle check || bundle install
+          command: |
+            gem install bundler:1.16.1
+            bundle check || bundle install
 
       - run:
           name: Load config into Solr

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,7 @@ jobs:
             sudo apt-get install -y postgresql-9.6 libpq-dev
       - run:
           name: Use Bundler version specified in Gemfile.lock
-          command: |
-            sudo gem update --system
-            sudo gem install -i /usr/local/lib/ruby/gems/2.4.0 bundler -v`(tail -n1 Gemfile.lock | xargs)`
+          command: gem install bundler:1.16.1
       - restore_cache:
           name: Restore cached bundle
           key: spot-gems-{{ checksum "Gemfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,9 +116,13 @@ jobs:
           at: ~/
 
       - run:
-          name: Install system dependencies
+          name: Install Postgres dependency
           command: |
-            sudo apt-get install -y postgresql-9.6
+            sudo apt-get update -y
+            curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+            echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/postgresql-pgdg.list > /dev/null
+            sudo apt-get update -y
+            sudo apt-get install -y postgresql-9.6 libpq-dev
 
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,6 @@ jobs:
           name: Use Bundler version specified in Gemfile.lock
           command: |
             sudo gem update --system
-            sudo gem uninstall -i /usr/local/lib/ruby/gems/2.4.0 -aIx bundler
             sudo gem install -i /usr/local/lib/ruby/gems/2.4.0 bundler -v`(tail -n1 Gemfile.lock | xargs)`
       - restore_cache:
           name: Restore cached bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,10 @@ jobs:
     steps:
       - checkout
       - run:
+        name: Install system dependencies
+        command: |
+          sudo apt-get install -y postgresql-9.6
+      - run:
           name: Use Bundler version specified in Gemfile.lock
           command: |
             sudo gem update --system
@@ -105,6 +109,11 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+
+      - run:
+          name: Install system dependencies
+          command: |
+            sudo apt-get install -y postgresql-9.6
 
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
             curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
             echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/postgresql-pgdg.list > /dev/null
             sudo apt-get update -y
-            sudo apt-get install -y postgresql-9.6
+            sudo apt-get install -y postgresql-9.6 postgresql-contrib-9.6
       - run:
           name: Use Bundler version specified in Gemfile.lock
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,8 +58,12 @@ jobs:
       - checkout
 
       - run:
-          name: Install system dependencies
+          name: Install Postgres dependency
           command: |
+            sudo apt-get update -y
+            curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+            echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/postgresql-pgdg.list > /dev/null
+            sudo apt-get update -y
             sudo apt-get install -y postgresql-9.6
       - run:
           name: Use Bundler version specified in Gemfile.lock

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,10 +56,11 @@ jobs:
     executor: ruby
     steps:
       - checkout
+
       - run:
-        name: Install system dependencies
-        command: |
-          sudo apt-get install -y postgresql-9.6
+          name: Install system dependencies
+          command: |
+            sudo apt-get install -y postgresql-9.6
       - run:
           name: Use Bundler version specified in Gemfile.lock
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,8 +102,11 @@ jobs:
     - attach_workspace:
         at: ~/
     - run:
+        name: Fine, we'll install bundler again
+        command: gem install bundler:1.16.1
+    - run:
         name: Get 'em Rubocop!
-        command: bundle exec rubocop
+        command: (bundle check || bundle install) && bundle exec rubocop
 
   test:
     executor: application

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,55 @@
 version: 2.1
+orbs:
+  browser-tools: circleci/browser-tools@1.4.0
+
 executors:
   ruby:
     docker:
-      - image: circleci/ruby:2.4.6-stretch-node-browsers-legacy
+      - image: cimg/ruby:2.4.10-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
     working_directory: ~/spot
     environment:
       BUNDLE_PATH: vendor/bundle
+
+  application:
+    docker:
+      - image: cimg/ruby:2.4.10-node
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+      - image: cimg/redis:5.0.14
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+      - image: postgres:9.6-alpine
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+        environment:
+          POSTGRES_USER: spot_dev_user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: spot_test
+      - image: samvera/fcrepo4:4.7.5
+        environment:
+          CATALINA_OPTS: '-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC'
+      - image: solr:7.5.0-alpine
+        command: bin/solr -cloud -noprompt -f -p 8983
+    working_directory: ~/spot
+    environment:
+      - BUNDLE_PATH=vendor/bundle
+      - CAS_BASE_URL=http://localhost
+      - CI=1
+      - FEDORA_TEST_URL=http://localhost:8080/rest
+      - IIIF_BASE_URL=http://localhost/iiif/2
+      - RAILS_ENV=test
+      - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+      - PSQL_DATABASE=spot_test
+      - PSQL_USER=spot_dev_user
+      - PSQL_PASSWORD=password
+      - SOLR_TEST_URL=http://localhost:8983/solr/spot-test
+      - URL_HOST=http://localhost
 
 jobs:
   bundle:
@@ -59,56 +100,18 @@ jobs:
         command: bundle exec rubocop
 
   test:
-    docker:
-      - image: circleci/ruby:2.4.3-stretch-node-browsers
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-      - image: circleci/redis:4
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-      - image: postgres:9.6-alpine
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-        environment:
-          POSTGRES_USER: spot_dev_user
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: spot_test
-      - image: samvera/fcrepo4:4.7.5
-        environment:
-          CATALINA_OPTS: '-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC'
-      - image: solr:7.5.0-alpine
-        command: bin/solr -cloud -noprompt -f -p 8983
-
-    working_directory: ~/spot
+    executor: application
     parallelism: 4
-
-    environment:
-      BUNDLE_PATH: vendor/bundle
-      RAILS_ENV: test
-      FEDORA_TEST_URL: http://localhost:8080/rest
-      SOLR_TEST_URL: http://localhost:8983/solr/spot-test
-      NOKOGIRI_USE_SYSTEM_LIBRARIES: true
-      PSQL_USER: spot_dev_user
-      PSQL_PASSWORD: password
-      PSQL_DATABASE: spot_test
-      CI: true
-      CAS_BASE_URL: http://localhost
-      URL_HOST: http://localhost
-      IIIF_BASE_URL: http://localhost/iiif/2
-
     steps:
       - attach_workspace:
           at: ~/
 
-      # Update to the latest release of Chrome
-      - run: wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-      - run: sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-      - run: sudo apt-get update
-      - run: sudo apt-get -y install google-chrome-stable postgresql-9.6
-      - run: google-chrome-stable --headless --disable-gpu -no-sandbox --browsertime.xvfb --remote-debugging-port=9222 http://localhost &
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
+
+      - run:
+          name: Start headless Chrome browser in the background
+          command: google-chrome --headless --disable-gpu -no-sandbox --browsertime.xvfb --remote-debugging-port=9222 http://localhost &
 
       - run:
           name: Make sure dependencies are valid
@@ -135,6 +138,7 @@ jobs:
             mkdir /tmp/test-results
             ./cc-test-reporter before-build
             bundle exec rspec \
+              --backtrace \
               --format RspecJunitFormatter \
               --out /tmp/test-results/rspec.xml \
               --format progress\
@@ -159,13 +163,7 @@ jobs:
           destination: test-results
 
   upload-coverage:
-    docker:
-      - image: circleci/ruby:2.4.3-stretch-node-browsers
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-    working_directory: ~/spot
-
+    executor: ruby
     steps:
       - attach_workspace:
           at: ~/spot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
             curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
             echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/postgresql-pgdg.list > /dev/null
             sudo apt-get update -y
-            sudo apt-get install -y postgresql-9.6 postgresql-contrib-9.6
+            sudo apt-get install -y postgresql-9.6 libpq-dev
       - run:
           name: Use Bundler version specified in Gemfile.lock
           command: |


### PR DESCRIPTION
starting to get errors re: installing google-chrome headless on circleci images (see: https://app.circleci.com/pipelines/github/LafayetteCollegeLibraries/spot/2179/workflows/dc0585b5-7533-4193-8bdd-c5a2c28403ab/jobs/8081). this borrows code from [another pr] to rewrite the jobs to use the newer `cimg` images and `browser-tools` orb.

[another pr]: https://github.com/LafayetteCollegeLibraries/spot/pull/907