### PR TITLE
2025.1.1

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -11,5 +11,5 @@ comment:                  #this is a top-level key
   behavior: default
   require_changes: false  # if true: only post the comment if coverage changes
   require_base: false        # [true :: must have a base report to post]
-  require_head: true       # [true :: must have a head report to post]
+  require_head: false       # [true :: must have a head report to post]
   hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]

--- a/.github/workflows/closed-branch-cleanup.yml
+++ b/.github/workflows/closed-branch-cleanup.yml
@@ -13,6 +13,7 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           BRANCH: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh extension install actions/gh-actions-cache
 

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -159,10 +159,8 @@ jobs:
           bundle exec rspec --backtrace --format progress --format RspecJunitFormatter --out /tmp/test-results/rspec.xml
       -
         name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         continue-on-error: true
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
       -
         name: Publish RSpec report
         uses: mikepenz/action-junit-report@v3


### PR DESCRIPTION
supplements to get gh actions working properly

- add gh token to `closed-branch-cleanup` action
- configure `codecov` to be tokenless (#1156)