### PR TITLE
treat empty REDIS_PASSWORD values as no password

### DIFF
--- a/config/initializers/redis_config.rb
+++ b/config/initializers/redis_config.rb
@@ -2,7 +2,7 @@
 require 'redis'
 
 config = Rails.application.config_for(:redis).with_indifferent_access
-config[:password] = ENV['REDIS_PASSWORD'] unless ENV['REDIS_PASSWORD'].nil?
+config[:password] = ENV['REDIS_PASSWORD'] unless ENV['REDIS_PASSWORD'].blank?
 
 if config[:url].present?
   config.delete(:host)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,10 +5,10 @@ Sidekiq.configure_server do |config|
   ActiveJob::Base.logger = Sidekiq::Logging.logger
 
   # tell Sidekiq about our redis customizations
-  if ENV['REDIS_URL'] || ENV['REDIS_PASSWORD']
+  if ENV['REDIS_URL'].present? || ENV['REDIS_PASSWORD'].present?
     config.redis = {}.tap do |redis|
-      redis[:url] = ENV['REDIS_URL'] if ENV['REDIS_URL']
-      redis[:password] = ENV['REDIS_PASSWORD'] if ENV['REDIS_PASSWORD']
+      redis[:url] = ENV['REDIS_URL'] if ENV['REDIS_URL'].present?
+      redis[:password] = ENV['REDIS_PASSWORD'] if ENV['REDIS_PASSWORD'].present?
     end
   end
 
@@ -19,10 +19,10 @@ end
 
 Sidekiq.configure_client do |config|
   # tell Sidekiq about our redis customizations
-  if ENV['REDIS_URL'] || ENV['REDIS_PASSWORD']
+  if ENV['REDIS_URL'].present? || ENV['REDIS_PASSWORD'].present?
     config.redis = {}.tap do |redis|
-      redis[:url] = ENV['REDIS_URL'] if ENV['REDIS_URL']
-      redis[:password] = ENV['REDIS_PASSWORD'] if ENV['REDIS_PASSWORD']
+      redis[:url] = ENV['REDIS_URL'] if ENV['REDIS_URL'].present?
+      redis[:password] = ENV['REDIS_PASSWORD'] if ENV['REDIS_PASSWORD'].present?
     end
   end
 end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -6,5 +6,4 @@ test:
   host: localhost
   port: 6379
 production:
-  password: <%= ENV['REDIS_PASSWORD'] %>
   url: <%= ENV['REDIS_URL'] %>


### PR DESCRIPTION
backport from #947 branch (0cc957a9) that allows REDIS_PASSWORD="" to behave the same as not providing a REDIS_PASSWORD environment variable at all