### PR TITLE
CodeCov Integration

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,17 @@
+codecov: 
+  token: 7dac3daa-47d7-4128-b35c-3889e6d9006b
+coverage:
+  status:
+    project: #add everything under here, more options at https://docs.codecov.com/docs/commit-status
+      default:
+        # basic
+        target: auto #default
+        threshold: 0%
+        base: auto 
+comment:                  #this is a top-level key
+  layout: " diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: false        # [true :: must have a base report to post]
+  require_head: true       # [true :: must have a head report to post]
+  hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -158,13 +158,11 @@ jobs:
           mkdir /tmp/test-results
           bundle exec rspec --backtrace --format progress --format RspecJunitFormatter --out /tmp/test-results/rspec.xml
       -
-        name: Publish UndercoverCI report
+        name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
         continue-on-error: true
-        run: |
-          ruby -e "$(curl -s https://undercover-ci.com/uploader.rb)" -- \
-            --repo ${{ github.repository }} \
-            --commit ${{ github.event.pull_request.head.sha || github.sha }} \
-            --lcov coverage/lcov/spot.lcov
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }
       -
         name: Publish RSpec report
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -162,7 +162,7 @@ jobs:
         uses: codecov/codecov-action@v3
         continue-on-error: true
         with:
-          token: ${{ secrets.CODECOV_TOKEN }
+          token: ${{ secrets.CODECOV_TOKEN }}
       -
         name: Publish RSpec report
         uses: mikepenz/action-junit-report@v3

--- a/Gemfile
+++ b/Gemfile
@@ -171,7 +171,7 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 4'
   gem 'simplecov', '~> 0.21.2', require: false
-  gem "simplecov-lcov", "~> 0.8.0", require: false
+  gem 'simplecov-cobertura', '~> 2.1', require: false
   gem 'stub_env', '~> 1.0.4'
   gem 'webmock', '~> 3.8'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -975,8 +975,10 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
-    simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
     slack-ruby-client (0.14.6)
       activesupport
@@ -1143,7 +1145,7 @@ DEPENDENCIES
   sidekiq-cron (~> 1.9.1)
   simple_form (< 5.2)
   simplecov (~> 0.21.2)
-  simplecov-lcov (~> 0.8.0)
+  simplecov-cobertura (~> 2.1)
   slack-ruby-client (~> 0.14.6)
   spring (~> 2.1.1)
   spring-watcher-listen (~> 2.0.0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ ENV['URL_HOST'] = 'http://localhost' if ENV['URL_HOST'].nil?
 if ENV['COVERAGE'] || ENV['CI']
   ENV['DISABLE_BOOTSNAP'] = 'true'
 
-  # set up code-coverage; 
+  # set up code-coverage
   require 'simplecov'
   require 'simplecov-cobertura'
   SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,15 +7,12 @@ ENV['URL_HOST'] = 'http://localhost' if ENV['URL_HOST'].nil?
 if ENV['COVERAGE'] || ENV['CI']
   ENV['DISABLE_BOOTSNAP'] = 'true'
 
-  # set up code-coverage; we use LCOV formatting to send to undercover-ci.
-  # @see https://undercover-ci.com/app
+  # set up code-coverage; 
   require 'simplecov'
-  require 'simplecov-lcov'
-  SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
-  SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+  require 'simplecov-cobertura'
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
   SimpleCov.start 'rails' do
     add_filter 'lib/mailer_previews'
-    enable_coverage(:branch)
   end
 end
 


### PR DESCRIPTION
Removes lcov and undercover scaffolding and adds integration with CodeCov. Needs to be merged directly into primary