### PR TITLE
bulkrax upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'bootsnap', '~> 1.17', require: false
 
 # Bulkrax for batch ingesting objects
 gem 'browse-everything', '~> 1.1.2'
-gem 'bulkrax', '~> 9.0.2'
+gem 'bulkrax', '~> 9.1.0'
 
 # This needs to be here if we want to compile our own JS
 # (there's like a single coffee-script file still remaining in hyrax)

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'bootsnap', '~> 1.17', require: false
 
 # Bulkrax for batch ingesting objects
 gem 'browse-everything', '~> 1.1.2'
-gem 'bulkrax', git: 'https://github.com/samvera/bulkrax.git', ref: 'fe825f9', require: false
+gem 'bulkrax', git: 'https://github.com/samvera/bulkrax.git', ref: 'fe825f9'
 
 # This needs to be here if we want to compile our own JS
 # (there's like a single coffee-script file still remaining in hyrax)

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'bootsnap', '~> 1.17', require: false
 
 # Bulkrax for batch ingesting objects
 gem 'browse-everything', '~> 1.1.2'
-gem 'bulkrax', '~> 9.1.0'
+gem 'bulkrax', git: 'https://github.com/samvera/bulkrax.git', ref: 'fe825f9', require: false
 
 # This needs to be here if we want to compile our own JS
 # (there's like a single coffee-script file still remaining in hyrax)

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'bootsnap', '~> 1.17', require: false
 
 # Bulkrax for batch ingesting objects
 gem 'browse-everything', '~> 1.1.2'
-gem 'bulkrax', '~> 9.2.0'
+gem 'bulkrax', '~> 9.2.1'
 
 # This needs to be here if we want to compile our own JS
 # (there's like a single coffee-script file still remaining in hyrax)

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'bootsnap', '~> 1.17', require: false
 
 # Bulkrax for batch ingesting objects
 gem 'browse-everything', '~> 1.1.2'
-gem 'bulkrax', git: 'https://github.com/samvera/bulkrax.git', ref: 'fe825f9'
+gem 'bulkrax', '~> 9.2.0'
 
 # This needs to be here if we want to compile our own JS
 # (there's like a single coffee-script file still remaining in hyrax)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
-    bulkrax (9.2.0)
+    bulkrax (9.2.1)
       bagit (~> 0.6.0)
       coderay
       denormalize_fields
@@ -1114,7 +1114,7 @@ DEPENDENCIES
   blacklight_range_limit (~> 6.3.3)
   bootsnap (~> 1.17)
   browse-everything (~> 1.1.2)
-  bulkrax (~> 9.2.0)
+  bulkrax (~> 9.2.1)
   byebug (~> 11.1.3)
   capybara (~> 3.38)
   capybara-screenshot (~> 1.0.26)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,3 @@
-GIT
-  remote: https://github.com/samvera/bulkrax.git
-  revision: fe825f98347c38c45cecb567c06cb0ee6c9a2ebd
-  ref: fe825f9
-  specs:
-    bulkrax (9.1.0)
-      bagit (~> 0.6.0)
-      coderay
-      denormalize_fields
-      iso8601 (~> 0.9.0)
-      kaminari
-      language_list (~> 1.2, >= 1.2.1)
-      libxml-ruby (~> 5.0)
-      loofah (>= 2.2.3)
-      marcel
-      oai (>= 0.4, < 2.x)
-      rack (>= 2.0.6)
-      rails (>= 5.1.6, < 7.0.0)
-      rdf (>= 2.0.2, < 4.0)
-      rubyzip
-      simple_form
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -190,6 +168,22 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
+    bulkrax (9.2.0)
+      bagit (~> 0.6.0)
+      coderay
+      denormalize_fields
+      iso8601 (~> 0.9.0)
+      kaminari
+      language_list (~> 1.2, >= 1.2.1)
+      libxml-ruby (~> 5.0)
+      loofah (>= 2.2.3)
+      marcel
+      oai (>= 0.4, < 2.x)
+      rack (>= 2.0.6)
+      rails (>= 5.1.6, < 7.0.0)
+      rdf (>= 2.0.2, < 4.0)
+      rubyzip
+      simple_form
     byebug (11.1.3)
     cancancan (1.17.0)
     capybara (3.39.2)
@@ -1120,7 +1114,7 @@ DEPENDENCIES
   blacklight_range_limit (~> 6.3.3)
   bootsnap (~> 1.17)
   browse-everything (~> 1.1.2)
-  bulkrax!
+  bulkrax (~> 9.2.0)
   byebug (~> 11.1.3)
   capybara (~> 3.38)
   capybara-screenshot (~> 1.0.26)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
-    bulkrax (9.0.2)
+    bulkrax (9.1.0)
       bagit (~> 0.6.0)
       coderay
       denormalize_fields
@@ -608,7 +608,7 @@ GEM
       rdf-vocab (~> 3.0)
     legato (0.7.0)
       multi_json
-    libxml-ruby (5.0.3)
+    libxml-ruby (5.0.5)
     link_header (0.0.8)
     linkeddata (3.1.6)
       equivalent-xml (~> 0.6)
@@ -1114,7 +1114,7 @@ DEPENDENCIES
   blacklight_range_limit (~> 6.3.3)
   bootsnap (~> 1.17)
   browse-everything (~> 1.1.2)
-  bulkrax (~> 9.0.2)
+  bulkrax (~> 9.1.0)
   byebug (~> 11.1.3)
   capybara (~> 3.38)
   capybara-screenshot (~> 1.0.26)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,25 @@
+GIT
+  remote: https://github.com/samvera/bulkrax.git
+  revision: fe825f98347c38c45cecb567c06cb0ee6c9a2ebd
+  ref: fe825f9
+  specs:
+    bulkrax (9.1.0)
+      bagit (~> 0.6.0)
+      coderay
+      denormalize_fields
+      iso8601 (~> 0.9.0)
+      kaminari
+      language_list (~> 1.2, >= 1.2.1)
+      libxml-ruby (~> 5.0)
+      loofah (>= 2.2.3)
+      marcel
+      oai (>= 0.4, < 2.x)
+      rack (>= 2.0.6)
+      rails (>= 5.1.6, < 7.0.0)
+      rdf (>= 2.0.2, < 4.0)
+      rubyzip
+      simple_form
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -168,22 +190,6 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
-    bulkrax (9.1.0)
-      bagit (~> 0.6.0)
-      coderay
-      denormalize_fields
-      iso8601 (~> 0.9.0)
-      kaminari
-      language_list (~> 1.2, >= 1.2.1)
-      libxml-ruby (~> 5.0)
-      loofah (>= 2.2.3)
-      marcel
-      oai (>= 0.4, < 2.x)
-      rack (>= 2.0.6)
-      rails (>= 5.1.6)
-      rdf (>= 2.0.2, < 4.0)
-      rubyzip
-      simple_form
     byebug (11.1.3)
     cancancan (1.17.0)
     capybara (3.39.2)
