### PR TITLE
fix docker syntax warnings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   app:
     image: lafayette/spot-web


### PR DESCRIPTION
- named stages in Dockerfile use `AS` casing (ex: `FROM ruby:2.7.8 AS ruby-base`)
- docker-compose.yml no longer requires "version" parameter