### PR TITLE
add file_set width/height to s3 metadata

### DIFF
--- a/app/services/spot/derivatives/access_master_service.rb
+++ b/app/services/spot/derivatives/access_master_service.rb
@@ -91,13 +91,18 @@ module Spot
         "#{file_set.id}-access.tif"
       end
 
+      #
       def upload_derivative_to_s3
         s3_client.put_object(
           bucket: s3_bucket,
           key: s3_derivative_key,
           body: File.open(derivative_path, 'r'),
           content_length: File.size(derivative_path),
-          content_md5: Digest::MD5.file(derivative_path).base64digest
+          content_md5: Digest::MD5.file(derivative_path).base64digest,
+          metadata: {
+            'height': file_set.height.first,
+            'width': file_set.width.first,
+          }
         )
       end
 

--- a/app/services/spot/derivatives/access_master_service.rb
+++ b/app/services/spot/derivatives/access_master_service.rb
@@ -100,8 +100,8 @@ module Spot
           content_length: File.size(derivative_path),
           content_md5: Digest::MD5.file(derivative_path).base64digest,
           metadata: {
-            'height': file_set.height.first,
-            'width': file_set.width.first,
+            'height' => file_set.height.first,
+            'width' => file_set.width.first
           }
         )
       end

--- a/spec/services/spot/derivatives/access_master_service_spec.rb
+++ b/spec/services/spot/derivatives/access_master_service_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe Spot::Derivatives::AccessMasterService do
   subject(:service) { described_class.new(file_set) }
 
-  let(:file_set) { build(:file_set, id: 'abc123def') }
+  let(:file_set) { build(:file_set, id: 'abc123def', height: ['100'], height: ['100']) }
   let(:derivative_path) { '/rails/tmp/derivatives/ab/c1/23/de/f-access.tif' }
   let(:src_path) { '/original/path/to/src/file.tif' }
   let(:file_size) { 0 }
@@ -97,6 +97,9 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
     end
 
     describe '#create_derivatives' do
+      let(:fs_width) { file_set.width.first }
+      let(:fs_height) { file_set.height.first }
+
       it 'puts the object into S3' do
         service.create_derivatives(derivative_path)
 
@@ -107,7 +110,11 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
             key: s3_key,
             body: stringio,
             content_md5: file_digest,
-            content_length: file_size
+            content_length: file_size,
+            metadata: {
+              width: fs_width,
+              height: fs_height,
+            }
           )
 
         expect(FileUtils).to have_received(:rm_f).with(derivative_path)

--- a/spec/services/spot/derivatives/access_master_service_spec.rb
+++ b/spec/services/spot/derivatives/access_master_service_spec.rb
@@ -115,8 +115,8 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
             content_md5: file_digest,
             content_length: file_size,
             metadata: {
-              width: fs_width,
-              height: fs_height
+              'width' => fs_width,
+              'height' => fs_height
             }
           )
 

--- a/spec/services/spot/derivatives/access_master_service_spec.rb
+++ b/spec/services/spot/derivatives/access_master_service_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe Spot::Derivatives::AccessMasterService do
   subject(:service) { described_class.new(file_set) }
 
-  let(:file_set) { build(:file_set, id: 'abc123def', height: ['100'], height: ['100']) }
+  let(:file_set) { build(:file_set, id: 'abc123def', height: ['100'], width: ['100']) }
   let(:derivative_path) { '/rails/tmp/derivatives/ab/c1/23/de/f-access.tif' }
   let(:src_path) { '/original/path/to/src/file.tif' }
   let(:file_size) { 0 }
@@ -113,7 +113,7 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
             content_length: file_size,
             metadata: {
               width: fs_width,
-              height: fs_height,
+              height: fs_height
             }
           )
 

--- a/spec/services/spot/derivatives/access_master_service_spec.rb
+++ b/spec/services/spot/derivatives/access_master_service_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe Spot::Derivatives::AccessMasterService do
   subject(:service) { described_class.new(file_set) }
 
-  let(:file_set) { build(:file_set, id: 'abc123def', height: ['100'], width: ['100']) }
+  let(:file_set) { build(:file_set, id: 'abc123def') }
   let(:derivative_path) { '/rails/tmp/derivatives/ab/c1/23/de/f-access.tif' }
   let(:src_path) { '/original/path/to/src/file.tif' }
   let(:file_size) { 0 }
@@ -44,6 +44,9 @@ RSpec.describe Spot::Derivatives::AccessMasterService do
     allow(FileUtils).to receive(:rm_f).with(File.dirname(derivative_path))
     allow(File).to receive(:open).with(derivative_path, "r").and_return(stringio)
     allow(Digest::MD5).to receive(:file).with(derivative_path).and_return(mock_digest)
+
+    allow(file_set).to receive(:width).and_return(['150'])
+    allow(file_set).to receive(:height).and_return(['150'])
   end
 
   after do


### PR DESCRIPTION
serverless-iiif uses this these values to generate the file_set's info.json values. see: https://github.com/samvera/serverless-iiif/blob/v4.2.0/src/resolvers.js#L31-L42