### PR TITLE
added label

### DIFF
--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <nav id="masthead" class="navbar navbar-inverse navbar-static-top" role="navigation">
+  <nav id="masthead" class="navbar navbar-inverse navbar-static-top" role="navigation" aria-label="masthead">
     <div class="container-fluid">
       <!-- Brand and toggle get grouped for better mobile display -->
       <div class="navbar-header">


### PR DESCRIPTION
added  aria-label="masthead" to the masthead.

Masthead no longer throwing Deque aXe tools errors