### PR TITLE
Deprecation warning fix

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -107,3 +107,10 @@ LAFAYETTE_WDS_API_KEY=
 
 # For local development, creates Admin accounts for each email address listed (comma separated)
 DEV_ADMIN_USERS=
+
+# Set to "-W0" to disable ruby warnings; otherwise do not include.
+RUBYOPT=
+
+# Used to ignore deprecation warnings from gems (particularly hyrax).
+# Set to "true" to ignore and "false" to see warnings.
+SPOT_IGNORE_DEPRECATIONS=

--- a/.env.sample
+++ b/.env.sample
@@ -112,5 +112,5 @@ DEV_ADMIN_USERS=
 RUBYOPT=
 
 # Used to ignore deprecation warnings from gems (particularly hyrax).
-# Set to "true" to ignore and "false" to see warnings.
+# Set to true to ignore and false to see warnings.
 SPOT_IGNORE_DEPRECATIONS=

--- a/.env.sample
+++ b/.env.sample
@@ -108,9 +108,9 @@ LAFAYETTE_WDS_API_KEY=
 # For local development, creates Admin accounts for each email address listed (comma separated)
 DEV_ADMIN_USERS=
 
-# Set to "-W0" to disable ruby warnings; otherwise do not include.
-RUBYOPT=
+# Uncomment to disable Ruby warnings
+# RUBYOPT="-W0"
 
-# Used to ignore deprecation warnings from gems (particularly hyrax).
-# Set to true to ignore and false to see warnings.
-SPOT_IGNORE_DEPRECATIONS=
+# Used to ignore deprecation warnings from gems (particularly Hyrax).
+# Default behavior is to show all warnings.
+SPOT_IGNORE_DEPRECATIONS=false

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require 'sprockets/es6'
 require 'rack-cas/session_store/active_record'
 require 'deprecation'
 
-if ENV.fetch('SPOT_IGNORE_DEPRECATIONS', false)
+if ActiveModel::Type::Boolean.new.cast(ENV.fetch('SPOT_IGNORE_DEPRECATIONS', false))
   ActiveSupport::Deprecation.silence do
     Deprecation.default_deprecation_behavior = :silence
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,14 +4,18 @@ require_relative 'boot'
 require 'rails/all'
 require 'sprockets/es6'
 require 'rack-cas/session_store/active_record'
-require 'deprecation'
 
+# Some gems in the Samvera stack use the 'deprecation' gem instead of
+# ActiveSupport::Deprecation calls, so we need to also set _that_ gem's
+# default behavior before requiring the stack's dependencies.
+#
+# @note dry-types uses its own Deprecation class but doesn't provide an API for silencing
 if ActiveModel::Type::Boolean.new.cast(ENV.fetch('SPOT_IGNORE_DEPRECATIONS', false))
+  require 'deprecation'
+
   ActiveSupport::Deprecation.silence do
     Deprecation.default_deprecation_behavior = :silence
 
-    # Require the gems listed in Gemfile, including any gems
-    # you've limited to :test, :development, or :production.
     Bundler.require(*Rails.groups)
   end
 else

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,10 +4,21 @@ require_relative 'boot'
 require 'rails/all'
 require 'sprockets/es6'
 require 'rack-cas/session_store/active_record'
+require 'deprecation'
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
-Bundler.require(*Rails.groups)
+if ENV.fetch('SPOT_IGNORE_DEPRECATIONS', false)
+  ActiveSupport::Deprecation.silence do
+    Deprecation.default_deprecation_behavior = :silence
+
+    # Require the gems listed in Gemfile, including any gems
+    # you've limited to :test, :development, or :production.
+    Bundler.require(*Rails.groups)
+  end
+else
+  # Require the gems listed in Gemfile, including any gems
+  # you've limited to :test, :development, or :production.
+  Bundler.require(*Rails.groups)
+end
 
 module Spot
   class Application < Rails::Application

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,11 +38,6 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  # Print deprecation notices to the Rails logger.
-  config.active_support.deprecation = begin
-    ActiveModel::Type::Boolean.new.cast(ENV.fetch('RAILS_SILENCE_DEPRECATIONS', false)) ? :silence : :log
-  end
-
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,9 +86,6 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  # ignore deprecation warnings on Production
-  config.active_support.deprecation = :silence
-
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,7 +35,5 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  config.active_support.deprecation = :stderr
-
   config.active_job.queue_adapter = :test
 end


### PR DESCRIPTION
Introduces RUBYOPT and SPOT_IGNORE_DEPRECATIONS variables. Optionally wrap Bundler.require in code to silence deprecation warnings dependent on SPOT_IGNORE_DEPRECATIONS.