### PR TITLE
Replace labels for physical medium with format

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -44,7 +44,7 @@ en:
         original_item_extent: Original Item Extent
         page_count: Page Count
         permalink: Permalink
-        physical_medium: Physical Medium
+        physical_medium: Format
         proxy_depositor: Proxy Depositor
         publisher: Publisher
         related_resource: Related Resource

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -34,7 +34,7 @@ en:
         note: Information important to internal maintenance of records or relevant to the original items, such as administrative, digitization, or decision documentation.
         organization: The organization associated with the resource.
         original_item_extent: The size or duration of the physical resource.
-        physical_medium: A physical material or carrier.  Examples include paper, canvas, or DVD.
+        physical_medium: The file format, physical medium, or dimensions of the resource.
         publisher: The person or group making the work available. Generally this is the institution.
         related_resource: Further information about the subject resource.
         repository_location: Location of the physical resource within the archives.


### PR DESCRIPTION
Relabels instances of "Physical Medium" and the associated description with "Format"and it's description. Functionally a rebranding of the :physical_medium field as a :format field that doesn't require a reindex