### PR TITLE
fall back to emails for advisor_label values

### DIFF
--- a/app/indexers/student_work_indexer.rb
+++ b/app/indexers/student_work_indexer.rb
@@ -15,7 +15,5 @@ class StudentWorkIndexer < BaseIndexer
     return email unless email.end_with?('@lafayette.edu')
 
     Spot::LafayetteInstructorsAuthorityService.label_for(email: email)
-  rescue ::KeyError, ::Spot::LafayetteInstructorsAuthorityService::UserNotFoundError
-    email
   end
 end

--- a/app/indexers/student_work_indexer.rb
+++ b/app/indexers/student_work_indexer.rb
@@ -15,5 +15,7 @@ class StudentWorkIndexer < BaseIndexer
     return email unless email.end_with?('@lafayette.edu')
 
     Spot::LafayetteInstructorsAuthorityService.label_for(email: email)
+  rescue ::KeyError, ::Spot::LafayetteInstructorsAuthorityService::UserNotFoundError
+    email
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,7 +68,7 @@ class User < ApplicationRecord
   #
   # @return [String]
   def authority_name
-    [surname, given_name].compact.join(', ')
+    [surname, given_name].reject(&:blank?).join(', ')
   end
 
   # Name rendered in a "Given-Name Surname" style

--- a/app/services/spot/lafayette_instructors_authority_service.rb
+++ b/app/services/spot/lafayette_instructors_authority_service.rb
@@ -9,7 +9,6 @@ module Spot
   #   Spot::LafayetteInstructorsAuthorityService.load(term: '202130', api_key: ENV.fetch('LAFAYETTE_WDS_API_KEY'))
   #   # => [#<Qa::LocalAuthorityEntry id: 1, local_authority_id: 1...>...]
   class LafayetteInstructorsAuthorityService
-    API_ENV_KEY =
     SUBAUTHORITY_NAME = 'lafayette_instructors'
 
     class UserNotFoundError < StandardError; end

--- a/spec/indexers/student_work_indexer_spec.rb
+++ b/spec/indexers/student_work_indexer_spec.rb
@@ -4,4 +4,30 @@ RSpec.describe StudentWorkIndexer do
 
   it_behaves_like 'a Spot indexer'
   it_behaves_like 'it indexes a sortable date'
+
+  describe 'advisor_label' do
+    subject { solr_doc['advisor_label_ssim'] }
+
+    let(:attributes) { { advisor: [advisor_email] } }
+    let(:advisor_email) { 'malantoa@lafayette.edu' }
+
+    context 'when WDS key is not present' do
+      it { is_expected.to eq [advisor_email] }
+    end
+
+    context 'when WDS key is present' do
+      let(:wds_service) { instance_double('Spot::LafayetteWdsService') }
+      let(:person_payload) do
+        { 'FIRST_NAME' => 'Anna', 'LAST_NAME' => 'Malantonio', 'EMAIL' => 'MALANTOA@LAFAYETTE.EDU' }
+      end
+
+      before do
+        stub_env('LAFAYETTE_WDS_API_KEY', 'secret key')
+        allow(Spot::LafayetteWdsService).to receive(:new).and_return(wds_service)
+        allow(wds_service).to receive(:person).with(email: advisor_email).and_return(person_payload)
+      end
+
+      it { is_expected.to eq ["#{person_payload['LAST_NAME']}, #{person_payload['FIRST_NAME']}"] }
+    end
+  end
 end

--- a/spec/services/spot/lafayette_instructors_authority_service_spec.rb
+++ b/spec/services/spot/lafayette_instructors_authority_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe Spot::LafayetteInstructorsAuthorityService do
   before do
-    stub_env(described_class::API_ENV_KEY, api_key)
+    stub_env('LAFAYETTE_WDS_API_KEY', api_key)
 
     allow(Spot::LafayetteWdsService).to receive(:new).with(api_key: nil).and_return(wds_service)
     allow(Spot::LafayetteWdsService).to receive(:new).with(api_key: api_key).and_return(wds_service)

--- a/spec/services/spot/lafayette_instructors_authority_service_spec.rb
+++ b/spec/services/spot/lafayette_instructors_authority_service_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Spot::LafayetteInstructorsAuthorityService do
   before do
     stub_env(described_class::API_ENV_KEY, api_key)
 
+    allow(Spot::LafayetteWdsService).to receive(:new).with(api_key: nil).and_return(wds_service)
     allow(Spot::LafayetteWdsService).to receive(:new).with(api_key: api_key).and_return(wds_service)
   end
 
@@ -81,9 +82,8 @@ RSpec.describe Spot::LafayetteInstructorsAuthorityService do
     context 'when an email does not match' do
       let(:wds_response) { false }
 
-      it 'raises an UserNotFoundError' do
-        expect { described_class.label_for(email: email) }
-          .to raise_error(described_class::UserNotFoundError, "No user found with email address: #{email}")
+      it 'creates a label with just the email address' do
+        expect(described_class.label_for(email: email)).to eq(email)
       end
     end
   end


### PR DESCRIPTION
in the event that an email isn't found in the WDS user database, or the WDS service isn't reachable, fall back to using the email as advisor_label value