### PR TITLE
store IIIF access copies in S3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,18 @@ RUN SECRET_KEY_BASE="$(bin/rake secret)" \
 ##
 FROM spot-base as spot-development
 ENV RAILS_ENV=development
+
+# install awscli the hard way (via python) bc our base image is
+# too old to include it in the alpine 3.10 apk
+#
+# @ see https://gist.github.com/gmoon/3800dd80498d242c4c6137860fe410fd
+RUN apk --no-cache --update add musl-dev gcc python3 python3-dev \
+    && python3 -m ensurepip --upgrade \
+    && pip3 install --upgrade pip \
+    && pip3 install --upgrade awscli \
+    && pip3 uninstall --yes pip \
+    && apk del python3-dev gcc musl-dev
+
 RUN bundle install --jobs "$(nproc)" --with="development test"
 COPY . /spot
 

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem 'hyrax', '~> 2.9.0'
 # modularize our javascripts
 gem 'almond-rails', '0.3.0'
 
+# interact with assets in s3 buckets
+gem 'aws-sdk-s3'
+
 # parse + build bagit-compliant files
 gem 'bagit', '0.4.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -986,6 +986,7 @@ PLATFORMS
 DEPENDENCIES
   almond-rails (= 0.3.0)
   amazing_print (= 1.2.1)
+  aws-sdk-s3
   bagit (= 0.4.4)
   bixby (= 1.0.0)
   blacklight_advanced_search (= 6.4.1)
@@ -1072,4 +1073,4 @@ DEPENDENCIES
   webmock (~> 3.8)
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/app/services/spot/derivatives/access_master_service.rb
+++ b/app/services/spot/derivatives/access_master_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'aws-sdk-s3'
 require 'digest/md5'
+require 'fileutils'
 
 module Spot
   module Derivatives
@@ -64,8 +65,7 @@ module Spot
 
         return unless use_s3?
 
-        upload_derivative_to_s3
-        cleanup_derivatives_local
+        upload_derivative_to_s3 && cleanup_local_derivatives
       end
 
       # copied from https://github.com/samvera/hyrax/blob/5a9d1be1/app/services/hyrax/file_set_derivatives_service.rb#L32-L37

--- a/app/services/spot/derivatives/access_master_service.rb
+++ b/app/services/spot/derivatives/access_master_service.rb
@@ -73,9 +73,8 @@ module Spot
       #
       # @return [String]
       def derivative_path
