### PR TITLE
use Firefox for feature specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,13 +116,13 @@ jobs:
             sudo apt-get update
             sudo apt-get -y install postgresql-13
 
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
+      - browser-tools/install-firefox
+      - browser-tools/install-geckodriver
 
-      # start chrome
+      # start firefox
       - run:
-          name: Start headless Chrome browser
-          command: google-chrome --headless --disable-gpu -no-sandbox --browsertime.xvfb --remote-debugging-port=9222 http://localhost &
+          name: Start headless Firefox browser
+          command: firefox --headless --disable-gpu -no-sandbox --browsertime.xvfb --remote-debugging-port=9222 http://localhost &
 
       - run:
           name: Make sure dependencies are valid

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
       # start firefox
       - run:
           name: Start headless Firefox browser
-          command: firefox --headless --disable-gpu -no-sandbox --browsertime.xvfb --remote-debugging-port=9222 http://localhost &
+          command: firefox --headless --remote-debugging-port=9222 http://localhost &
 
       - run:
           name: Make sure dependencies are valid

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ COPY config/pdfjs/web/lafayette-viewer-enhancements.js /tmp/pdfjs/web
 # Installs Ruby development dependencies
 ##
 FROM spot-base AS spot-web-development
+RUN apt-get update -y && apt-get install -y firefox-esr
 RUN bundle config unset with &&\
     bundle config unset without && \
     bundle config set with "development:test" && \

--- a/Gemfile
+++ b/Gemfile
@@ -168,9 +168,9 @@ group :development, :test do
   gem 'rspec-its', '~> 1.1'
   gem 'rspec_junit_formatter', '~> 0.4.1'
   gem 'rspec-rails', '~> 5.1'
+  gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 4'
   gem 'simplecov', '~> 0.21.2', require: false
   gem 'stub_env', '~> 1.0.4'
-  gem 'webdrivers', '~> 5'
   gem 'webmock', '~> 3.8'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1150,6 +1150,7 @@ DEPENDENCIES
   rspec_junit_formatter (~> 0.4.1)
   rubyzip (~> 2.3.2)
   sass-rails (~> 5.1.0)
+  selenium-webdriver
   shoulda-matchers (~> 4)
   sidekiq (~> 5.2.9)
   sidekiq-cron (~> 1.9.1)

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,6 +13,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
+  url: "postgres://<%= ENV.fetch('PSQL_USER', 'spot_dev_user') %>:<%= ENV.fetch('PSQL_PASSWORD', 'spot_dev_pw') %>@<%= ENV.fetch('PSQL_HOST', 'localhost') %>/<%= ENV.fetch('PSQL_TEST_DATABASE', 'spot_test') %>"
 
 production:
   <<: *default

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,23 +34,14 @@ require 'equivalent-xml'
 require 'equivalent-xml/rspec_matchers'
 require 'mail'
 
-# copied selenium chrome drive config from samvera/hyrax/spec/spec_helper.rb
-#
-# @note In January 2018, TravisCI disabled Chrome sandboxing in its Linux
-#       container build environments to mitigate Meltdown/Spectre
-#       vulnerabilities, at which point Hyrax could no longer use the
-#       Capybara-provided :selenium_chrome_headless driver (which does not
-#       include the `--no-sandbox` argument).
-Capybara.register_driver :selenium_chrome_headless_sandboxless do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
+Capybara.register_driver :selenium_firefox_headless do |app|
+  browser_options = ::Selenium::WebDriver::Firefox::Options.new
   browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  browser_options.args << '--no-sandbox'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+  Capybara::Selenium::Driver.new(app, browser: :firefox, options: browser_options)
 end
 
 Capybara.default_driver = :rack_test # This is a faster driver
-Capybara.javascript_driver = :selenium_chrome_headless_sandboxless # This is slower
+Capybara.javascript_driver = :selenium_firefox_headless # This is slower
 
 # Uncomment this block to watch feature tests run in a web browser
 # Capybara.javascript_driver = :selenium
@@ -62,7 +53,7 @@ Capybara.javascript_driver = :selenium_chrome_headless_sandboxless # This is slo
 # since we've created a custsom driver (that is a wrapper around a Selenium
 # driver), we need to tell capybara-screenshot how to take a screenshot
 # (which is copied from the Selenium configuration)
-Capybara::Screenshot.register_driver(:selenium_chrome_headless_sandboxless) do |driver, path|
+Capybara::Screenshot.register_driver(:selenium_firefox_headless) do |driver, path|
   driver.browser.save_screenshot(path)
 end
 
@@ -160,12 +151,10 @@ WebMock.disable_net_connect!(
   allow_localhost: true,
   net_http_connect_on_start: true,
 
-  # let webdrivers gem fetch the chrome browser and
   # account for our aliased services via docker
   allow: %w[
-    googlechromelabs.github.io
-    chromedriver.storage.googleapis.com
-    storage.googleapis.com
+    objects.githubusercontent.com
+    github.com
     db
     fedora
     fitsservlet


### PR DESCRIPTION
it looks like chrome isn't available in an arm64 variety, which is why browser-based feature tests stopped working when i upgraded my machine 🙃 

this replaces chrome with firefox in selenium and installs the binary in the `spot-web-development` target