### PR TITLE
2025.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1140,7 +1140,6 @@ DEPENDENCIES
   okcomputer (~> 1.18.5)
   pg (~> 1.5.4)
   puma (~> 6.4.0)
-  qa (~> 5.15.0)
   rails (~> 5.2.7)
   rails-controller-testing (~> 1.0.5)
   rdf-vocab (~> 3.2.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       activemodel (= 5.2.8.1)
       activesupport (= 5.2.8.1)
       arel (>= 9.0)
-    activerecord-import (1.4.1)
+    activerecord-import (2.2.0)
       activerecord (>= 4.2)
     activestorage (5.2.8.1)
       actionpack (= 5.2.8.1)
@@ -105,6 +105,7 @@ GEM
     bagit (0.6.0)
       docopt (~> 0.5.0)
       validatable (~> 1.6)
+    base64 (0.3.0)
     bcp47 (0.3.3)
       i18n
     bcrypt (3.1.19)
@@ -216,6 +217,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    csv (3.3.5)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.1.0)
@@ -366,7 +368,9 @@ GEM
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
     gems (1.2.0)
-    geocoder (1.8.2)
+    geocoder (1.8.5)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     gli (2.21.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -721,14 +725,14 @@ GEM
     public_suffix (5.0.3)
     puma (6.4.2)
       nio4r (~> 2.0)
-    qa (5.11.0)
+    qa (5.15.0)
       activerecord-import
       deprecation
       faraday (< 3.0, != 2.0.0)
       geocoder
       ldpath
       nokogiri (~> 1.6)
-      rails (>= 5.0, < 7.2)
+      rails (>= 5.0, < 8.1)
       rdf
     raabro (1.4.0)
     racc (1.7.3)
@@ -1136,6 +1140,7 @@ DEPENDENCIES
   okcomputer (~> 1.18.5)
   pg (~> 1.5.4)
   puma (~> 6.4.0)
+  qa (~> 5.15.0)
   rails (~> 5.2.7)
   rails-controller-testing (~> 1.0.5)
   rdf-vocab (~> 3.2.7)

--- a/config/authorities/assign_fast/oclc_assign_fast.json
+++ b/config/authorities/assign_fast/oclc_assign_fast.json
@@ -1,0 +1,7 @@
+{
+  "search": {
+    "urls": {
+      "fastsuggest": "https://fast.oclc.org/fastsuggest"
+    }
+  }
+}

--- a/spec/actors/hyrax/actors/publication_actor_spec.rb
+++ b/spec/actors/hyrax/actors/publication_actor_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe Hyrax::Actors::PublicationActor do
       before { allow(work).to receive(:embargo).and_return embargo }
 
       let(:embargo) do
-        instance_double(Hydra::AccessControls::Embargo,
-                        embargo_release_date: tomorrow_time,
-                        to_hash: {})
+        Hyrax::Embargo.new(embargo_release_date: tomorrow_time,
+                           visibility_during_embargo: 'metadata',
+                           visibility_after_embargo: 'open')
       end
       let(:tomorrow_time) { Time.zone.tomorrow }
       let(:tomorrow) { tomorrow_time.strftime('%Y-%m-%d') }

--- a/spec/actors/hyrax/actors/publication_actor_spec.rb
+++ b/spec/actors/hyrax/actors/publication_actor_spec.rb
@@ -32,12 +32,16 @@ RSpec.describe Hyrax::Actors::PublicationActor do
     end
 
     context 'when an embargo is set for the work' do
-      before { allow(work).to receive(:embargo).and_return embargo }
+      before do
+        work.embargo = embargo
+      end
 
       let(:embargo) do
-        Hyrax::Embargo.new(embargo_release_date: tomorrow_time,
-                           visibility_during_embargo: 'metadata',
-                           visibility_after_embargo: 'open')
+        Hydra::AccessControls::Embargo.create!(
+          embargo_release_date: tomorrow_time,
+          visibility_during_embargo: 'metadata',
+          visibility_after_embargo: 'open'
+        )
       end
       let(:tomorrow_time) { Time.zone.tomorrow }
       let(:tomorrow) { tomorrow_time.strftime('%Y-%m-%d') }

--- a/spec/features/create_audio_visual_spec.rb
+++ b/spec/features/create_audio_visual_spec.rb
@@ -2,7 +2,7 @@
 RSpec.feature 'Create a Audio Visual', :clean, :js do
   before do
     stub_request(:get, subject)
-    stub_request(:get, /fast\.oclc\.org\/searchfast\/fastsuggest/)
+    stub_request(:get, /fast\.oclc\.org\/fastsuggest/)
 
     # Only enqueue the ingest job, not charactarization.
     # (h/t: https://github.com/curationexperts/mahonia/blob/89b036c/spec/features/access_etd_spec.rb#L9-L10)

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature 'Create an Image', :clean, :js do
   before do
     stub_request(:get, subject_uri)
-    stub_request(:get, /fast\.oclc\.org\/searchfast\/fastsuggest/)
+    stub_request(:get, /fast\.oclc\.org\/fastsuggest/)
 
     # Only enqueue the ingest job, not charactarization.
     # (h/t: https://github.com/curationexperts/mahonia/blob/89b036c/spec/features/access_etd_spec.rb#L9-L10)

--- a/spec/features/create_publication_spec.rb
+++ b/spec/features/create_publication_spec.rb
@@ -2,7 +2,7 @@
 RSpec.feature 'Create a Publication', :clean, :js do
   before do
     stub_request(:get, subject_uri)
-    stub_request(:get, /fast\.oclc\.org\/searchfast\/fastsuggest/)
+    stub_request(:get, /fast\.oclc\.org\/fastsuggest/)
 
     # Only enqueue the ingest job, not charactarization.
     # (h/t: https://github.com/curationexperts/mahonia/blob/89b036c/spec/features/access_etd_spec.rb#L9-L10)

--- a/spec/features/create_student_work_spec.rb
+++ b/spec/features/create_student_work_spec.rb
@@ -2,7 +2,7 @@
 RSpec.feature 'Create a StudentWork', :clean, :js do
   before do
     stub_request(:get, subject_uri)
-    stub_request(:get, /fast\.oclc\.org\/searchfast\/fastsuggest/)
+    stub_request(:get, /fast\.oclc\.org\/fastsuggest/)
 
     # Only enqueue the ingest job, not charactarization.
     # (h/t: https://github.com/curationexperts/mahonia/blob/89b036c/spec/features/access_etd_spec.rb#L9-L10)

--- a/spec/models/spot/controlled_vocabularies/assign_fast_subject_spec.rb
+++ b/spec/models/spot/controlled_vocabularies/assign_fast_subject_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Spot::ControlledVocabularies::AssignFastSubject do
 
   describe '#fetch' do
     let(:search_url) do
-      "http://fast.oclc.org/searchfast/fastsuggest?&query=#{fast_id_number}&queryIndex=idroot&queryReturn=idroot%2Cidroot%2Cauth%2Ctype&suggest=autoSubject&rows=20"
+      "https://fast.oclc.org/fastsuggest?&query=#{fast_id_number}&queryIndex=idroot&queryReturn=idroot%2Cidroot%2Cauth%2Ctype&sort=usage%20desc&suggest=autoSubject&rows=20"
     end
 
     let(:search_response) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,6 +68,10 @@ Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |f| require f }
 
 ActiveRecord::Migration.maintain_test_schema!
 
+# DatabaseCleaner will raise an error if the db is configured to a remote url,
+# which is how we're using our local docker setup, so we need to tell it to chill out
+DatabaseCleaner.allow_remote_database_url = true
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`


### PR DESCRIPTION
## updates
- questioning_authority to 5.15.0; adds `config/authorities/assign_fast/oclc_assign_fast.json` to update the base url for AssignFAST (#1172)