### PR TITLE
[fcrepo] add JAVA_OPTIONS from on-campus deploy

### DIFF
--- a/docker/fcrepo/scripts/ldr-fedora-entrypoint.sh
+++ b/docker/fcrepo/scripts/ldr-fedora-entrypoint.sh
@@ -21,4 +21,17 @@ export JAVA_OPTIONS="${JAVA_OPTIONS} \
   -Dfcrepo.postgresql.host=${db_host} \
   -Dfcrepo.postgresql.port=${db_port}"
 
+# JAVA_OPTIONS from our on-campus deploy, as recommended by FCRepo wiki
+export JAVA_OPTIONS="${JAVA_OPTIONS} \
+  -server \
+  -Dfile.encoding=UTF-8 \
+  -Xms${FCREPO_MIN_MEMORY:-512m} \
+  -Xmx${FCREPO_MAX_MEMORY:-2048m} \
+  -XX:NewSize=256m \
+  -XX:MaxNewSize=256m \
+  -XX:MetaspaceSize=64m \
+  -XX:MaxMetaspaceSize=256m \
+  -XX:+UseG1GC \
+  -XX:+DisableExplicitGC"
+
 exec /fedora-entrypoint.sh "$@"


### PR DESCRIPTION
enables min/max allotted memory to be configured via `FCREPO_MIN_MEMORY` and `FCREPO_MAX_MEMORY` environment variables. the rest of the config is copied as-is