### PR TITLE
[solr] add solr.in.sh config (+ disable large pages)

### DIFF
--- a/docker/solr/Dockerfile
+++ b/docker/solr/Dockerfile
@@ -3,6 +3,7 @@ FROM solr:8.11.2
 ENV SOLR_CORES=spot
 ENV SOLR_CORE_CONF_DIR=/spot-config
 ENV SOLR_HOST=localhost
+ENV SOLR_INCLUDE=/usr/local/share/solr/solr.in.sh
 
 # store config in a conf/ subdirectory so solr uses it consistently
 # (core was being created + configured to use memory store)
@@ -11,5 +12,8 @@ COPY --chown=solr:root config $SOLR_CORE_CONF_DIR/conf
 
 # custom scripts to be run on solr inits
 COPY --chown=solr:root scripts/*.sh /docker-entrypoint-initdb.d/
+
+# custom env settings
+COPY --chown=solr:root assets/solr.in.sh $SOLR_INCLUDE
 
 HEALTHCHECK CMD curl http://localhost:8983/solr/ || exit 1

--- a/docker/solr/assets/solr.in.sh
+++ b/docker/solr/assets/solr.in.sh
@@ -1,0 +1,2 @@
+# Disable LargePages to help prevent out of memory errors
+SOLR_OPTS="$SOLR_OPTS -XX:-UseLargePages"


### PR DESCRIPTION
adds support for fine-tuning solr/jvm environment variables and resolves `OpenJDK 64-Bit Server VM warning: Failed to reserve shared memory.` warnings