-        Hyrax::DerivativePath
-          .derivative_path_for_reference(file_set, 'access.tif')
-          .to_s.gsub(%r{\.#{'access.tif'}$}, '')
+        @derivative_path ||=
+          Hyrax::DerivativePath.derivative_path_for_reference(file_set, 'access.tif').to_s.gsub(/\.access\.tif$/, '')
       end
 
       private
@@ -98,7 +97,7 @@ module Spot
           key: s3_derivative_key,
           body: File.open(derivative_path, 'r'),
           content_length: File.size(derivative_path),
-          content_md5: Digest::MD5.file(derivative_path).to_s
+          content_md5: Digest::MD5.file(derivative_path).base64digest
         )
       end
 

--- a/app/services/spot/derivatives/access_master_service.rb
+++ b/app/services/spot/derivatives/access_master_service.rb
@@ -1,21 +1,52 @@
 # frozen_string_literal: true
+require 'aws-sdk-s3'
+require 'digest/md5'
+
 module Spot
   module Derivatives
     # Creates access_master derivatives for all image-based works.
     # Intended to be run as part of a subset within {Spot::ImageDerivativesService}
     # and needs to respond to :cleanup_derivatives and :create_derivatives (the
     # latter receives a source filename as a parameter).
+    #
+    # When the following AWS-related environment variables are present, this will
+    # write the file to a defined S3 bucket and remove the local copy:
+    #   - AWS_ACCESS_KEY_ID
+    #   - AWS_SECRET_ACCESS_KEY
+    #   - AWS_IIIF_ASSET_BUCKET
+    #
+    # @example
+    #   file_set = FileSet.find(id: 'abc123def')
+    #   src_path = Rails.root.join('tmp', 'uploads', more_path, 'original-file.tif')
+    #   Spot::Derivatives::AccessMasterService.new(file_set).create_derivatives(src_path)
     class AccessMasterService < BaseDerivativesService
-      # Deletes the local access_master derivative if it exists
+      # Determines which cleanup method to use based on whether or not AWS related
+      # variables are present in ENV
       #
       # @return [void]
       def cleanup_derivatives
+        use_s3? ? cleanup_s3_derivatives : cleanup_local_derivatives
+      end
+
+      # Deletes the local access_master derivative if it exists
+      #
+      # @return [void]
+      def cleanup_local_derivatives
         FileUtils.rm_f(derivative_path) if File.exist?(derivative_path)
       end
 
+      # Deletes the derivative from the S3 bucket
+      # @todo maybe we should hang onto these when we delete + put them in a glacier grave?
+      # @return [void]
+      # @see https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html#delete_object-instance_method
+      def cleanup_s3_derivatives
+        s3_client.delete_object(bucket: s3_bucket, key: s3_derivative_key)
+      end
+
       # Since we want to pass some extended options to the creation process,
-      # we'll just use MiniMagick, rather than use
-      # Hydra::Derviatives::ImageDerivatives.
+      # we'll use MiniMagick directly instead of Hydra::Derviatives::ImageDerivatives.
+      # If AWS ENV variables are present, this will upload the generated file
+      # to an S3 bucket and then delete the local copy.
       #
       # @param [String,Pathname] filename the src path of the file
       # @return [void]
@@ -30,6 +61,11 @@ module Spot
           magick.merge! %w[-define tiff:tile-geometry=128x128 -compress jpeg]
           magick << "ptif:#{derivative_path}"
         end
+
+        return unless use_s3?
+
+        upload_derivative_to_s3
+        cleanup_derivatives_local
       end
 
       # copied from https://github.com/samvera/hyrax/blob/5a9d1be1/app/services/hyrax/file_set_derivatives_service.rb#L32-L37
@@ -40,6 +76,38 @@ module Spot
         Hyrax::DerivativePath
           .derivative_path_for_reference(file_set, 'access.tif')
           .to_s.gsub(%r{\.#{'access.tif'}$}, '')
+      end
+
+      private
+
+      def s3_bucket
+        ENV['AWS_IIIF_ASSET_BUCKET']
+      end
+
+      def s3_client
+        @s3_client ||= Aws::S3::Client.new
+      end
+
+      def s3_derivative_key
+        "#{file_set.id}-access.tif"
+      end
+
+      def upload_derivative_to_s3
+        s3_client.put_object(
+          bucket: s3_bucket,
+          key: s3_derivative_key,
+          body: File.open(derivative_path, 'r'),
+          content_length: File.size(derivative_path),
+          content_md5: Digest::MD5.file(derivative_path).to_s
+        )
+      end
+
+      def use_s3?
+        %w[
+          AWS_ACCESS_KEY_ID
+          AWS_SECRET_ACCESS_KEY
+          AWS_IIIF_ASSET_BUCKET
+        ].all? { |k| ENV[k].present? }
       end
     end
   end

--- a/bin/migrate-and-seed-db.sh
+++ b/bin/migrate-and-seed-db.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
-echo "creating s3 bucket"
-aws --endpoint-url="${AWS_ENDPOINT_URL:-"http://localhost:4566"}" s3 mb "s3://${AWS_IIIF_ASSET_BUCKET}"
+if [[ ! -z "$AWS_IIIF_ASSET_BUCKET" ]]; then
+  echo "creating s3 bucket"
+  aws --endpoint-url="${AWS_ENDPOINT_URL:-"http://localhost:4566"}" s3 mb "s3://${AWS_IIIF_ASSET_BUCKET}"
+fi
 
 script_root="$(dirname $0)"
 $script_root/wait-for.sh db:5432

--- a/bin/migrate-and-seed-db.sh
+++ b/bin/migrate-and-seed-db.sh
@@ -2,7 +2,7 @@
 
 if [[ ! -z "$AWS_IIIF_ASSET_BUCKET" ]]; then
   echo "creating s3 bucket"
-  aws --endpoint-url="${AWS_ENDPOINT_URL:-"http://localhost:4566"}" s3 mb "s3://${AWS_IIIF_ASSET_BUCKET}"
+  aws --endpoint-url="${AWS_ENDPOINT_URL:-"http://localhost:9000"}" s3 mb "s3://${AWS_IIIF_ASSET_BUCKET}"
 fi
 
 script_root="$(dirname $0)"

--- a/bin/migrate-and-seed-db.sh
+++ b/bin/migrate-and-seed-db.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+echo "creating s3 bucket"
+aws --endpoint-url="${AWS_ENDPOINT_URL:-"http://localhost:4566"}" s3 mb "s3://${AWS_IIIF_ASSET_BUCKET}"
+
 script_root="$(dirname $0)"
 $script_root/wait-for.sh db:5432
 
@@ -14,3 +17,4 @@ $script_root/wait-for.sh fedora:8080
 
 echo "seeding dev databases"
 bundle exec rails db:seed
+

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+Aws.config.update(endpoint: ENV['AWS_ENDPOINT_URL']) if ENV['AWS_ENDPOINT_URL'].present?
+Aws.config.update(force_path_style: true) unless Rails.env.production?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,6 @@ services:
       - "443:443"
     env_file:
       - .env.local
-    environment:
-      AWS_ACCESS_KEY_ID: localstack_access_key
-      AWS_SECRET_ACCESS_KEY: localstack_secret_access_key
     depends_on:
       - cantaloupe
       - db
@@ -31,17 +28,18 @@ services:
 
   cantaloupe:
     image: uclalibrary/cantaloupe:4.1.5
-    volumes:
-      - ./config/cantaloupe/delegates.rb:/delegates.rb
-      - rails_tmp:/spot
     ports:
       - "8182:8182"
     environment:
-      CANTALOUPE_DELEGATE_SCRIPT_ENABLED: "true"
-      CANTALOUPE_DELEGATE_SCRIPT_PATHNAME: /delegates.rb
-      CANTALOUPE_FILESYSTEMSOURCE_LOOKUP_STRATEGY: ScriptLookupStrategy
       CANTALOUPE_BASE_URI: 'http://localhost:8182'
-      DERIVATIVES_PATH: "/spot/derivatives"
+      CANTALOUPE_SOURCE_STATIC: S3Source
+      CANTALOUPE_S3SOURCE_ACCESS_KEY_ID: minio_root_user
+      CANTALOUPE_S3SOURCE_SECRET_KEY: minio_root_password
+      CANTALOUPE_S3SOURCE_BASICLOOKUPSTRATEGY_BUCKET_NAME: iiif-derivatives
+      CANTALOUPE_S3SOURCE_BASICLOOKUPSTRATEGY_PATH_SUFFIX: "-access.tif"
+      CANTALOUPE_S3SOURCE_ENDPOINT: "http://minio:9000"
+      CANTALOUPE_S3SOURCE_LOOKUP_STRATEGY: BasicLookupStrategy
+      CANTALOUPE_LOG_APPLICATION_LEVEL: trace
     restart: always
 
   db:
@@ -83,20 +81,17 @@ services:
     depends_on:
       - db
 
-  localstack:
-    image: localstack/localstack:latest
+  minio:
+    image: minio/minio:latest
     environment:
-      AWS_ACCESS_KEY_ID: localstack_access_key
-      AWS_SECRET_ACCESS_KEY: localstack_secret_access_key
-      AWS_DEFAULT_REGION: us-east-1
-      EDGE_PORT: 4566
-      SERVICES: s3
-      S3_DIR: /tmp/s3-buckets
+      MINIO_ROOT_USER: minio_root_user
+      MINIO_ROOT_PASSWORD: minio_root_password
+    command: server --console-address ":9001" /data
     volumes:
-      - localstack:/var/lib/localstack
-      - /var/run/docker.sock:/var/run/docker.sock
+      - minio:/data
     ports:
-      - '4566-4583:4566-4583'
+      - 9000:9000
+      - 9001:9001
 
   redis:
     image: redis:alpine
@@ -143,7 +138,7 @@ services:
 volumes:
   db:
   fedora:
-  localstack:
+  minio:
   solr:
   rails_tmp:
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
       - "443:443"
     env_file:
       - .env.local
+    environment:
+      AWS_ACCESS_KEY_ID: localstack_access_key
+      AWS_SECRET_ACCESS_KEY: localstack_secret_access_key
     depends_on:
       - cantaloupe
       - db
@@ -80,6 +83,21 @@ services:
     depends_on:
       - db
 
+  localstack:
+    image: localstack/localstack:latest
+    environment:
+      AWS_ACCESS_KEY_ID: localstack_access_key
+      AWS_SECRET_ACCESS_KEY: localstack_secret_access_key
+      AWS_DEFAULT_REGION: us-east-1
+      EDGE_PORT: 4566
+      SERVICES: s3
+      S3_DIR: /tmp/s3-buckets
+    volumes:
+      - localstack:/var/lib/localstack
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - '4566-4583:4566-4583'
+
   redis:
     image: redis:alpine
     volumes:
@@ -123,11 +141,9 @@ services:
 
 
 volumes:
-  derivatives:
   db:
   fedora:
-  gem_storage:
+  localstack:
   solr:
   rails_tmp:
   redis:
-  uploads:

--- a/spec/services/spot/derivatives/access_master_service_spec.rb
+++ b/spec/services/spot/derivatives/access_master_service_spec.rb
@@ -3,8 +3,12 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
   subject(:service) { described_class.new(file_set) }
 
   let(:file_set) { build(:file_set, id: 'abc123def') }
-  let(:derivative_path) { '/path/to/a/fs-access.tif' }
-  let(:src_path) { '/another/path/to/src/file.tif' }
+  let(:derivative_path) { '/rails/tmp/derivatives/ab/c1/23/de/f-access.tif' }
+  let(:src_path) { '/original/path/to/src/file.tif' }
+  let(:file_size) { 0 }
+  let(:file_digest) { '<MD5 hash>' }
+  let(:stringio) { StringIO.new('hi') }
+
   let(:magick_commands) do
     [].tap do |arr|
       arr.define_singleton_method(:merge!) do |args|
@@ -13,57 +17,62 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
     end
   end
 
+  let(:expected_magick_commands) do
+    ["#{src_path}[0]", '-define', 'tiff:tile-geometry=128x128', '-compress', 'jpeg', "ptif:#{derivative_path}"]
+  end
+
+  # rubocop:disable RSpec/InstanceVariable
   before do
+    @aws_access_key_id = ENV['AWS_ACCESS_KEY_ID']
+    @aws_secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
+    @aws_iiif_asset_bucket = ENV['AWS_IIIF_ASSET_BUCKET']
+    %w[AWS_ACCESS_KEY_ID AWS_SECRET_ACESS_KEY AWS_IIIF_ASSET_BUCKET].each { |k| ENV.delete(k) }
+
     allow(Hyrax::DerivativePath)
       .to receive(:derivative_path_for_reference)
       .with(file_set, 'access.tif')
       .and_return("#{derivative_path}.access.tif")
 
     allow(File).to receive(:exist?).with(derivative_path).and_return true
+    allow(File).to receive(:open).with(derivative_path, 'r')
+    allow(File).to receive(:size).with(derivative_path).and_return(file_size)
     allow(FileUtils).to receive(:rm_f).with(derivative_path)
 
     allow(MiniMagick::Tool::Convert).to receive(:new).and_yield(magick_commands)
-    allow(FileUtils).to receive(:mkdir_p).with(File.dirname(derivative_path))
+    allow(FileUtils).to receive(:rm_f).with(File.dirname(derivative_path))
+    allow(File).to receive(:open).with(derivative_path, "r").and_return(stringio)
+    allow(Digest::MD5).to receive(:file).with(derivative_path).and_return(file_digest)
   end
 
-  shared_examples 'it rimrafs the derivative_path provided' do
-    it do
-      cleanup_derivatives!
+  after do
+    ENV['AWS_ACCESS_KEY_ID'] = @aws_access_key_id unless @aws_access_key_id.blank?
+    ENV['AWS_SECRET_ACCESS_KEY'] = @aws_secret_access_key unless @aws_secret_access_key.blank?
+    ENV['AWS_IIIF_ASSET_BUCKET'] = @aws_iiif_asset_bucket unless @aws_iiif_asset_bucket.blank?
+  end
+  # rubocop:enable RSpec/InstanceVariable
+
+  describe '#cleanup_derivatives' do
+    it 'rimrafs the derivative_path provided' do
+      service.cleanup_derivatives
+
       expect(FileUtils).to have_received(:rm_f).with(derivative_path)
     end
   end
 
-  shared_examples 'it sends commands to MiniMagick' do
-    it do
-      create_derivatives!
-
-      expect(magick_commands)
-        .to eq([
-          "#{src_path}[0]",
-          '-define', 'tiff:tile-geometry=128x128',
-          '-compress', 'jpeg',
-          "ptif:#{derivative_path}"
-        ])
-    end
-  end
-
-  describe '#cleanup_derivatives' do
-    it_behaves_like 'it rimrafs the derivative_path provided'
-  end
-
   describe '#create_derivatives' do
-    it_behaves_like 'it sends commands to MiniMagick'
+    it 'sends `convert` commands to MiniMagick' do
+      service.create_derivatives(src_path)
+
+      expect(magick_commands).to eq(expected_magick_commands)
+    end
   end
 
   context 'when AWS environment variables are available' do
     let(:aws_access_key_id) { 'AWS-access_key-id' }
     let(:aws_secret_access_key) { 'AWS-secret-access_key' }
     let(:aws_iiif_asset_bucket) { 'iiif-assets' }
-    let(:mock_s3_client) { Aws::S3::Client.new(stub_responses: true) }
+    let(:mock_s3_client) { instance_double(Aws::S3::Client, delete_object: {}, put_object: {}) }
     let(:s3_key) { "#{file_set.id}-access.tif" }
-    let(:file_size) { 0 }
-    let(:file_digest) { '<MD5 hash>' }
-    let(:stringio) { StringIO.new('hi') }
 
     before do
       stub_env('AWS_ACCESS_KEY_ID', aws_access_key_id)
@@ -71,38 +80,23 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
       stub_env('AWS_IIIF_ASSET_BUCKET', aws_iiif_asset_bucket)
 
       allow(Aws::S3::Client).to receive(:new).and_return(mock_s3_client)
-      allow(File).to receive(:size).with(src_path).and_return(file_size)
-      allow(File).to receive(:open).with(src_path).and_return(stringio)
-      allow(Digest::MD5).to receive(:file).with(src_path).and_return(file_digest)
     end
 
     describe '#cleanup_derivatives' do
-      subject(:cleanup_derivatives!) { service.cleanup_derivatives }
-
-      before do
-        mock_s3_client.stub_data(:delete_object, {})
-      end
-
-      it_behaves_like 'it rimrafs the derivative_path provided'
+      subject { service.cleanup_derivatives }
 
       it 'deletes the object from S3' do
+        service.cleanup_derivatives
+
         expect(mock_s3_client)
-          .to have_received(:destroy_object)
+          .to have_received(:delete_object)
           .with(bucket: aws_iiif_asset_bucket, key: s3_key)
       end
     end
 
     describe '#create_derivatives' do
-      subject(:create_derivatives!) { service.create_derivatives(src_path) }
-
-      before do
-        mock_s3_client.stub_data(:put_object, {})
-      end
-
-      it_behaves_like 'it sends commands to MiniMagick'
-
       it 'puts the object into S3' do
-        create_derivatives!
+        service.create_derivatives(derivative_path)
 
         expect(mock_s3_client)
           .to have_received(:put_object)
@@ -111,8 +105,10 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
             key: s3_key,
             body: stringio,
             content_md5: file_digest,
-            content_length: file.length,
+            content_length: file_size
           )
+
+        expect(FileUtils).to have_received(:rm_f).with(derivative_path)
       end
     end
   end

--- a/spec/services/spot/derivatives/access_master_service_spec.rb
+++ b/spec/services/spot/derivatives/access_master_service_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
     allow(File).to receive(:exist?).with(derivative_path).and_return true
     allow(File).to receive(:open).with(derivative_path, 'r')
     allow(File).to receive(:size).with(derivative_path).and_return(file_size)
+    allow(File).to receive(:directory?).with(File.dirname(derivative_path)).and_return(true)
     allow(FileUtils).to receive(:rm_f).with(derivative_path)
 
     allow(MiniMagick::Tool::Convert).to receive(:new).and_yield(magick_commands)

--- a/spec/services/spot/derivatives/access_master_service_spec.rb
+++ b/spec/services/spot/derivatives/access_master_service_spec.rb
@@ -2,56 +2,118 @@
 RSpec.describe Spot::Derivatives::AccessMasterService do
   subject(:service) { described_class.new(file_set) }
 
-  let(:file_set) { FileSet.new }
+  let(:file_set) { build(:file_set, id: 'abc123def') }
   let(:derivative_path) { '/path/to/a/fs-access.tif' }
+  let(:src_path) { '/another/path/to/src/file.tif' }
+  let(:magick_commands) do
+    [].tap do |arr|
+      arr.define_singleton_method(:merge!) do |args|
+        args.each { |arg| self << arg }
+      end
+    end
+  end
 
   before do
     allow(Hyrax::DerivativePath)
       .to receive(:derivative_path_for_reference)
       .with(file_set, 'access.tif')
       .and_return("#{derivative_path}.access.tif")
+
+    allow(File).to receive(:exist?).with(derivative_path).and_return true
+    allow(FileUtils).to receive(:rm_f).with(derivative_path)
+
+    allow(MiniMagick::Tool::Convert).to receive(:new).and_yield(magick_commands)
+    allow(FileUtils).to receive(:mkdir_p).with(File.dirname(derivative_path))
   end
 
-  describe '#cleanup_derivatives' do
-    before do
-      allow(File).to receive(:exist?).with(derivative_path).and_return true
-      allow(FileUtils).to receive(:rm_f).with(derivative_path)
-    end
-
-    it 'rimrafs all of the paths provided' do
-      service.cleanup_derivatives
-
+  shared_examples 'it rimrafs the derivative_path provided' do
+    it do
+      cleanup_derivatives!
       expect(FileUtils).to have_received(:rm_f).with(derivative_path)
     end
   end
 
+  shared_examples 'it sends commands to MiniMagick' do
+    it do
+      create_derivatives!
+
+      expect(magick_commands)
+        .to eq([
+          "#{src_path}[0]",
+          '-define', 'tiff:tile-geometry=128x128',
+          '-compress', 'jpeg',
+          "ptif:#{derivative_path}"
+        ])
+    end
+  end
+
+  describe '#cleanup_derivatives' do
+    it_behaves_like 'it rimrafs the derivative_path provided'
+  end
+
   describe '#create_derivatives' do
+    it_behaves_like 'it sends commands to MiniMagick'
+  end
+
+  context 'when AWS environment variables are available' do
+    let(:aws_access_key_id) { 'AWS-access_key-id' }
+    let(:aws_secret_access_key) { 'AWS-secret-access_key' }
+    let(:aws_iiif_asset_bucket) { 'iiif-assets' }
+    let(:mock_s3_client) { Aws::S3::Client.new(stub_responses: true) }
+    let(:s3_key) { "#{file_set.id}-access.tif" }
+    let(:file_size) { 0 }
+    let(:file_digest) { '<MD5 hash>' }
+    let(:stringio) { StringIO.new('hi') }
+
     before do
-      allow(MiniMagick::Tool::Convert).to receive(:new).and_yield(magick_commands)
-      allow(FileUtils).to receive(:mkdir_p).with('/path/to/a')
+      stub_env('AWS_ACCESS_KEY_ID', aws_access_key_id)
+      stub_env('AWS_SECRET_ACCESS_KEY', aws_secret_access_key)
+      stub_env('AWS_IIIF_ASSET_BUCKET', aws_iiif_asset_bucket)
+
+      allow(Aws::S3::Client).to receive(:new).and_return(mock_s3_client)
+      allow(File).to receive(:size).with(src_path).and_return(file_size)
+      allow(File).to receive(:open).with(src_path).and_return(stringio)
+      allow(Digest::MD5).to receive(:file).with(src_path).and_return(file_digest)
     end
 
-    let(:magick_commands) do
-      [].tap do |arr|
-        arr.define_singleton_method(:merge!) do |args|
-          args.each { |arg| self << arg }
-        end
+    describe '#cleanup_derivatives' do
+      subject(:cleanup_derivatives!) { service.cleanup_derivatives }
+
+      before do
+        mock_s3_client.stub_data(:delete_object, {})
+      end
+
+      it_behaves_like 'it rimrafs the derivative_path provided'
+
+      it 'deletes the object from S3' do
+        expect(mock_s3_client)
+          .to have_received(:destroy_object)
+          .with(bucket: aws_iiif_asset_bucket, key: s3_key)
       end
     end
 
-    let(:expected_commands) do
-      [
-        '/path/to/file.jpg[0]',
-        '-define', 'tiff:tile-geometry=128x128',
-        '-compress', 'jpeg',
-        'ptif:/path/to/a/fs-access.tif'
-      ]
-    end
+    describe '#create_derivatives' do
+      subject(:create_derivatives!) { service.create_derivatives(src_path) }
 
-    it 'sends imagemagick commands to MiniMagick' do
-      service.create_derivatives('/path/to/file.jpg')
+      before do
+        mock_s3_client.stub_data(:put_object, {})
+      end
 
-      expect(magick_commands).to eq(expected_commands)
+      it_behaves_like 'it sends commands to MiniMagick'
+
+      it 'puts the object into S3' do
+        create_derivatives!
+
+        expect(mock_s3_client)
+          .to have_received(:put_object)
+          .with(
+            bucket: aws_iiif_asset_bucket,
+            key: s3_key,
+            body: stringio,
+            content_md5: file_digest,
+            content_length: file.length,
+          )
+      end
     end
   end
 end

--- a/spec/services/spot/derivatives/access_master_service_spec.rb
+++ b/spec/services/spot/derivatives/access_master_service_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
   let(:derivative_path) { '/rails/tmp/derivatives/ab/c1/23/de/f-access.tif' }
   let(:src_path) { '/original/path/to/src/file.tif' }
   let(:file_size) { 0 }
-  let(:file_digest) { '<MD5 hash>' }
+  let(:file_digest) { 'base64digest' }
   let(:stringio) { StringIO.new('hi') }
+  let(:mock_digest) { instance_double(Digest::MD5, base64digest: file_digest) }
 
   let(:magick_commands) do
     [].tap do |arr|
@@ -42,7 +43,7 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
     allow(MiniMagick::Tool::Convert).to receive(:new).and_yield(magick_commands)
     allow(FileUtils).to receive(:rm_f).with(File.dirname(derivative_path))
     allow(File).to receive(:open).with(derivative_path, "r").and_return(stringio)
-    allow(Digest::MD5).to receive(:file).with(derivative_path).and_return(file_digest)
+    allow(Digest::MD5).to receive(:file).with(derivative_path).and_return(mock_digest)
   end
 
   after do


### PR DESCRIPTION
since we'll be using [serverless-iiif] for our image viewer on aws, we need to store our pyramid tiffs in an s3 bucket, instead of on disk. 

[serverless-iiif]: https://github.com/samvera/serverless-iiif