### PR TITLE
Image Work Type Language Property Fix

### DIFF
--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -2,7 +2,7 @@
 module Hyrax
   class ImageForm < ::Spot::Forms::WorkForm
     transforms_language_tags_for :title, :title_alternative, :subtitle, :description, :inscription
-    transforms_nested_fields_for :subject_ocm
+    transforms_nested_fields_for :subject_ocm, :language
     singular_form_fields :title
 
     self.model_class = ::Image


### PR DESCRIPTION
ads the language property to the transforms_nested_fields_for list for the image form. Fixes bug where language field was not correctly saving on form submission