### PR TITLE
description added

### DIFF
--- a/app/views/spot/page/about.html.erb
+++ b/app/views/spot/page/about.html.erb
@@ -2,7 +2,7 @@
   <h1><%= t('.header', name: application_name) %></h1>
 </div>
 
-<%= image_tag('about-splash.jpg', class: 'splash-image img-responsive', alt: '') %>
+<%= image_tag('about-splash.jpg', class: 'splash-image img-responsive', alt: 'A black and white image of several people using a library card catalog.') %>
 
 <p>
   The Lafayette Digital Repository (LDR) is both an institutional repository and


### PR DESCRIPTION
Added an alt test description to the about page's splash image. Description is: "A black and white image of several people using a library card catalog."