### PR TITLE
twelve items on the browse collections page

### DIFF
--- a/app/controllers/spot/collections_controller.rb
+++ b/app/controllers/spot/collections_controller.rb
@@ -16,7 +16,7 @@ module Spot
     end
 
     def index_search_builder
-      Spot::ParentCollectionsSearchBuilder.new(self).with(page: params[:page], rows: params[:per_page])
+      Spot::ParentCollectionsSearchBuilder.new(self).with(page: params[:page], rows: 12)
     end
   end
 end


### PR DESCRIPTION
Hard coded 12 as the number of items per page on the browse collections page.