### PR TITLE
fulltext for ocm field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -168,7 +168,7 @@ class CatalogController < ApplicationController
         source_tesim abstract_tesim description_tesim note_tesim
         subject_label_tesim identifier_ssim bibliographic_citation_tesim
         english_language_date_teim file_format_tesim
-        extracted_text_tsimv keyword_tesim date_associated_tesim
+        extracted_text_tsimv keyword_tesim date_associated_tesim subject_ocm_tesim
       ]
 
       field.solr_parameters = {

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -50,7 +50,7 @@ class Image < ActiveFedora::Base
 
   # @note The URI provided is the landing page for the OCM, as a predicate doesn't exist
   property :subject_ocm, predicate: ::RDF::URI('https://hraf.yale.edu/resources/reference/outline-of-cultural-materials') do |index|
-    index.as :symbol
+    index.as :symbol, :stored_searchable
   end
 
   # see {Spot::WorkBehavior.setup_nested_attributes!}

--- a/spec/indexers/image_indexer_spec.rb
+++ b/spec/indexers/image_indexer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ImageIndexer do
     creator: %w[tesim sim],
     contributor: %w[tesim sim],
     related_resource: %w[tesim sim],
-    subject_ocm: %w[ssim],
+    subject_ocm: %w[ssim tesim],
     date_associated: %w[ssim tesim]
   }.each_pair do |method, suffixes|
     let(:work_method) { method }


### PR DESCRIPTION
Added :stored_searchable to subject_ocm property definition. Added subject_ocm_tesim to all_feilds search to allow the OCM feild to be full text searchable.