@@ -1114,7 +1120,7 @@ DEPENDENCIES
   blacklight_range_limit (~> 6.3.3)
   bootsnap (~> 1.17)
   browse-everything (~> 1.1.2)
-  bulkrax (~> 9.1.0)
+  bulkrax!
   byebug (~> 11.1.3)
   capybara (~> 3.38)
   capybara-screenshot (~> 1.0.26)

--- a/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
+++ b/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+module Spot
+  # Bulkrax will display a link to an imported work's record but the ObjectFactory
+  # appears to be searching for a work's 'source_identifier' as the object's ID.
+  # This modifies the search to query Solr for the work's source_identifier and
+  # then return the object if it's found.
+  #
+  # @see config/initializers/spot_overrides.rb
+  module BulkraxObjectFactoryFindPatch
+    extend ActiveSupport::Concern
+
+    # For some reason, just overwriting :find_by_identifier wasn't working,
+    # so we'll write over the :find method to try finding by source_identifier
+    # first and then otherwise fall back to Bulkrax behavior.
+    #
+    # @see https://github.com/samvera/bulkrax/blob/v9.1.0/app/factories/bulkrax/object_factory_interface.rb#L317-L325
+    def find
+      find_by_source_identifier || super
+    end
+
+    def find_by_source_identifier
+      return unless attributes.key?('source_identifier') && attributes['source_identifier'].present?
+      self.class.find(Array.wrap(attributes['source_identifier']).first)
+    end
+
+    module ClassMethods
+      # @see https://github.com/samvera/bulkrax/blob/v9.1.0/app/factories/bulkrax/object_factory.rb#L57-L64
+      # @see https://github.com/samvera/bulkrax/blob/v9.1.0/app/factories/bulkrax/object_factory_interface.rb#L164-L168
+      def find(identifier)
+        id_doc = Hyrax::SolrService.get("source_identifier_ssim:#{identifier}").try(:[], 'response').try(:[], 'docs')&.first
+        return super(identifier) if id_doc.nil? || id_doc.try(:[], 'id').nil?
+
+        ActiveFedora::Base.find(id_doc['id'])
+      end
+    end
+  end
+end

--- a/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
+++ b/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
@@ -15,29 +15,59 @@ module Spot
     #
     # @see https://github.com/samvera/bulkrax/blob/v9.1.0/app/factories/bulkrax/object_factory_interface.rb#L317-L325
     def find
-      find_by_source_identifier || find_by_id || super
+      find_by_source_identifier || find_by_id|| search_by_identifier || nil
     end
 
     def find_by_source_identifier
-      Hyrax.logger.warn("find - source_identifier")
+      # Hyrax.logger.warn("find_by_source_identifier")
       return unless attributes.key?('source_identifier') && attributes['source_identifier'].present?
-      Hyrax.logger.warn("continue")
+      # Hyrax.logger.warn("continue")
       identifier = Array.wrap(attributes['source_identifier']).first
