### PR TITLE
add Spot::ControlledVocabularies::Base#full_label method to match hyrax api

### DIFF
--- a/app/models/spot/controlled_vocabularies/base.rb
+++ b/app/models/spot/controlled_vocabularies/base.rb
@@ -58,6 +58,16 @@ module Spot
         RdfLabel.where(uri: rdf_subject.to_s).first_or_create(&block)
       end
 
+      # Temporarily patching - I'd like to revisit this and Spot::ControlledVocabularies::Location
+      # and see if we can strip out some of these customizations.
+      #
+      # @return [String]
+      # @see https://github.com/samvera/hyrax/blob/hyrax-v3.6.0/lib/hyrax/controlled_vocabularies/location.rb#L16-L18
+      # @see https://github.com/samvera/hyrax/blob/hyrax-v3.6.0/app/inputs/controlled_vocabulary_input.rb#L70
+      def full_label
+        rdf_label.first
+      end
+
       # Does this value have a label or is it just an URI?
       #
       # @return [TrueClass,FalseClass]

--- a/spec/models/spot/controlled_vocabularies/base_spec.rb
+++ b/spec/models/spot/controlled_vocabularies/base_spec.rb
@@ -55,6 +55,13 @@ RSpec.describe Spot::ControlledVocabularies::Base do
     end
   end
 
+  describe '#full_label' do
+    it 'uses the first value of :rdf_label' do
+      expect(resource.full_label).to eq labels.first
+      expect(resource).to have_received(:rdf_label).exactly(1).times
+    end
+  end
+
   describe '#preferred_label' do
     subject(:pref_label) { resource.preferred_label }
 


### PR DESCRIPTION
hyrax v3 adds a `#full_label` method to its controlled vocabulary model and calls it in the edit form input. this adds the method as an alias for `#rdf_label`.

see: https://github.com/samvera/hyrax/blob/hyrax-v3.6.0/lib/hyrax/controlled_vocabularies/location.rb#L16-L18, https://github.com/samvera/hyrax/blob/hyrax-v3.6.0/app/inputs/controlled_vocabulary_input.rb#L70