### PR TITLE
allow test reporting to fail without ruining workflows

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -157,6 +157,10 @@ jobs:
           export PATH="$(dirname $(which geckodriver)):${PATH}"
           mkdir /tmp/test-results
           bundle exec rspec --backtrace --format progress --format RspecJunitFormatter --out /tmp/test-results/rspec.xml
+      -
+        name: Publish UndercoverCI report
+        continue-on-error: true
+        run: |
           ruby -e "$(curl -s https://undercover-ci.com/uploader.rb)" -- \
             --repo ${{ github.repository }} \
             --commit ${{ github.event.pull_request.head.sha || github.sha }} \
@@ -165,6 +169,7 @@ jobs:
         name: Publish RSpec report
         uses: mikepenz/action-junit-report@v3
         if: always()
+        continue-on-error: true
         with:
           check_name: Test summary
           report_paths: /tmp/test-results/*.xml
@@ -172,6 +177,7 @@ jobs:
         name: Publish coverage
         uses: joshmfrankel/simplecov-check-action@main
         if: always()
+        continue-on-error: true
         with:
           check_job_name: Test coverage
           minimum_suite_coverage: 95


### PR DESCRIPTION
moves undercover-ci reporting into its own step and prevents the workflow from failing if we run into issues with test reporting