-      Hyrax.logger.warn(identifier)
+      # Hyrax.logger.warn(identifier)
       id_doc = Hyrax::SolrService.get("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene')
-      Hyrax.logger.warn(id_doc.to_s)
+      # Hyrax.logger.warn(id_doc.to_s)
       id_doc = id_doc.try(:[], 'response').try(:[], 'docs')&.first
-      Hyrax.logger.warn(id_doc.to_s)
+      # Hyrax.logger.warn(id_doc.to_s)
       return nil if id_doc.nil? || id_doc.try(:[], 'id').nil?
 
       ActiveFedora::Base.find(id_doc['id'])
     end
 
-    def find_by_id
-      Hyrax.logger.warn("find - id")
-      return unless attributes.key?('id') && attributes['id'].present?
-      Hyrax.logger.warn("continue")
-      ActiveFedora::Base.find(attributes['id'])
-    end
+    # def find_by_id
+    #   Hyrax.logger.warn("find_by_id")
+    #   return false if attributes[:id].blank?
+    #   Hyrax.logger.warn("continue")
+    #   # Rails / Ruby upgrade, we moved from :exists? to :exist?  However we want to continue (for a
+    #   # bit) to support older versions.
+    #   method_name = klass.respond_to?(:exist?) ? :exist? : :exists?
+    #   Hyrax.logger.warn("method name - " + method_name.to_s)
+    #   klass.find(attributes[:id]) if klass.send(method_name, attributes[:id])
+    # rescue Valkyrie::Persistence::ObjectNotFoundError
+    #   Hyrax.logger.warn("valkyrie error")
+    #   false
+    # end
+
+    # def find_by_id_alt
+    #   Hyrax.logger.warn("find_by_id_alt")
+    #   return unless attributes.key?('id') && attributes['id'].present?
+    #   Hyrax.logger.warn("continue")
+    #   ActiveFedora::Base.find(attributes['id'])
+    # end
+
+    # def search_by_identifier
+    #   Hyrax.logger.warn("find_by_source_identifier")
+    #   return false if source_identifier_value.blank?
+    #   Hyrax.logger.warn("continue")
+    #   Hyrax.logger.warn("klass - " + klass.to_s)
+    #   Hyrax.logger.warn("work_identifier_search_field - " + work_identifier_search_field.to_s)
+    #   Hyrax.logger.warn("source_identifier_value - " + source_identifier_value.to_s)
+    #   Hyrax.logger.warn("work_identifier - " + work_identifier.to_s)
+    #   self.class.search_by_property(
+    #     klass: klass,
+    #     search_field: work_identifier_search_field,
+    #     value: source_identifier_value,
+    #     name_field: work_identifier
+    #   )
+    # end
   end
 end

--- a/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
+++ b/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
@@ -15,15 +15,22 @@ module Spot
     #
     # @see https://github.com/samvera/bulkrax/blob/v9.1.0/app/factories/bulkrax/object_factory_interface.rb#L317-L325
     def find
-      find_by_source_identifier || super
+      find_by_source_identifier || find_by_id || super
     end
 
     def find_by_source_identifier
-      sleep (2)
       Hyrax.logger.warn("find - source_identifier")
       return unless attributes.key?('source_identifier') && attributes['source_identifier'].present?
       Hyrax.logger.warn("continue")
-      self.class.find(Array.wrap(attributes['source_identifier']).first)
+      identifier = Array.wrap(attributes['source_identifier']).first
+      Hyrax.logger.warn(identifier)
+      id_doc = Hyrax::SolrService.get("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene')
+      Hyrax.logger.warn(id_doc.to_s)
+      id_doc = id_doc.try(:[], 'response').try(:[], 'docs')&.first
+      Hyrax.logger.warn(id_doc.to_s)
+      return nil if id_doc.nil? || id_doc.try(:[], 'id').nil?
+
+      ActiveFedora::Base.find(id_doc['id'])
     end
 
     def find_by_id
@@ -31,22 +38,6 @@ module Spot
       return unless attributes.key?('id') && attributes['id'].present?
       Hyrax.logger.warn("continue")
       ActiveFedora::Base.find(attributes['id'])
-    end
-
-    module ClassMethods
-      # @see https://github.com/samvera/bulkrax/blob/v9.1.0/app/factories/bulkrax/object_factory.rb#L57-L64
-      # @see https://github.com/samvera/bulkrax/blob/v9.1.0/app/factories/bulkrax/object_factory_interface.rb#L164-L168
-      def find(identifier)
-        Hyrax.logger.warn("find - identifier")
-        Hyrax.logger.warn(identifier)
-        id_doc = Hyrax::SolrService.get("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene')
-        Hyrax.logger.warn(id_doc.to_s)
-        id_doc = id_doc.try(:[], 'response').try(:[], 'docs')&.first
-        Hyrax.logger.warn(id_doc.to_s)
-        return super(identifier) if id_doc.nil? || id_doc.try(:[], 'id').nil?
-
-        ActiveFedora::Base.find(id_doc['id'])
-      end
     end
   end
 end

--- a/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
+++ b/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
@@ -31,16 +31,18 @@ module Spot
       find_by_source_identifier || find_by_id || search_by_identifier || nil
     end
 
-    # This method modifies the search to query Solr for the work's
-    # source_identifier and then returns the object if it's found.
-    def find_by_source_identifier
-      return unless attributes.key?('source_identifier') && attributes['source_identifier'].present?
-      identifier = Array.wrap(attributes['source_identifier']).first
-      id_doc = Hyrax::SolrService.get("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene')
-      id_doc = id_doc.try(:[], 'response').try(:[], 'docs')&.first
-      return nil if id_doc.nil? || id_doc.try(:[], 'id').nil?
+    module ClassMethods
+      # This method modifies the search to query Solr for the work's
+      # source_identifier and then returns the object if it's found.
+      def find_by_source_identifier
+        return unless attributes.key?('source_identifier') && attributes['source_identifier'].present?
+        identifier = Array.wrap(attributes['source_identifier']).first
+        id_doc = Hyrax::SolrService.get("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene')
+        id_doc = id_doc.try(:[], 'response').try(:[], 'docs')&.first
+        return nil if id_doc.nil? || id_doc.try(:[], 'id').nil?
 
-      ActiveFedora::Base.find(id_doc['id'])
+        ActiveFedora::Base.find(id_doc['id'])
+      end
     end
   end
 end

--- a/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
+++ b/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
@@ -43,6 +43,15 @@ module Spot
 
         ActiveFedora::Base.find(id_doc['id'])
       end
+
+      # We have to implement these for testing purposes.
+      def find_by_id
+        super
+      end
+
+      def search_by_identifier
+        super
+      end
     end
   end
 end

--- a/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
+++ b/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
@@ -19,15 +19,30 @@ module Spot
     end
 
     def find_by_source_identifier
+      sleep (2)
+      Hyrax.logger.warn("find - source_identifier")
       return unless attributes.key?('source_identifier') && attributes['source_identifier'].present?
+      Hyrax.logger.warn("continue")
       self.class.find(Array.wrap(attributes['source_identifier']).first)
+    end
+
+    def find_by_id
+      Hyrax.logger.warn("find - id")
+      return unless attributes.key?('id') && attributes['id'].present?
+      Hyrax.logger.warn("continue")
+      ActiveFedora::Base.find(attributes['id'])
     end
 
     module ClassMethods
       # @see https://github.com/samvera/bulkrax/blob/v9.1.0/app/factories/bulkrax/object_factory.rb#L57-L64
       # @see https://github.com/samvera/bulkrax/blob/v9.1.0/app/factories/bulkrax/object_factory_interface.rb#L164-L168
       def find(identifier)
-        id_doc = Hyrax::SolrService.get("source_identifier_ssim:#{identifier}").try(:[], 'response').try(:[], 'docs')&.first
+        Hyrax.logger.warn("find - identifier")
+        Hyrax.logger.warn(identifier)
+        id_doc = Hyrax::SolrService.get("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene')
+        Hyrax.logger.warn(id_doc.to_s)
+        id_doc = id_doc.try(:[], 'response').try(:[], 'docs')&.first
+        Hyrax.logger.warn(id_doc.to_s)
         return super(identifier) if id_doc.nil? || id_doc.try(:[], 'id').nil?
 
         ActiveFedora::Base.find(id_doc['id'])

--- a/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
+++ b/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
@@ -1,73 +1,46 @@
 # frozen_string_literal: true
 module Spot
-  # Bulkrax will display a link to an imported work's record but the ObjectFactory
-  # appears to be searching for a work's 'source_identifier' as the object's ID.
-  # This modifies the search to query Solr for the work's source_identifier and
-  # then return the object if it's found.
+  # We made this patch because there are two places that the original ‘find’
+  # method in Bulkrax was failing to perform. First, Bulkrax will display a link
+  # to an imported work's record but the ObjectFactory appears to be searching
+  # for a work's 'source_identifier' as the object's ID. The second is that the ‘find’
+  # Method is what is used to match and object with a collection at ingest, also
+  # using 'source_identifier' as the object's ID. We believe that both of these
+  # problems arise from our setup being on Hyrax 3.6.0 and unvalkyrized, and
+  # that we can retire this patch once larger upgrades are made. This patch adds
+  # a new method, ‘find_by_source_identifier’, which is added to the front of the
+  # queue of methods to try in ‘find’. Notably, ‘find_by_source_identifier’ does not
+  # succeed when called during ingest to make the link, but for some reason truly
+  # unknown to us, if this method is called before ‘search_by_identifier’, that
+  # method then succeeds where it would typically fail. The order of those methods
+  # being switched does not produce the same result, both methods fail in that case.
+  # However, once the CreateRelationshipsJob stage is reached,
+  # ‘find_by_source_identifier’ always succeeds where ‘search_by_identifier’ always
+  # fails. Truly incomprehensible. Nonetheless, this order seems to fulfill all desired
+  # functions.
   #
   # @see config/initializers/spot_overrides.rb
   module BulkraxObjectFactoryFindPatch
     extend ActiveSupport::Concern
 
-    # For some reason, just overwriting :find_by_identifier wasn't working,
-    # so we'll write over the :find method to try finding by source_identifier
-    # first and then otherwise fall back to Bulkrax behavior.
+    # We have to overwrite this behavior to add 'find_by_source_identifier'
+    # to the queue of methods to try.
     #
     # @see https://github.com/samvera/bulkrax/blob/v9.1.0/app/factories/bulkrax/object_factory_interface.rb#L317-L325
     def find
-      find_by_source_identifier || find_by_id|| search_by_identifier || nil
+      find_by_source_identifier || find_by_id || search_by_identifier || nil
     end
 
+    # This method modifies the search to query Solr for the work's
+    # source_identifier and then returns the object if it's found.
     def find_by_source_identifier
-      # Hyrax.logger.warn("find_by_source_identifier")
       return unless attributes.key?('source_identifier') && attributes['source_identifier'].present?
-      # Hyrax.logger.warn("continue")
       identifier = Array.wrap(attributes['source_identifier']).first
-      # Hyrax.logger.warn(identifier)
       id_doc = Hyrax::SolrService.get("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene')
-      # Hyrax.logger.warn(id_doc.to_s)
       id_doc = id_doc.try(:[], 'response').try(:[], 'docs')&.first
-      # Hyrax.logger.warn(id_doc.to_s)
       return nil if id_doc.nil? || id_doc.try(:[], 'id').nil?
 
       ActiveFedora::Base.find(id_doc['id'])
     end
-
-    # def find_by_id
-    #   Hyrax.logger.warn("find_by_id")
-    #   return false if attributes[:id].blank?
-    #   Hyrax.logger.warn("continue")
-    #   # Rails / Ruby upgrade, we moved from :exists? to :exist?  However we want to continue (for a
-    #   # bit) to support older versions.
-    #   method_name = klass.respond_to?(:exist?) ? :exist? : :exists?
-    #   Hyrax.logger.warn("method name - " + method_name.to_s)
-    #   klass.find(attributes[:id]) if klass.send(method_name, attributes[:id])
-    # rescue Valkyrie::Persistence::ObjectNotFoundError
-    #   Hyrax.logger.warn("valkyrie error")
-    #   false
-    # end
-
-    # def find_by_id_alt
-    #   Hyrax.logger.warn("find_by_id_alt")
-    #   return unless attributes.key?('id') && attributes['id'].present?
-    #   Hyrax.logger.warn("continue")
-    #   ActiveFedora::Base.find(attributes['id'])
-    # end
-
-    # def search_by_identifier
-    #   Hyrax.logger.warn("find_by_source_identifier")
-    #   return false if source_identifier_value.blank?
-    #   Hyrax.logger.warn("continue")
-    #   Hyrax.logger.warn("klass - " + klass.to_s)
-    #   Hyrax.logger.warn("work_identifier_search_field - " + work_identifier_search_field.to_s)
-    #   Hyrax.logger.warn("source_identifier_value - " + source_identifier_value.to_s)
-    #   Hyrax.logger.warn("work_identifier - " + work_identifier.to_s)
-    #   self.class.search_by_property(
-    #     klass: klass,
-    #     search_field: work_identifier_search_field,
-    #     value: source_identifier_value,
-    #     name_field: work_identifier
-    #   )
-    # end
   end
 end

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -140,11 +140,6 @@ Rails.application.config.to_prepare do
     end
   end
 
-  Bulkrax::ObjectFactory.class_eval do
-    class << self
-      prepend Spot::BulkraxObjectFactoryFindPatch::ClassMethods
-    end
-  end
   Bulkrax::ObjectFactory.prepend(Spot::BulkraxObjectFactoryFindPatch)
 
   # To be honest, I'm not sure why the Hyrax code doesn't work as-is,

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -140,6 +140,11 @@ Rails.application.config.to_prepare do
     end
   end
 
+  Bulkrax::ObjectFactory.class_eval do
+    class << self
+      prepend Spot::BulkraxObjectFactoryFindPatch::ClassMethods
+    end
+  end
   Bulkrax::ObjectFactory.prepend(Spot::BulkraxObjectFactoryFindPatch)
 
   # To be honest, I'm not sure why the Hyrax code doesn't work as-is,

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -293,7 +293,6 @@ Rails.application.config.to_prepare do
   # @see spec/matchers/bulkrax/application_matcher_spec.rb
   Bulkrax::ApplicationMatcher.prepend(Spot::BulkraxMatcherWhitespacePatch)
 
-
   # Modifying the Downloads Controller to not send an unauthorized status for requests.
   # The unauthorized status breaks the laf only thumbnail.
   #

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -140,6 +140,13 @@ Rails.application.config.to_prepare do
     end
   end
 
+  Bulkrax::ObjectFactory.class_eval do
+    class << self
+      prepend Spot::BulkraxObjectFactoryFindPatch::ClassMethods
+    end
+  end
+  Bulkrax::ObjectFactory.prepend(Spot::BulkraxObjectFactoryFindPatch)
+
   # To be honest, I'm not sure why the Hyrax code doesn't work as-is,
   # but rewriting the solr_params[:sort] assignment to this kinda
   # wonky one-liner seems to preserve user-selected sorting. ¯\_(ツ)_/¯
@@ -285,6 +292,7 @@ Rails.application.config.to_prepare do
   # @see app/services/concerns/spot/bulkrax_matcher_whitespace_patch.rb
   # @see spec/matchers/bulkrax/application_matcher_spec.rb
   Bulkrax::ApplicationMatcher.prepend(Spot::BulkraxMatcherWhitespacePatch)
+
 
   # Modifying the Downloads Controller to not send an unauthorized status for requests.
   # The unauthorized status breaks the laf only thumbnail.

--- a/spec/factories/concerns/spot/bulkrax_object_factory_find_patch_spec.rb
+++ b/spec/factories/concerns/spot/bulkrax_object_factory_find_patch_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+RSpec.describe BulkraxObjectFactoryFindPatch do
+  describe '#find' do
+    subject {find}
+    let(:mock_work) { instance_double(Hyrax::Work) }
+      
+    context "'find_by_source_identifier' returns the object"
+      before do 
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(mock_work)
+      end
+
+      expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+      expect(Bulkrax::ObjectFactory).to_not receive(:find_by_id)
+      expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
+
+      it {is_expected.to eq mock_work}
+    end
+
+    context "'find_by_id' returns the object"
+      before do 
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(mock_work)
+      end
+
+      expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+      expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
+      expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
+
+      it {is_expected.to eq mock_work}
+    end
+
+    context "'search_by_identifier' returns the object"
+      before do 
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(nil)
+        allow(Bulkrax::ObjectFactory).to receive(:search_by_identifier).and_return(mock_work)
+      end
+
+      expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+      expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
+      expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
+
+      it {is_expected.to eq mock_work}
+    end
+
+    context "all methods return nil"
+      before do 
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(nil)
+        allow(Bulkrax::ObjectFactory).to receive(:search_by_identifier).and_return(nil)
+      end
+
+      expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+      expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
+      expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
+
+      it {is_expected.to eq nil}
+    end
+  end
+end

--- a/spec/factories/concerns/spot/bulkrax_object_factory_find_patch_spec.rb
+++ b/spec/factories/concerns/spot/bulkrax_object_factory_find_patch_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe BulkraxObjectFactoryFindPatch do
     subject {find}
     let(:mock_work) { instance_double(Hyrax::Work) }
       
-    context "'find_by_source_identifier' returns the object"
+    context "'find_by_source_identifier' returns the object" do
       before do 
         allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(mock_work)
       end
@@ -16,7 +16,7 @@ RSpec.describe BulkraxObjectFactoryFindPatch do
       it {is_expected.to eq mock_work}
     end
 
-    context "'find_by_id' returns the object"
+    context "'find_by_id' returns the object" do
       before do 
         allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(mock_work)
@@ -29,7 +29,7 @@ RSpec.describe BulkraxObjectFactoryFindPatch do
       it {is_expected.to eq mock_work}
     end
 
-    context "'search_by_identifier' returns the object"
+    context "'search_by_identifier' returns the object" do
       before do 
         allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(nil)
@@ -43,7 +43,7 @@ RSpec.describe BulkraxObjectFactoryFindPatch do
       it {is_expected.to eq mock_work}
     end
 
-    context "all methods return nil"
+    context "all methods return nil" do
       before do 
         allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(nil)

--- a/spec/factories/concerns/spot/bulkrax_object_factory_find_patch_spec.rb
+++ b/spec/factories/concerns/spot/bulkrax_object_factory_find_patch_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe BulkraxObjectFactoryFindPatch do
   describe '#find' do
     subject { find }
     let(:mock_work) { instance_double(Hyrax::Work) }
-      
+
     context "'find_by_source_identifier' returns the object" do
       before do
         allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(mock_work)

--- a/spec/factories/concerns/spot/bulkrax_object_factory_find_patch_spec.rb
+++ b/spec/factories/concerns/spot/bulkrax_object_factory_find_patch_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 RSpec.describe BulkraxObjectFactoryFindPatch do
   describe '#find' do
-    subject {find}
+    subject { find }
     let(:mock_work) { instance_double(Hyrax::Work) }
       
     context "'find_by_source_identifier' returns the object" do
-      before do 
+      before do
         allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(mock_work)
       end
 
@@ -13,11 +13,11 @@ RSpec.describe BulkraxObjectFactoryFindPatch do
       expect(Bulkrax::ObjectFactory).to_not receive(:find_by_id)
       expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
 
-      it {is_expected.to eq mock_work}
+      it { is_expected.to eq mock_work }
     end
 
     context "'find_by_id' returns the object" do
-      before do 
+      before do
         allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(mock_work)
       end
@@ -26,11 +26,11 @@ RSpec.describe BulkraxObjectFactoryFindPatch do
       expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
       expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
 
-      it {is_expected.to eq mock_work}
+      it { is_expected.to eq mock_work }
     end
 
     context "'search_by_identifier' returns the object" do
-      before do 
+      before do
         allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:search_by_identifier).and_return(mock_work)
@@ -40,11 +40,11 @@ RSpec.describe BulkraxObjectFactoryFindPatch do
       expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
       expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
 
-      it {is_expected.to eq mock_work}
+      it { is_expected.to eq mock_work }
     end
 
     context "all methods return nil" do
-      before do 
+      before do
         allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:search_by_identifier).and_return(nil)
@@ -54,7 +54,7 @@ RSpec.describe BulkraxObjectFactoryFindPatch do
       expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
       expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
 
-      it {is_expected.to eq nil}
+      it { is_expected.to eq nil }
     end
   end
 end

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Bulkrax::ObjectFactory do
 
     let(:mock_attributes) { instance_double(ActiveSupport::HashWithIndifferentAccess) }
 
-    before(:each) { attributes = mock_attributes }
+    before(:each) { :attributes = mock_attributes }
 
     context "there is no source_identifier" do
       before do

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe BulkraxObjectFactoryFindPatch do
+RSpec.describe Bulkrax::ObjectFactory do
   describe '#find' do
     subject { find }
     let(:mock_work) { instance_double(Hyrax::Work) }

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Bulkrax::ObjectFactory do
 
     context "'find_by_source_identifier' returns the object" do
       before do
-        allow(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier).and_return(mock_work)
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(mock_work)
       end
 
       it "runs the first method only and returns the object" do
-        expect(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier)
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
         expect(Bulkrax::ObjectFactory).to_not receive(:find_by_id)
         expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
         is_expected.to eq mock_work
@@ -19,12 +19,12 @@ RSpec.describe Bulkrax::ObjectFactory do
 
     context "'find_by_id' returns the object" do
       before do
-        allow(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier).and_return(nil)
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(mock_work)
       end
 
       it "runs the first two methods only and returns the object" do
-        expect(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier)
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
         expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
         expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
         is_expected.to eq mock_work
@@ -33,13 +33,13 @@ RSpec.describe Bulkrax::ObjectFactory do
 
     context "'search_by_identifier' returns the object" do
       before do
-        allow(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier).and_return(nil)
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:search_by_identifier).and_return(mock_work)
       end
 
       it "runs all methods and returns the object" do
-        expect(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier)
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
         expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
         expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
         is_expected.to eq mock_work
@@ -48,13 +48,13 @@ RSpec.describe Bulkrax::ObjectFactory do
 
     context "all methods return nil" do
       before do
-        allow(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier).and_return(nil)
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:search_by_identifier).and_return(nil)
       end
 
       it "runs all methods and returns nil" do
-        expect(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier)
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
         expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
         expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
         is_expected.to eq nil

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Spot::BulkraxObjectFactoryFindPatch do
+RSpec.describe Bulkrax::ObjectFactory do
   describe '#find' do
     subject { find }
     let(:mock_work) { instance_double(Hyrax::Work) }

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -61,4 +61,52 @@ RSpec.describe Bulkrax::ObjectFactory do
       end
     end
   end
+
+  describe '#find_by_source_identifier' do
+    subject { described_class.find_by_source_identifier }
+
+    context "there is no source_identifier" do
+      let(:attributes) { { 'source_identifier': nil } }
+
+      it { is_expected.to eq nil }
+    end
+
+    context "there is a source_identifier" do
+      let(:identifier) { "test_0_0" }
+      let(:attributes) { { 'source_identifier': [identifier] } }
+
+      context "the solr query does not match with an object" do
+        before do
+          allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(nil)
+        end
+
+        it { is_expected.to eq nil }
+      end
+
+      context "the solr query matches with an object" do
+        context "the id is empty" do
+          let(:id_doc) { { 'response': { 'docs': [{ 'id': nil }] } } }
+
+          before do
+            allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
+          end
+
+          it { is_expected.to eq nil }
+        end
+        
+        context "the id is not empty" do
+          let(:id) { "0a0a0a0a"}
+          let(:id_doc) { { 'response': { 'docs': [{ 'id': id }] } } }
+          let(:mock_work) { instance_double(Hyrax::Work) }
+
+          before do
+            allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
+            allow(ActiveFedora::Base).to receive(:find).with(id).and_return(mock_work)
+          end
+
+          it { is_expected.to eq mock_work }
+        end
+      end
+    end
+  end
 end

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -66,22 +66,17 @@ RSpec.describe Bulkrax::ObjectFactory do
     subject { described_class.find_by_source_identifier }
 
     context "there is no source_identifier" do
-      let(:attributes) { { 'source_identifier': nil } }
-
-      before do
-        allow(Bulkrax::ObjectFactory).to receive(:attributes).and_return(attributes)
-      end
+      let(@attributes) { { 'source_identifier': nil } }
 
       it { is_expected.to eq nil }
     end
 
     context "there is a source_identifier" do
       let(:identifier) { "test_0_0" }
-      let(:attributes) { { 'source_identifier': [identifier] } }
+      let(@attributes) { { 'source_identifier': [identifier] } }
 
       context "the solr query does not match with an object" do
         before do
-          allow(Bulkrax::ObjectFactory).to receive(:attributes).and_return(attributes)
           allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(nil)
         end
 
@@ -93,7 +88,6 @@ RSpec.describe Bulkrax::ObjectFactory do
           let(:id_doc) { { 'response': { 'docs': [{ 'id': nil }] } } }
 
           before do
-            allow(Bulkrax::ObjectFactory).to receive(:attributes).and_return(attributes)
             allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
           end
 
@@ -106,7 +100,6 @@ RSpec.describe Bulkrax::ObjectFactory do
           let(:mock_work) { instance_double(Hyrax::Work) }
 
           before do
-            allow(Bulkrax::ObjectFactory).to receive(:attributes).and_return(attributes)
             allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
             allow(ActiveFedora::Base).to receive(:find).with(id).and_return(mock_work)
           end

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Bulkrax::ObjectFactory do
 
     let(:mock_attributes) { instance_double(ActiveSupport::HashWithIndifferentAccess) }
 
-    before(:each) { :attributes = mock_attributes }
+    before(:each) { attributes = mock_attributes } #rubocop:disable Lint/UselessAssignment
 
     context "there is no source_identifier" do
       before do

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -9,11 +9,12 @@ RSpec.describe Bulkrax::ObjectFactory do
         allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(mock_work)
       end
 
-      expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
-      expect(Bulkrax::ObjectFactory).to_not receive(:find_by_id)
-      expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
-
-      it { is_expected.to eq mock_work }
+      it "runs the first method only and returns the object" do
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+        expect(Bulkrax::ObjectFactory).to_not receive(:find_by_id)
+        expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
+        is_expected.to eq mock_work
+      end
     end
 
     context "'find_by_id' returns the object" do
@@ -22,11 +23,12 @@ RSpec.describe Bulkrax::ObjectFactory do
         allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(mock_work)
       end
 
-      expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
-      expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
-      expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
-
-      it { is_expected.to eq mock_work }
+      it "runs the first two methods only and returns the object" do
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
+        expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
+        is_expected.to eq mock_work
+      end
     end
 
     context "'search_by_identifier' returns the object" do
@@ -36,11 +38,12 @@ RSpec.describe Bulkrax::ObjectFactory do
         allow(Bulkrax::ObjectFactory).to receive(:search_by_identifier).and_return(mock_work)
       end
 
-      expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
-      expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
-      expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
-
-      it { is_expected.to eq mock_work }
+      it "runs all methods and returns the object" do
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
+        expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
+        is_expected.to eq mock_work
+      end
     end
 
     context "all methods return nil" do
@@ -50,11 +53,12 @@ RSpec.describe Bulkrax::ObjectFactory do
         allow(Bulkrax::ObjectFactory).to receive(:search_by_identifier).and_return(nil)
       end
 
-      expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
-      expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
-      expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
-
-      it { is_expected.to eq nil }
+      it "runs all methods and returns nil" do
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
+        expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
+        is_expected.to eq nil
+      end
     end
   end
 end

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -68,6 +68,10 @@ RSpec.describe Bulkrax::ObjectFactory do
     context "there is no source_identifier" do
       let(:attributes) { { 'source_identifier': nil } }
 
+      before do
+        allow(Bulkrax::ObjectFactory).to receive(:attributes).and_return(attributes)
+      end
+
       it { is_expected.to eq nil }
     end
 
@@ -77,6 +81,7 @@ RSpec.describe Bulkrax::ObjectFactory do
 
       context "the solr query does not match with an object" do
         before do
+          allow(Bulkrax::ObjectFactory).to receive(:attributes).and_return(attributes)
           allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(nil)
         end
 
@@ -88,6 +93,7 @@ RSpec.describe Bulkrax::ObjectFactory do
           let(:id_doc) { { 'response': { 'docs': [{ 'id': nil }] } } }
 
           before do
+            allow(Bulkrax::ObjectFactory).to receive(:attributes).and_return(attributes)
             allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
           end
 
@@ -100,6 +106,7 @@ RSpec.describe Bulkrax::ObjectFactory do
           let(:mock_work) { instance_double(Hyrax::Work) }
 
           before do
+            allow(Bulkrax::ObjectFactory).to receive(:attributes).and_return(attributes)
             allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
             allow(ActiveFedora::Base).to receive(:find).with(id).and_return(mock_work)
           end

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe Bulkrax::ObjectFactory do
   describe '#find' do
-    subject { find }
+    subject { described_class.find }
     let(:mock_work) { instance_double(Hyrax::Work) }
 
     context "'find_by_source_identifier' returns the object" do

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -88,19 +88,19 @@ RSpec.describe Bulkrax::ObjectFactory do
           let(:id_doc) { { 'response': { 'docs': [{ 'id': nil }] } } }
 
           before do
-            allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
+            allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{ identifier }", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
           end
 
           it { is_expected.to eq nil }
         end
-        
+
         context "the id is not empty" do
-          let(:id) { "0a0a0a0a"}
+          let(:id) { "0a0a0a0a" }
           let(:id_doc) { { 'response': { 'docs': [{ 'id': id }] } } }
           let(:mock_work) { instance_double(Hyrax::Work) }
 
           before do
-            allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
+            allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{ identifier }", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
             allow(ActiveFedora::Base).to receive(:find).with(id).and_return(mock_work)
           end
 

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -62,70 +62,70 @@ RSpec.describe Bulkrax::ObjectFactory do
     end
   end
 
-  describe '#find_by_source_identifier' do
-    subject { described_class.find_by_source_identifier }
+  # describe '#find_by_source_identifier' do
+  #   subject { described_class.find_by_source_identifier }
 
-    let(:mock_attributes) { instance_double(ActiveSupport::HashWithIndifferentAccess) }
+  #   let(:mock_attributes) { instance_double(ActiveSupport::HashWithIndifferentAccess) }
 
-    before(:each) { attributes = mock_attributes } # rubocop:disable Lint/UselessAssignment
+  #   before(:each) { attributes = mock_attributes } # rubocop:disable Lint/UselessAssignment
 
-    context "there is no source_identifier" do
-      before do
-        allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(false)
-      end
+  #   context "there is no source_identifier" do
+  #     before do
+  #       allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(false)
+  #     end
 
-      it { is_expected.to eq nil }
-    end
+  #     it { is_expected.to eq nil }
+  #   end
 
-    context "source_identifier is nil" do
-      before do
-        allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(true)
-        allow(mock_attributes).to receive(:[]).with('source_identifier').and_return(nil)
-      end
+  #   context "source_identifier is nil" do
+  #     before do
+  #       allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(true)
+  #       allow(mock_attributes).to receive(:[]).with('source_identifier').and_return(nil)
+  #     end
 
-      it { is_expected.to eq nil }
-    end
+  #     it { is_expected.to eq nil }
+  #   end
 
-    context "there is a source_identifier" do
-      let(:identifier) { "test_0_0" }
+  #   context "there is a source_identifier" do
+  #     let(:identifier) { "test_0_0" }
 
-      before do
-        allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(true)
-        allow(mock_attributes).to receive(:[]).with('source_identifier').and_return([identifier])
-      end
+  #     before do
+  #       allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(true)
+  #       allow(mock_attributes).to receive(:[]).with('source_identifier').and_return([identifier])
+  #     end
 
-      context "the solr query does not match with an object" do
-        before do
-          allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(nil)
-        end
+  #     context "the solr query does not match with an object" do
+  #       before do
+  #         allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(nil)
+  #       end
 
-        it { is_expected.to eq nil }
-      end
+  #       it { is_expected.to eq nil }
+  #     end
 
-      context "the solr query matches with an object" do
-        context "the id is empty" do
-          let(:id_doc) { { 'response': { 'docs': [{ 'id': nil }] } } }
+  #     context "the solr query matches with an object" do
+  #       context "the id is empty" do
+  #         let(:id_doc) { { 'response': { 'docs': [{ 'id': nil }] } } }
 
-          before do
-            allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
-          end
+  #         before do
+  #           allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
+  #         end
 
-          it { is_expected.to eq nil }
-        end
+  #         it { is_expected.to eq nil }
+  #       end
 
-        context "the id is not empty" do
-          let(:id) { "0a0a0a0a" }
-          let(:id_doc) { { 'response': { 'docs': [{ 'id': id }] } } }
-          let(:mock_work) { instance_double(Hyrax::Work) }
+  #       context "the id is not empty" do
+  #         let(:id) { "0a0a0a0a" }
+  #         let(:id_doc) { { 'response': { 'docs': [{ 'id': id }] } } }
+  #         let(:mock_work) { instance_double(Hyrax::Work) }
 
-          before do
-            allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
-            allow(ActiveFedora::Base).to receive(:find).with(id).and_return(mock_work)
-          end
+  #         before do
+  #           allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
+  #           allow(ActiveFedora::Base).to receive(:find).with(id).and_return(mock_work)
+  #         end
 
-          it { is_expected.to eq mock_work }
-        end
-      end
-    end
-  end
+  #         it { is_expected.to eq mock_work }
+  #       end
+  #     end
+  #   end
+  # end
 end

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
-RSpec.describe Bulkrax::ObjectFactory do
+RSpec.describe Spot::BulkraxObjectFactoryFindPatch do
   describe '#find' do
     subject { find }
     let(:mock_work) { instance_double(Hyrax::Work) }
 
     context "'find_by_source_identifier' returns the object" do
       before do
-        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(mock_work)
+        allow(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier).and_return(mock_work)
       end
 
       it "runs the first method only and returns the object" do
-        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+        expect(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier)
         expect(Bulkrax::ObjectFactory).to_not receive(:find_by_id)
         expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
         is_expected.to eq mock_work
@@ -19,12 +19,12 @@ RSpec.describe Bulkrax::ObjectFactory do
 
     context "'find_by_id' returns the object" do
       before do
-        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
+        allow(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(mock_work)
       end
 
       it "runs the first two methods only and returns the object" do
-        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+        expect(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier)
         expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
         expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
         is_expected.to eq mock_work
@@ -33,13 +33,13 @@ RSpec.describe Bulkrax::ObjectFactory do
 
     context "'search_by_identifier' returns the object" do
       before do
-        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
+        allow(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:search_by_identifier).and_return(mock_work)
       end
 
       it "runs all methods and returns the object" do
-        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+        expect(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier)
         expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
         expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
         is_expected.to eq mock_work
@@ -48,13 +48,13 @@ RSpec.describe Bulkrax::ObjectFactory do
 
     context "all methods return nil" do
       before do
-        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
+        allow(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(nil)
         allow(Bulkrax::ObjectFactory).to receive(:search_by_identifier).and_return(nil)
       end
 
       it "runs all methods and returns nil" do
-        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+        expect(Spot::BulkraxObjectFactoryFindPatch).to receive(:find_by_source_identifier)
         expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
         expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
         is_expected.to eq nil

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Bulkrax::ObjectFactory do
 
     let(:mock_attributes) { instance_double(ActiveSupport::HashWithIndifferentAccess) }
 
-    before(:each) { attributes = mock_attributes } #rubocop:disable Lint/UselessAssignment
+    before(:each) { attributes = mock_attributes } # rubocop:disable Lint/UselessAssignment
 
     context "there is no source_identifier" do
       before do

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Bulkrax::ObjectFactory do
           let(:id_doc) { { 'response': { 'docs': [{ 'id': nil }] } } }
 
           before do
-            allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{ identifier }", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
+            allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
           end
 
           it { is_expected.to eq nil }
@@ -100,7 +100,7 @@ RSpec.describe Bulkrax::ObjectFactory do
           let(:mock_work) { instance_double(Hyrax::Work) }
 
           before do
-            allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{ identifier }", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
+            allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
             allow(ActiveFedora::Base).to receive(:find).with(id).and_return(mock_work)
           end
 

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -65,11 +65,13 @@ RSpec.describe Bulkrax::ObjectFactory do
   describe '#find_by_source_identifier' do
     subject { described_class.find_by_source_identifier }
 
-    let(@attributes) { instance_double(ActiveSupport::HashWithIndifferentAccess) }
+    let(:mock_attributes) { instance_double(ActiveSupport::HashWithIndifferentAccess) }
+
+    before(:each) { @attributes = mock_attributes }
 
     context "there is no source_identifier" do
       before do
-        allow(@attributes).to receive(:key?).with('source_identifier').and_return(false)
+        allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(false)
       end
 
       it { is_expected.to eq nil }
@@ -77,8 +79,8 @@ RSpec.describe Bulkrax::ObjectFactory do
 
     context "source_identifier is nil" do
       before do
-        allow(@attributes).to receive(:key?).with('source_identifier').and_return(true)
-        allow(@attributes).to receive(:[]).with('source_identifier').and_return(nil)
+        allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(true)
+        allow(mock_attributes).to receive(:[]).with('source_identifier').and_return(nil)
       end
 
       it { is_expected.to eq nil }
@@ -88,8 +90,8 @@ RSpec.describe Bulkrax::ObjectFactory do
       let(:identifier) { "test_0_0" }
 
       before do
-        allow(@attributes).to receive(:key?).with('source_identifier').and_return(true)
-        allow(@attributes).to receive(:[]).with('source_identifier').and_return([identifier])
+        allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(true)
+        allow(mock_attributes).to receive(:[]).with('source_identifier').and_return([identifier])
       end
 
       context "the solr query does not match with an object" do

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Bulkrax::ObjectFactory do
 
     let(:mock_attributes) { instance_double(ActiveSupport::HashWithIndifferentAccess) }
 
-    before(:each) { @attributes = mock_attributes }
+    before(:each) { attributes = mock_attributes }
 
     context "there is no source_identifier" do
       before do

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -65,15 +65,32 @@ RSpec.describe Bulkrax::ObjectFactory do
   describe '#find_by_source_identifier' do
     subject { described_class.find_by_source_identifier }
 
+    let(@attributes) { instance_double(ActiveSupport::HashWithIndifferentAccess) }
+
     context "there is no source_identifier" do
-      let(@attributes) { { 'source_identifier': nil } }
+      before do
+        allow(@attributes).to receive(:key?).with('source_identifier').and_return(false)
+      end
+
+      it { is_expected.to eq nil }
+    end
+
+    context "source_identifier is nil" do
+      before do
+        allow(@attributes).to receive(:key?).with('source_identifier').and_return(true)
+        allow(@attributes).to receive(:[]).with('source_identifier').and_return(nil)
+      end
 
       it { is_expected.to eq nil }
     end
 
     context "there is a source_identifier" do
       let(:identifier) { "test_0_0" }
-      let(@attributes) { { 'source_identifier': [identifier] } }
+
+      before do
+        allow(@attributes).to receive(:key?).with('source_identifier').and_return(true)
+        allow(@attributes).to receive(:[]).with('source_identifier').and_return([identifier])
+      end
 
       context "the solr query does not match with an object" do
         before do


### PR DESCRIPTION
Upgrades to the newest version of bulkrax to fix the issue of imported works not successfully attaching to collections. A patch is included to fix inconsistencies with the object factory, but the patch is largely untested and behaves as a black box. This branch is shelved until after the upgrade to hyrax 4 and valkyrization to determine if it is necessary. 