### PR TITLE
update Hyrax::HasOneTitleValidator to accept RDF::Literals

### DIFF
--- a/app/validators/hyrax/has_one_title_validator.rb
+++ b/app/validators/hyrax/has_one_title_validator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module Hyrax
+  # Locally modified version of Hyrax code to allow RDF literal values to be passed as titles.
+  # (Previously was failing because Literals do not have an :empty? method). All this is doing
+  # is stringifying the values in `record.title` before checking their validity.
+  #
+  # validates that the title has at least one title
+  class HasOneTitleValidator < ActiveModel::Validator
+    def validate(record)
+      return unless record.title.map(&:to_s).reject(&:empty?).empty?
+      record.errors[:title] << "You must provide a title"
+    end
+  end
+end

--- a/spec/validators/hyrax/has_one_title_validator_spec.rb
+++ b/spec/validators/hyrax/has_one_title_validator_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe Hyrax::HasOneTitleValidator do
+  let(:validator) { described_class.new }
+
+  context 'when an object has a title' do
+    let(:object) { Collection.new }
+
+    before do
+      object.title = ['Cool Collection']
+    end
+
+    it 'validates' do
+      validator.validate(object)
+
+      expect(object.errors[:title]).to be_empty
+    end
+  end
+
+  context 'when an object has a language-tagged title' do
+    let(:object) { Collection.new }
+
+    before do
+      object.title = [RDF::Literal.new('Cool Collection', language: :en)]
+    end
+
+    it 'validates' do
+      validator.validate(object)
+
+      expect(object.errors[:title]).to be_empty
+    end
+  end
+
+  context 'when an object has no title' do
+    let(:object) { Collection.new }
+
+    it 'adds an error to the object' do
+      validator.validate(object)
+
+      expect(object.errors[:title].size).to eq 1
+      expect(object.errors[:title].first.to_s). to eq 'You must provide a title'
+    end
+  end
+end

--- a/spec/validators/hyrax/has_one_title_validator_spec.rb
+++ b/spec/validators/hyrax/has_one_title_validator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.describe Hyrax::HasOneTitleValidator do
   let(:validator) { described_class.new }
 


### PR DESCRIPTION
previously, language tagging a title would throw an error (RDF::Literals don't respond to `.blank?`)