### PR TITLE
[hyrax 5] prevent cas logout loop

### DIFF
--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -21,10 +21,7 @@
           <%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path(current_user), class: "dropdown-item" %>
         <% end %>
         <div class="dropdown-divider"></div>
-        <%= button_to t("hyrax.toolbar.profile.logout"),
-                      main_app.destroy_user_session_path,
-                      class: "dropdown-item",
-                      method: ::Devise.sign_out_via %>
+        <%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path, class: "dropdown-item" %>
       </div>
     </li>
   <% else %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,6 @@ require_relative 'boot'
 
 require 'rails/all'
 require 'sprockets/es6'
-require 'rack-cas/session_store/active_record'
 
 # Some gems in the Samvera stack use the 'deprecation' gem instead of
 # ActiveSupport::Deprecation calls, so we need to also set _that_ gem's

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,8 +9,6 @@ Rails.application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
-  Rails.logger.debug 'starting with classes cached' if ENV['ENABLE_CLASS_CACHE'] == 'true'
-
   # Rails' default is to not eager_load in development for speed's sake (I think?)
   # but we were encountering a lot of Missing Constant errors in our Sidekiq logs
   # and eager_loding classes seemed to help fix that.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   ##
 
   # user routes
-  devise_for :users
+  devise_for :users, sign_out_via: :get
 
   # need to call `root` before mounting our engines
   root 'spot/homepage#index'


### PR DESCRIPTION
the hyrax 5 navbar uses a button to send a `:post` or `:delete` request to log out and this conflicts with the `devise_cas_authenticatable` gem's controller in a way that causes a redirect back to the cas login screen. replacing the button with a hyperlink prevents this.