### PR TITLE
use assignFAST as authority for #subject

### DIFF
--- a/app/views/records/edit_fields/_subject.html.erb
+++ b/app/views/records/edit_fields/_subject.html.erb
@@ -5,14 +5,14 @@
           input_html: {
             class: 'form-control',
             data: {
-              'autocomplete-url' => '/authorities/search/linked_data/oclc_fast',
+              'autocomplete-url' => '/authorities/search/assign_fast/all',
               'autocomplete' => 'subject'
             }
           },
           ### Required for the ControlledVocabulary javascript:
           wrapper_html: {
             data: {
-              'autocomplete-url' => '/authorities/search/linked_data/oclc_fast',
+              'autocomplete-url' => '/authorities/search/assign_fast/all',
               'field-name' => 'subject'
             }
           },

--- a/config/authorities/remote_authorities.yml
+++ b/config/authorities/remote_authorities.yml
@@ -1,7 +1,7 @@
 terms:
   - id: fast
     label: FAST
-    search: /authorities/search/linked_data/oclc_fast
+    search: /authorities/search/assign_fast/all
   - id: geonames
     label: GeoNames
     search: /authorities/search/geonames

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -231,4 +231,27 @@ Rails.application.config.to_prepare do
       nil
     end
   end
+
+  # Modifying how Questiong Authority returns AssignFAST results by
+  # converting fst ids into URLs
+  require 'qa/authorities/assign_fast'
+  Qa::Authorities::AssignFast::GenericAuthority.class_eval do
+    private
+
+    def parse_authority_response(raw_response)
+      raw_response['response']['docs'].map do |doc|
+        index = Qa::Authorities::AssignFast.index_for_authority(subauthority)
+        term = doc[index].first
+        term += " (USE #{doc['auth']})" if doc['type'] == 'alt'
+        fast_id = Array.wrap(doc['idroot']).first
+
+        {
+          fast_id: fast_id,
+          id: "http://id.worldcat.org/fast/#{fast_id.gsub(/^fst0/, '')}",
+          label: term,
+          value: doc['auth']
+        }
+      end
+    end
+  end
 end

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -247,7 +247,7 @@ Rails.application.config.to_prepare do
 
         {
           fast_id: fast_id,
-          id: "http://id.worldcat.org/fast/#{fast_id.gsub(/^fst0/, '')}",
+          id: "http://id.worldcat.org/fast/#{fast_id.gsub(/^fst/, '')}",
           label: term,
           value: doc['auth']
         }

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature 'Create an Image', :clean, :js do
 
         fill_in_autocomplete '.image_subject', with: attrs[:subject].first
         expect(page).to have_css('.image_subject.form-control[data-autocomplete="subject"]', visible: false)
-        expect(page).to have_css('.image_subject.form-control[data-autocomplete-url="/authorities/search/linked_data/oclc_fast"]', visible: false)
+        expect(page).to have_css('.image_subject.form-control[data-autocomplete-url="/authorities/search/assign_fast/all"]', visible: false)
         expect(page).to have_css('.image_subject .controls-add-text')
 
         # multi-authority for location


### PR DESCRIPTION
the service QA uses for FAST Linked Data searches has been deprecated (or rather, urls redirect to a now-deprecated host, experimental.oclc.org), so we'll use QA's assignFAST authority instead