### PR TITLE
transform controlled_properties fields into nested_attributes

### DIFF
--- a/app/actors/spot/actors/base_actor.rb
+++ b/app/actors/spot/actors/base_actor.rb
@@ -62,9 +62,9 @@ module Spot
       # @return [void]
       def transform_controlled_properties(env)
         env.curation_concern.class.controlled_properties.map(&:to_s).each do |property|
-          next if env.attributes[property].blank?
-
           values = env.attributes.delete(property)
+          next if values.blank?
+
           env.attributes[:"#{property}_attributes"] = Array.wrap(values).map { |value| { id: value } }
         end
       end

--- a/app/actors/spot/actors/base_actor.rb
+++ b/app/actors/spot/actors/base_actor.rb
@@ -24,16 +24,17 @@ module Spot
         env.curation_concern.date_uploaded = get_date_uploaded_value(env)
       end
 
-      # if we've been passed attributes with a :rights_statement value, convert it
-      # to an RDF::URI object for storage
+      # Allows for modifying env.attributes properties before the work is saved.
       #
       # @param [Hyrax::Actors::Environment] env
       # @return [void]
       def apply_save_data_to_curation_concern(env)
         transform_rights_statement(env) if env.attributes.key?(:rights_statement)
+        transform_controlled_properties(env) if env.curation_concern.class.respond_to?(:controlled_properties)
 
         super
       end
+
 
       # @param [Hyrax::Actors::Environment] env
       # @return [DateTime]
@@ -55,6 +56,23 @@ module Spot
         end
       end
 
+      # We may need to convert controlled_properties form their string value
+      # to their nested_attribute values (this came up with Bulkrax)
+      #
+      # @param [Hyrax::Actors::Environment] env
+      # @return [void]
+      def transform_controlled_properties(env)
+        env.curation_concern.class.controlled_properties.map(&:to_s).each do |property|
+          next if env.attributes[property].blank?
+
+          values = env.attributes.delete(property)
+          env.attributes[:"#{property}_attributes"] = Array.wrap(values).map { |value| { id: value } }
+        end
+      end
+
+      # if we've been passed attributes with a :rights_statement value, convert it
+      # to an RDF::URI object for storage
+      #
       # @param [Hyrax::Actors::Environment] env
       # @return [void]
       def transform_rights_statement(env)

--- a/app/actors/spot/actors/base_actor.rb
+++ b/app/actors/spot/actors/base_actor.rb
@@ -35,7 +35,6 @@ module Spot
         super
       end
 
-
       # @param [Hyrax::Actors::Environment] env
       # @return [DateTime]
       def get_date_uploaded_value(env)


### PR DESCRIPTION
addresses an issue with bulkrax where controlled fields (ie `#subject`, `#location`) need to be set as `*_attributes` in order for their values to be converted into rdf literals. since this is already handled by hyrax, this fix will mostly be used during batch ingest