### PR TITLE
Bulkrax collections fix

### DIFF
--- a/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
+++ b/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
@@ -31,27 +31,23 @@ module Spot
       find_by_source_identifier || find_by_id || search_by_identifier || nil
     end
 
-    module ClassMethods
-      # This method modifies the search to query Solr for the work's
-      # source_identifier and then returns the object if it's found.
-      def find_by_source_identifier
-        return unless attributes.key?('source_identifier') && attributes['source_identifier'].present?
-        identifier = Array.wrap(attributes['source_identifier']).first
-        id_doc = Hyrax::SolrService.get("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene')
-        id_doc = id_doc.try(:[], 'response').try(:[], 'docs')&.first
-        return nil if id_doc.nil? || id_doc.try(:[], 'id').nil?
+    def find_by_source_identifier
+      return unless attributes.key?('source_identifier') && attributes['source_identifier'].present?
+      identifier = Array.wrap(attributes['source_identifier']).first
+      id_doc = Hyrax::SolrService.get("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene')
+      id_doc = id_doc.try(:[], 'response').try(:[], 'docs')&.first
+      return nil if id_doc.nil? || id_doc.try(:[], 'id').nil?
 
-        ActiveFedora::Base.find(id_doc['id'])
-      end
+      ActiveFedora::Base.find(id_doc['id'])
+    end
 
-      # We have to implement these for testing purposes.
-      def find_by_id
-        super
-      end
+    # We have to implement these for testing purposes.
+    def find_by_id
+      super
+    end
 
-      def search_by_identifier
-        super
-      end
+    def search_by_identifier
+      super
     end
   end
 end

--- a/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
+++ b/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+module Spot
+  # We made this patch because there are two places that the original ‘find’
+  # method in Bulkrax was failing to perform. First, Bulkrax will display a link
+  # to an imported work's record but the ObjectFactory appears to be searching
+  # for a work's 'source_identifier' as the object's ID. The second is that the ‘find’
+  # Method is what is used to match and object with a collection at ingest, also
+  # using 'source_identifier' as the object's ID. We believe that both of these
+  # problems arise from our setup being on Hyrax 3.6.0 and unvalkyrized, and
+  # that we can retire this patch once larger upgrades are made. This patch adds
+  # a new method, ‘find_by_source_identifier’, which is added to the front of the
+  # queue of methods to try in ‘find’. Notably, ‘find_by_source_identifier’ does not
+  # succeed when called during ingest to make the link, but for some reason truly
+  # unknown to us, if this method is called before ‘search_by_identifier’, that
+  # method then succeeds where it would typically fail. The order of those methods
+  # being switched does not produce the same result, both methods fail in that case.
+  # However, once the CreateRelationshipsJob stage is reached,
+  # ‘find_by_source_identifier’ always succeeds where ‘search_by_identifier’ always
+  # fails. Truly incomprehensible. Nonetheless, this order seems to fulfill all desired
+  # functions.
+  #
+  # @see config/initializers/spot_overrides.rb
+  module BulkraxObjectFactoryFindPatch
+    extend ActiveSupport::Concern
+
+    # We have to overwrite this behavior to add 'find_by_source_identifier'
+    # to the queue of methods to try.
+    #
+    # @see https://github.com/samvera/bulkrax/blob/v9.1.0/app/factories/bulkrax/object_factory_interface.rb#L317-L325
+    def find
+      find_by_source_identifier || find_by_id || search_by_identifier || nil
+    end
+
+    module ClassMethods
+      # This method modifies the search to query Solr for the work's
+      # source_identifier and then returns the object if it's found.
+      def find_by_source_identifier
+        return unless attributes.key?('source_identifier') && attributes['source_identifier'].present?
+        identifier = Array.wrap(attributes['source_identifier']).first
+        id_doc = Hyrax::SolrService.get("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene')
+        id_doc = id_doc.try(:[], 'response').try(:[], 'docs')&.first
+        return nil if id_doc.nil? || id_doc.try(:[], 'id').nil?
+
+        ActiveFedora::Base.find(id_doc['id'])
+      end
+
+      # We have to implement these for testing purposes.
+      def find_by_id
+        super
+      end
+
+      def search_by_identifier
+        super
+      end
+    end
+  end
+end

--- a/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
+++ b/app/factories/concerns/spot/bulkrax_object_factory_find_patch.rb
@@ -42,6 +42,7 @@ module Spot
     end
 
     # We have to implement these for testing purposes.
+    # :nocov:
     def find_by_id
       super
     end
@@ -49,5 +50,6 @@ module Spot
     def search_by_identifier
       super
     end
+    # :nocov:
   end
 end

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -433,4 +433,12 @@ Rails.application.reloader.to_prepare do
       User.find_by_user_key(user_key) || User.create!(user_key_field => user_key)
     end
   end
+
+  Bulkrax::ObjectFactory.class_eval do
+    class << self
+      prepend Spot::BulkraxObjectFactoryFindPatch::ClassMethods
+    end
+  end
+  
+  Bulkrax::ObjectFactory.prepend(Spot::BulkraxObjectFactoryFindPatch)
 end

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -439,6 +439,6 @@ Rails.application.reloader.to_prepare do
       prepend Spot::BulkraxObjectFactoryFindPatch::ClassMethods
     end
   end
-  
+
   Bulkrax::ObjectFactory.prepend(Spot::BulkraxObjectFactoryFindPatch)
 end

--- a/config/initializers/spot_overrides.rb
+++ b/config/initializers/spot_overrides.rb
@@ -434,11 +434,5 @@ Rails.application.reloader.to_prepare do
     end
   end
 
-  Bulkrax::ObjectFactory.class_eval do
-    class << self
-      prepend Spot::BulkraxObjectFactoryFindPatch::ClassMethods
-    end
-  end
-
   Bulkrax::ObjectFactory.prepend(Spot::BulkraxObjectFactoryFindPatch)
 end

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+RSpec.describe Bulkrax::ObjectFactory do
+  describe '#find' do
+    subject { described_class.find }
+    let(:mock_work) { instance_double(Hyrax::Work) }
+
+    context "'find_by_source_identifier' returns the object" do
+      before do
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(mock_work)
+      end
+
+      it "runs the first method only and returns the object" do
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+        expect(Bulkrax::ObjectFactory).to_not receive(:find_by_id)
+        expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
+        is_expected.to eq mock_work
+      end
+    end
+
+    context "'find_by_id' returns the object" do
+      before do
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(mock_work)
+      end
+
+      it "runs the first two methods only and returns the object" do
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
+        expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
+        is_expected.to eq mock_work
+      end
+    end
+
+    context "'search_by_identifier' returns the object" do
+      before do
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(nil)
+        allow(Bulkrax::ObjectFactory).to receive(:search_by_identifier).and_return(mock_work)
+      end
+
+      it "runs all methods and returns the object" do
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
+        expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
+        is_expected.to eq mock_work
+      end
+    end
+
+    context "all methods return nil" do
+      before do
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
+        allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(nil)
+        allow(Bulkrax::ObjectFactory).to receive(:search_by_identifier).and_return(nil)
+      end
+
+      it "runs all methods and returns nil" do
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
+        expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
+        expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
+        is_expected.to eq nil
+      end
+    end
+  end
+
+  # describe '#find_by_source_identifier' do
+  #   subject { described_class.find_by_source_identifier }
+
+  #   let(:mock_attributes) { instance_double(ActiveSupport::HashWithIndifferentAccess) }
+
+  #   before(:each) { attributes = mock_attributes } # rubocop:disable Lint/UselessAssignment
+
+  #   context "there is no source_identifier" do
+  #     before do
+  #       allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(false)
+  #     end
+
+  #     it { is_expected.to eq nil }
+  #   end
+
+  #   context "source_identifier is nil" do
+  #     before do
+  #       allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(true)
+  #       allow(mock_attributes).to receive(:[]).with('source_identifier').and_return(nil)
+  #     end
+
+  #     it { is_expected.to eq nil }
+  #   end
+
+  #   context "there is a source_identifier" do
+  #     let(:identifier) { "test_0_0" }
+
+  #     before do
+  #       allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(true)
+  #       allow(mock_attributes).to receive(:[]).with('source_identifier').and_return([identifier])
+  #     end
+
+  #     context "the solr query does not match with an object" do
+  #       before do
+  #         allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(nil)
+  #       end
+
+  #       it { is_expected.to eq nil }
+  #     end
+
+  #     context "the solr query matches with an object" do
+  #       context "the id is empty" do
+  #         let(:id_doc) { { 'response': { 'docs': [{ 'id': nil }] } } }
+
+  #         before do
+  #           allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
+  #         end
+
+  #         it { is_expected.to eq nil }
+  #       end
+
+  #       context "the id is not empty" do
+  #         let(:id) { "0a0a0a0a" }
+  #         let(:id_doc) { { 'response': { 'docs': [{ 'id': id }] } } }
+  #         let(:mock_work) { instance_double(Hyrax::Work) }
+
+  #         before do
+  #           allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
+  #           allow(ActiveFedora::Base).to receive(:find).with(id).and_return(mock_work)
+  #         end
+
+  #         it { is_expected.to eq mock_work }
+  #       end
+  #     end
+  #   end
+  # end
+end

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 RSpec.describe Bulkrax::ObjectFactory do
-  subject(:factory) { 
-                      described_class.new(
-                        attributes: {},
-                        source_identifier_value: :source_identifier,
-                        work_identifier: :source_identifier,
-                        work_identifier_search_field: 'source_identifier_ssim'
-                      )
-                    }
+  subject(:factory) do
+    described_class.new(
+      attributes: {},
+      source_identifier_value: :source_identifier,
+      work_identifier: :source_identifier,
+      work_identifier_search_field: 'source_identifier_ssim'
+    )
+  end
 
   let(:mock_user) { instance_double(User) }
 
@@ -119,7 +119,7 @@ RSpec.describe Bulkrax::ObjectFactory do
 
       context "the solr query matches with an object" do
         context "the id is empty" do
-          let(:id_doc) { { "response"=> { "docs"=> [{ "id"=> nil }] } } }
+          let(:id_doc) { { "response" => { "docs" => [{ "id" => nil }] } } }
 
           before do
             allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
@@ -130,7 +130,7 @@ RSpec.describe Bulkrax::ObjectFactory do
 
         context "the id is not empty" do
           let(:id) { "0a0a0a0a" }
-          let(:id_doc) { { "response"=> { "docs"=> [{ "id"=> id }] } } }
+          let(:id_doc) { { "response" => { "docs" => [{ "id" => id }] } } }
           let(:mock_work) { instance_double(Hyrax::Work) }
 
           before do

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe Bulkrax::ObjectFactory do
-  subject(:factory)
+  subject(:factory) =>
     { 
       described_class.new(
         attributes: {},

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -1,19 +1,18 @@
 # frozen_string_literal: true
 RSpec.describe Bulkrax::ObjectFactory do
-  subject(:factory) =>
-    { 
-      described_class.new(
-        attributes: {},
-        source_identifier_value: :source_identifier,
-        work_identifier: :source,
-        work_identifier_search_field: 'source_sim'
-      )
-    }
+  subject(:factory) { 
+                      described_class.new(
+                        attributes: {},
+                        source_identifier_value: :source_identifier,
+                        work_identifier: :source,
+                        work_identifier_search_field: 'source_sim'
+                      )
+                    }
 
-  let(:mock_user) { instance_double(Spot::User) }
+  let(:mock_user) { instance_double(User) }
 
   before do
-    allow(Spot::User).to receive(:find_or_create_system_user).and_return(mock_user)
+    allow(User).to receive(:find_or_create_system_user).and_return(mock_user)
   end
 
   describe '#find' do

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -1,62 +1,74 @@
 # frozen_string_literal: true
 RSpec.describe Bulkrax::ObjectFactory do
+  subject(:factory) { described_class.new(
+        attributes: {},
+        source_identifier_value: :source_identifier,
+        work_identifier: :source,
+        work_identifier_search_field: 'source_sim') }
+
+  let(:mock_user) { instance_double(Spot::User) }
+
+  before do
+    allow(Spot::User).to receive(:find_or_create_system_user).and_return(mock_user)
+  end
+
   describe '#find' do
-    subject { described_class.find }
+    subject { factory.find }
     let(:mock_work) { instance_double(Hyrax::Work) }
 
     context "'find_by_source_identifier' returns the object" do
       before do
-        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(mock_work)
+        allow(factory).to receive(:find_by_source_identifier).and_return(mock_work)
       end
 
       it "runs the first method only and returns the object" do
-        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
-        expect(Bulkrax::ObjectFactory).to_not receive(:find_by_id)
-        expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
+        expect(factory).to receive(:find_by_source_identifier)
+        expect(factory).to_not receive(:find_by_id)
+        expect(factory).to_not receive(:search_by_identifier)
         is_expected.to eq mock_work
       end
     end
 
     context "'find_by_id' returns the object" do
       before do
-        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
-        allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(mock_work)
+        allow(factory).to receive(:find_by_source_identifier).and_return(nil)
+        allow(factory).to receive(:find_by_id).and_return(mock_work)
       end
 
       it "runs the first two methods only and returns the object" do
-        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
-        expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
-        expect(Bulkrax::ObjectFactory).to_not receive(:search_by_identifier)
+        expect(factory).to receive(:find_by_source_identifier)
+        expect(factory).to receive(:find_by_id)
+        expect(factory).to_not receive(:search_by_identifier)
         is_expected.to eq mock_work
       end
     end
 
     context "'search_by_identifier' returns the object" do
       before do
-        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
-        allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(nil)
-        allow(Bulkrax::ObjectFactory).to receive(:search_by_identifier).and_return(mock_work)
+        allow(factory).to receive(:find_by_source_identifier).and_return(nil)
+        allow(factory).to receive(:find_by_id).and_return(nil)
+        allow(factory).to receive(:search_by_identifier).and_return(mock_work)
       end
 
       it "runs all methods and returns the object" do
-        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
-        expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
-        expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
+        expect(factory).to receive(:find_by_source_identifier)
+        expect(factory).to receive(:find_by_id)
+        expect(factory).to receive(:search_by_identifier)
         is_expected.to eq mock_work
       end
     end
 
     context "all methods return nil" do
       before do
-        allow(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier).and_return(nil)
-        allow(Bulkrax::ObjectFactory).to receive(:find_by_id).and_return(nil)
-        allow(Bulkrax::ObjectFactory).to receive(:search_by_identifier).and_return(nil)
+        allow(factory).to receive(:find_by_source_identifier).and_return(nil)
+        allow(factory).to receive(:find_by_id).and_return(nil)
+        allow(factory).to receive(:search_by_identifier).and_return(nil)
       end
 
       it "runs all methods and returns nil" do
-        expect(Bulkrax::ObjectFactory).to receive(:find_by_source_identifier)
-        expect(Bulkrax::ObjectFactory).to receive(:find_by_id)
-        expect(Bulkrax::ObjectFactory).to receive(:search_by_identifier)
+        expect(factory).to receive(:find_by_source_identifier)
+        expect(factory).to receive(:find_by_id)
+        expect(factory).to receive(:search_by_identifier)
         is_expected.to eq nil
       end
     end

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 RSpec.describe Bulkrax::ObjectFactory do
-  subject(:factory) { described_class.new(
-        attributes: {},
-        source_identifier_value: :source_identifier,
-        work_identifier: :source,
-        work_identifier_search_field: 'source_sim') }
+  subject(:factory) { 
+        described_class.new(
+          attributes: {},
+          source_identifier_value: :source_identifier,
+          work_identifier: :source,
+          work_identifier_search_field: 'source_sim') 
+      }
 
   let(:mock_user) { instance_double(Spot::User) }
 

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Bulkrax::ObjectFactory do
 
     let(:mock_attributes) { instance_double(ActiveSupport::HashWithIndifferentAccess) }
 
-    before(:each) { attributes = mock_attributes } # rubocop:disable Lint/UselessAssignment
+    before(:each) { factory.instance_variable_set(:@attributes, mock_attributes) }
 
     context "there is no source_identifier" do
       before do
@@ -119,7 +119,7 @@ RSpec.describe Bulkrax::ObjectFactory do
 
       context "the solr query matches with an object" do
         context "the id is empty" do
-          let(:id_doc) { { 'response': { 'docs': [{ 'id': nil }] } } }
+          let(:id_doc) { { "response"=> { "docs"=> [{ "id"=> nil }] } } }
 
           before do
             allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
@@ -130,7 +130,7 @@ RSpec.describe Bulkrax::ObjectFactory do
 
         context "the id is not empty" do
           let(:id) { "0a0a0a0a" }
-          let(:id_doc) { { 'response': { 'docs': [{ 'id': id }] } } }
+          let(:id_doc) { { "response"=> { "docs"=> [{ "id"=> id }] } } }
           let(:mock_work) { instance_double(Hyrax::Work) }
 
           before do

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Bulkrax::ObjectFactory do
                       described_class.new(
                         attributes: {},
                         source_identifier_value: :source_identifier,
-                        work_identifier: :source,
-                        work_identifier_search_field: 'source_sim'
+                        work_identifier: :source_identifier,
+                        work_identifier_search_field: 'source_identifier_ssim'
                       )
                     }
 
@@ -77,70 +77,74 @@ RSpec.describe Bulkrax::ObjectFactory do
     end
   end
 
-  # describe '#find_by_source_identifier' do
-  #   subject { described_class.find_by_source_identifier }
+  describe '#find_by_source_identifier' do
+    subject { factory.find_by_source_identifier }
 
-  #   let(:mock_attributes) { instance_double(ActiveSupport::HashWithIndifferentAccess) }
+    let(:mock_attributes) { instance_double(ActiveSupport::HashWithIndifferentAccess) }
 
-  #   before(:each) { attributes = mock_attributes } # rubocop:disable Lint/UselessAssignment
+    before(:each) { attributes = mock_attributes } # rubocop:disable Lint/UselessAssignment
 
-  #   context "there is no source_identifier" do
-  #     before do
-  #       allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(false)
-  #     end
+    context "there is no source_identifier" do
+      before do
+        allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(false)
+      end
 
-  #     it { is_expected.to eq nil }
-  #   end
+      it { is_expected.to eq nil }
+    end
 
-  #   context "source_identifier is nil" do
-  #     before do
-  #       allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(true)
-  #       allow(mock_attributes).to receive(:[]).with('source_identifier').and_return(nil)
-  #     end
+    context "source_identifier is nil" do
+      before do
+        allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(true)
+        allow(mock_attributes).to receive(:[]).with('source_identifier').and_return(nil)
+      end
 
-  #     it { is_expected.to eq nil }
-  #   end
+      it { is_expected.to eq nil }
+    end
 
-  #   context "there is a source_identifier" do
-  #     let(:identifier) { "test_0_0" }
+    context "there is a source_identifier" do
+      let(:identifier) { "test_0_0" }
 
-  #     before do
-  #       allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(true)
-  #       allow(mock_attributes).to receive(:[]).with('source_identifier').and_return([identifier])
-  #     end
+      before do
+        allow(mock_attributes).to receive(:key?).with('source_identifier').and_return(true)
+        allow(mock_attributes).to receive(:[]).with('source_identifier').and_return([identifier])
+      end
 
-  #     context "the solr query does not match with an object" do
-  #       before do
-  #         allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(nil)
-  #       end
+      context "the solr query does not match with an object" do
+        before do
+          allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(nil)
+        end
 
-  #       it { is_expected.to eq nil }
-  #     end
+        it { is_expected.to eq nil }
+      end
 
-  #     context "the solr query matches with an object" do
-  #       context "the id is empty" do
-  #         let(:id_doc) { { 'response': { 'docs': [{ 'id': nil }] } } }
+      context "the solr query matches with an object" do
+        context "the id is empty" do
+          let(:id_doc) { { 'response': { 'docs': [{ 'id': nil }] } } }
 
-  #         before do
-  #           allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
-  #         end
+          before do
+            allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
+          end
 
-  #         it { is_expected.to eq nil }
-  #       end
+          it { is_expected.to eq nil }
+        end
 
-  #       context "the id is not empty" do
-  #         let(:id) { "0a0a0a0a" }
-  #         let(:id_doc) { { 'response': { 'docs': [{ 'id': id }] } } }
-  #         let(:mock_work) { instance_double(Hyrax::Work) }
+        context "the id is not empty" do
+          let(:id) { "0a0a0a0a" }
+          let(:id_doc) { { 'response': { 'docs': [{ 'id': id }] } } }
+          let(:mock_work) { instance_double(Hyrax::Work) }
 
-  #         before do
-  #           allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
-  #           allow(ActiveFedora::Base).to receive(:find).with(id).and_return(mock_work)
-  #         end
+          before do
+            allow(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene').and_return(id_doc)
+            allow(ActiveFedora::Base).to receive(:find).with(id).and_return(mock_work)
+          end
 
-  #         it { is_expected.to eq mock_work }
-  #       end
-  #     end
-  #   end
-  # end
+          it "searches for and returns the object" do
+            expect(Hyrax::SolrService).to receive(:get).with("source_identifier_ssim:#{identifier}", fl: ['id', 'source_identifier_ssim'], defType: 'lucene')
+            expect(ActiveFedora::Base).to receive(:find).with(id)
+            is_expected.to eq mock_work
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/overrides/bulkrax_object_factory_spec.rb
+++ b/spec/overrides/bulkrax_object_factory_spec.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 RSpec.describe Bulkrax::ObjectFactory do
-  subject(:factory) { 
-        described_class.new(
-          attributes: {},
-          source_identifier_value: :source_identifier,
-          work_identifier: :source,
-          work_identifier_search_field: 'source_sim') 
-      }
+  subject(:factory)
+    { 
+      described_class.new(
+        attributes: {},
+        source_identifier_value: :source_identifier,
+        work_identifier: :source,
+        work_identifier_search_field: 'source_sim'
+      )
+    }
 
   let(:mock_user) { instance_double(Spot::User) }
 


### PR DESCRIPTION
Resurrection of the bulkrax-upgrade branch. Old branch comment:

> Upgrades to the newest version of bulkrax to fix the issue of imported works not successfully attaching to collections. A patch is included to fix inconsistencies with the object factory, but the patch is largely untested and behaves as a black box. This branch is shelved until after the upgrade to hyrax 4 and valkyrization to determine if it is necessary.

Unshelving on Hyrax 5, unvalkyrized.