### PR TITLE
Limit pdf viewer size to 65mb

### DIFF
--- a/app/helpers/pdf_viewer_helper.rb
+++ b/app/helpers/pdf_viewer_helper.rb
@@ -3,6 +3,16 @@
 # Helper methods to generate the PDFjs viewer and populate the search query
 # (if present)
 module PdfViewerHelper
+  # Whether or not to display a PDF file in the viewer
+  #
+  # @param [#file_size] file_set to test
+  # @param [Number] limit_mb size limit in megabytes
+  # @return [true,false]
+  def pdf_too_large_for_viewer?(file_set, limit_mb = 65)
+    file_size_in_mb = file_set.file_size.to_i / (1024 * 1024)
+    file_size_in_mb >= limit_mb
+  end
+
   # @param [String] path
   # @return [String] URL to the viewer
   def viewer_url(path)

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -3,9 +3,11 @@
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
     </div>
 
-    <% if (file_set.file_size/(1024*1024)) >= 65 %>
-        <div class="alert alert-warning">This file is <%= file_set.file_size/(1024*1024) %>mb, which is too large to display in browser. The file can still be downloaded to view.</div>
-
+    <% if pdf_too_large?(file_set) %>
+        <div class="alert alert-warning">
+            This file is <%= number_to_human_size(file_set.file_size) %>, which is too large to display in browser.
+            The file can still be downloaded to view.
+        </div>
     <% else %>
         <iframe id="pdf-viewer" width="100%" height="600px" frameborder="0"
                 scrolling="no" marginheight="0" marginwidth="0"

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -3,7 +3,7 @@
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
     </div>
 
-    <% if pdf_too_large?(file_set) %>
+    <% if pdf_too_large_for_viewer?(file_set) %>
         <div class="alert alert-warning">
             This file is <%= number_to_human_size(file_set.file_size) %>, which is too large to display in browser.
             The file can still be downloaded to view.

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -3,9 +3,14 @@
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
     </div>
 
-    <iframe id="pdf-viewer" width="100%" height="600px" frameborder="0"
-            scrolling="no" marginheight="0" marginwidth="0"
-            title="PDF Document" src="<%= viewer_url(download_path(file_set)) %>"></iframe>
+    <% if (file_set.file_size/(1024*1024)) >= 65 %>
+        <div class="alert alert-warning">This file is <%= file_set.file_size/(1024*1024) %>mb, which is too large to display in browser. The file can still be downloaded to view.</div>
+
+    <% else %>
+        <iframe id="pdf-viewer" width="100%" height="600px" frameborder="0"
+                scrolling="no" marginheight="0" marginwidth="0"
+                title="PDF Document" src="<%= viewer_url(download_path(file_set)) %>"></iframe>
+    <% end %>
 <% else %>
     <div>
       <%= image_tag thumbnail_url(file_set),

--- a/spec/features/show_publication_spec.rb
+++ b/spec/features/show_publication_spec.rb
@@ -36,6 +36,10 @@ RSpec.feature 'Show Publication page', js: false do
       .to receive(presenter_check_method)
       .and_return true
 
+    allow_any_instance_of(Hyrax::FileSetPresenter)
+      .to receive(:file_size)
+      .and_return 1
+
     visit item_base_url
   end
 

--- a/spec/features/show_student_work_spec.rb
+++ b/spec/features/show_student_work_spec.rb
@@ -42,6 +42,10 @@ RSpec.feature 'Show Student Work page', js: false do
       .to receive(presenter_check_method)
       .and_return true
 
+    allow_any_instance_of(Hyrax::FileSetPresenter)
+      .to receive(:file_size)
+      .and_return 1
+
     visit item_base_url
   end
 

--- a/spec/helpers/pdf_viewer_helper_spec.rb
+++ b/spec/helpers/pdf_viewer_helper_spec.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 RSpec.describe PdfViewerHelper do
+  describe '#pdf_too_large_for_viewer?' do
+    subject { helper.pdf_too_large_for_viewer?(file_set) }
+
+    let(:file_set) { instance_double(Hyrax::FileSetPresenter, file_size: file_size_mb.to_s) }
+
+    context 'when the PDF is too large' do
+      let(:file_size_mb) { 66.75 * (1024 * 1024) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the PDF is just right' do
+      let(:file_size_mb) { 20.1 * (1024 * 1024) }
+
+      it { is_expected.to be false }
+    end
+  end
+
   describe '#viewer_url' do
     subject { helper.viewer_url(path) }
 


### PR DESCRIPTION
Pdfs over 65mb will now not display in the browser. Instead, an alert will tell the user to download the file for viewing