### PR TITLE
bugfix: install uv in dev entrypoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,5 +26,9 @@
 
 # don't copy over generated files
 public/assets
+!public/assets/.keep
+
 public/branding
+!public/branding/.keep
+
 public/uv

--- a/.dockerignore
+++ b/.dockerignore
@@ -26,9 +26,5 @@
 
 # don't copy over generated files
 public/assets
-!public/assets/.keep
-
 public/branding
-!public/branding/.keep
-
 public/uv

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,13 +77,10 @@ RUN apk --no-cache --update add musl-dev gcc python3 python3-dev \
     && apk del python3-dev gcc musl-dev
 
 RUN bundle install --jobs "$(nproc)" --with="development test"
+COPY . /spot/
 
-COPY config/uv /spot/config/uv
-COPY ["package.json", "yarn.lock", "/spot/"]
-
-COPY . /spot
-WORKDIR /spot
-RUN yarn install
+ENTRYPOINT ["/spot/bin/spot-dev-entrypoint.sh"]
+CMD ["bundle", "exec", "rails", "server", "-b", "ssl://0.0.0.0:443?key=/spot/tmp/ssl/application.key&cert=/spot/tmp/ssl/application.crt"]
 
 
 ##

--- a/bin/spot-dev-entrypoint.sh
+++ b/bin/spot-dev-entrypoint.sh
@@ -4,11 +4,18 @@ set -e
 app_root="/spot"
 uv_root="$app_root/public/uv"
 
+if [[ -d "$uv_root" && -f "$uv_root/uv.js" && -f "$uv_root/uv.html" ]];
+then
+  echo "not installing UniversalViewer as it already exists"
+else
+  echo "installing UniversalViewer via Yarn"
+  cd "$app_root" && yarn install
+fi
+
 # copy the dev UV configuration _after_ running yarn install.
 # previously, i was adding this file with a volume link in the
 # docker-compose#app config, but it was causing the `yarn install`
 # command to fail because the file was unable to be deleted.
-mkdir -p "$uv_root"
 cp "$app_root/config/uv/uv-config-development.json" "$uv_root/uv-config.json"
 
 exec "$app_root/bin/spot-entrypoint.sh" "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.7'
 services:
   app:
-    image: lafayette/rails_web
+    image: lafayette/spot-web
     build:
       context: .
       target: spot-development
@@ -23,8 +23,6 @@ services:
       - db_migrate
     stdin_open: true
     tty: true
-    entrypoint: ["/spot/bin/spot-dev-entrypoint.sh"]
-    command: ["bundle", "exec", "rails", "server", "-b", "ssl://0.0.0.0:443?key=/spot/tmp/ssl/application.key&cert=/spot/tmp/ssl/application.crt"]
 
   cantaloupe:
     image: uclalibrary/cantaloupe:4.1.5
@@ -56,7 +54,7 @@ services:
     restart: always
 
   db_migrate:
-    image: lafayette/rails_web
+    image: lafayette/spot-web
     env_file:
       - .env.local
     entrypoint: ["sh", "-c"]
@@ -102,7 +100,7 @@ services:
       - 6379:6379
 
   sidekiq:
-    image: lafayette/rails_worker:dev
+    image: lafayette/spot-worker
     build:
       context: .
       target: spot-worker


### PR DESCRIPTION
prevents development bind-mounts (via docker-compose.yml) from layering over the generated UniversalViewer files, which effectively disappears them.

(lint is failing from bulkrax-browse base branch + the tests don't really apply, so merge away if this works)