### PR TITLE
add dummy admin role for production

### DIFF
--- a/config/role_map.yml
+++ b/config/role_map.yml
@@ -20,4 +20,5 @@ test:
     - leland_himself@example.com
 
 production:
-  # Add roles for users here.
+  admin:
+    - admin@example.org


### PR DESCRIPTION
we don't use `config/role_map.yml`, but [`HyraxHelper#available_user_groups`](https://github.com/samvera/hyrax/blob/hyrax-v3.6.0/app/helpers/hyrax/hyrax_helper_behavior.rb#L26) checks the file and needs something there, I guess? new work pages weren't loading in a production environment and this seems to solve that problem.