### PR TITLE
store ldr-related cas entitlements in session

### DIFF
--- a/app/services/spot/cas_user_roles_service.rb
+++ b/app/services/spot/cas_user_roles_service.rb
@@ -16,11 +16,10 @@ module Spot
   #   user.save
   class CasUserRolesService
     # URI host for valid entitlements
-    ENTITLEMENT_HOST = 'ldr.lafayette.edu'
+    class_attribute :entitlement_host, default: 'ldr.lafayette.edu'
 
     # Roles/Groups that we handle via CAS attributes
-    class_attribute :group_names_from_cas
-    self.group_names_from_cas = [
+    class_attribute :group_names_from_cas, default: [
       Ability.alumni_group_name,
       Ability.faculty_group_name,
       Ability.staff_group_name,
@@ -65,7 +64,7 @@ module Spot
     # @return [String]
     def role_name_from_entitlement(value)
       parsed = URI.parse(value)
-      return unless parsed.host == ENTITLEMENT_HOST
+      return unless parsed.host == entitlement_host
 
       case parsed.path
       when '/alumni'  then Ability.alumni_group_name

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module Spot
 
     config.rack_cas.server_url = ENV['CAS_BASE_URL']
     config.rack_cas.service = '/users/service'
-    config.rack_cas.extra_attributes_filter = %w[uid email givenName surname lnumber]
+    config.rack_cas.extra_attributes_filter = %w[uid email givenName surname lnumber eduPersonEntitlement]
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -190,11 +190,12 @@ Rails.application.config.to_prepare do
   Hyrax::AdminSetCreateService.singleton_class.send(:prepend, Spot::AdminSetCreateServiceDecorator)
 
   # Only store entitlements related to us in the session to prevent a cookie overflow
+  # rubocop:disable Style/IfUnlessModifier
   require 'rack/cas'
   Rack::CAS.class_eval do
     def store_session(request, user, ticket, extra_attrs = {})
       if RackCAS.config.extra_attributes_filter?
-        extra_attrs.select! { |key, val| RackCAS.config.extra_attributes_filter.map(&:to_s).include? key.to_s }
+        extra_attrs.select! { |key, _val| RackCAS.config.extra_attributes_filter.map(&:to_s).include? key.to_s }
       end
 
       if extra_attrs['eduPersonEntitlement'].present?


### PR DESCRIPTION
reverts #1115 and patches Rack-CAS to only store LDR related entitlements