### PR TITLE
[browse-everything] use ambient service credentials for s3

### DIFF
--- a/config/browse_everything_providers.yml
+++ b/config/browse_everything_providers.yml
@@ -1,7 +1,5 @@
 ---
 s3:
   bucket: <%= ENV.fetch('AWS_BULKRAX_IMPORTS_BUCKET') %>
-  app_key: <%= ENV.fetch('AWS_ACCESS_KEY_ID') %>
-  app_secret: <%= ENV.fetch('AWS_SECRET_ACCESS_KEY') %>
-  region: <%= ENV.fetch('AWS_REGION') %>
+  region: <%= ENV.fetch('AWS_REGION') { 'us-east-1' } %>
   response_type: s3_uri


### PR DESCRIPTION
since we'll be serving this on AWS, calls to `Aws::S3::Client.new` should be able to pick up credentials without them being explicitly provided (see also: https://github.com/LafayetteCollegeLibraries/spot/blob/primary/app/services/spot/derivatives/access_master_service.rb)