### PR TITLE
use localhost hostname for s3 urls in development

### DIFF
--- a/app/helpers/audio_visual_helper.rb
+++ b/app/helpers/audio_visual_helper.rb
@@ -4,8 +4,12 @@
 module AudioVisualHelper
   # @param [String] s3 key
   # @return [String] presigned URL
+  # @note For development environments, we need to subsitute the service hostname of S3 ('minio')
+  #       with 'localhost' for links to resolve. In production, 'AWS_ENDPOINT_URL's hostname is valid.
   def s3_url(key)
-    client = Aws::S3::Client.new
+    client_opts = {}
+    client_opts = { endpoint: ENV['AWS_ENDPOINT_URL']&.sub('minio', 'localhost') } if Rails.env.development?
+    client = Aws::S3::Client.new(**client_opts)
     obj = Aws::S3::Object.new(bucket_name: ENV['AWS_BULKRAX_IMPORTS_BUCKET'], key: key, client: client)
     url = obj.presigned_url(:get, expires_in: 3600)
     url


### PR DESCRIPTION
kinda hacky, but dev environments can't resolve the service hostname for minio, so we'll make it localhost