### PR TITLE
fix assign_fast subject dropdown

### DIFF
--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -262,11 +262,11 @@ Rails.application.config.to_prepare do
     def index_for_authority(authority)
       return authority if authority == 'idroot'
 
-      super
+      Qa::Authorities::AssignFastSubauthority::SUBAUTHORITIES[authority]
     end
 
     def subauthorities
-      super + ['idroot']
+      Qa::Authorities::AssignFastSubauthority::SUBAUTHORITIES.keys + ['idroot']
     end
   end
 end


### PR DESCRIPTION
copies over questioning_authority overridden methods instead of calling `super` (which wasn't actually doing anything).

see also #1133, #1139 