### PR TITLE
2026.2

### DIFF
--- a/.github/workflows/build-ondemand.yml
+++ b/.github/workflows/build-ondemand.yml
@@ -22,6 +22,7 @@ on:
           - Both
           - Stage
           - Production
+          - Future
       skip_tests:
         description: Build containers without tests
         required: true
@@ -84,6 +85,9 @@ jobs:
             ;;
           "Production")
             output_txt='environments=["production"]'
+            ;;
+          "Future")
+            output_txt='environments=["future"]'
             ;;
         esac
 

--- a/app/helpers/spot/catalog_helper.rb
+++ b/app/helpers/spot/catalog_helper.rb
@@ -5,9 +5,14 @@ module Spot
     # Falls back to the original value.
     #
     # @return [String]
+    # @todo since we're also utilizing this code in the Spot::HumanizesDateFields mixin
+    #       for presenters, it might be good to deduplicate.
     def humanize_edtf_values(args)
       Array.wrap(args[:value]).map do |value|
-        Date.edtf(value).humanize
+        Date.edtf(value)
+            .humanize
+            .gsub(/0{0,3}(\d+)/, '\1') # remove leading zeroes
+            .gsub(/-(\d{1,4}[\?\~\%]?)/, '\1 BCE') # convert negative dates to BCE
       rescue
         value
       end.to_sentence

--- a/app/presenters/concerns/spot/humanizes_date_fields.rb
+++ b/app/presenters/concerns/spot/humanizes_date_fields.rb
@@ -14,20 +14,21 @@ module Spot
 
           define_method(field) do
             values = solr_document.send(field)
-            values.is_a?(Array) ? values.map { |v| humanize_value(v) } : humanize_value(values)
+            values.is_a?(Array) ? values.map { |v| humanize_edtf_value(v) } : humanize_edtf_value(values)
           end
         end
       end
     end
-
-    private
 
     # run a value through +Date.edtf+, return the +.humanize+ value,
     # and fallback to the value if it's unparseable.
     #
     # @param [String] val
     # @return [String]
-    def humanize_value(val)
+    #
+    # @todo since we're also utilizing this in Spot::CatalogHelper#humanize_edtf_values
+    #       it might be good to find a way to deduplicate.
+    def humanize_edtf_value(val)
       Date.edtf(val)
           .humanize
           .gsub(/0{0,3}(\d+)/, '\1') # remove leading zeroes

--- a/app/presenters/concerns/spot/humanizes_date_fields.rb
+++ b/app/presenters/concerns/spot/humanizes_date_fields.rb
@@ -28,7 +28,10 @@ module Spot
     # @param [String] val
     # @return [String]
     def humanize_value(val)
-      Date.edtf(val).humanize
+      Date.edtf(val)
+          .humanize
+          .gsub(/0{0,3}(\d+)/, '\1') # remove leading zeroes
+          .gsub(/-(\d{1,4}[\?\~\%]?)/, '\1 BCE') # convert negative dates to BCE
     rescue
       val
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,7 @@ module Spot
     config.lograge.enabled = ENV.fetch('SPOT_ENABLE_LOGRAGE') { false }
 
     config.rack_cas.server_url = ENV['CAS_BASE_URL']
-    config.rack_cas.service = '/users/service'
+    config.rack_cas.service = ENV['URL_HOST'].present? ? "#{ENV['URL_HOST']}/users/service" : '/users/service'
     config.rack_cas.extra_attributes_filter = %w[uid email givenName surname lnumber eduPersonEntitlement]
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/spec/helpers/spot/catalog_helper_spec.rb
+++ b/spec/helpers/spot/catalog_helper_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe Spot::CatalogHelper, type: :helper do
 
       it { is_expected.to eq 'unparseable' }
     end
+
+    context 'when a date is negative' do
+      let(:value) { ['-0023'] }
+
+      it { is_expected.to eq '23 BCE' }
+    end
   end
 
   describe 'visibility helpers' do

--- a/spec/support/shared_examples/presenters/humanizes_date_fields.rb
+++ b/spec/support/shared_examples/presenters/humanizes_date_fields.rb
@@ -30,6 +30,18 @@ RSpec.shared_examples 'it humanizes date fields' do |opts|
 
         it { is_expected.to eq ['1986 to 2020'] }
       end
+
+      context 'circa dates' do
+        let(:original_value) { ['0077%/0080'] }
+
+        it { is_expected.to eq ['circa 77? to 80'] }
+      end
+
+      context 'bce dates' do
+        let(:original_value) { ['-0080/-0077%'] }
+
+        it { is_expected.to eq ['80 BCE to circa 77? BCE'] }
+      end
     end
   end
 end


### PR DESCRIPTION
## updates
- add temp 'future' environment option for migration deployment [070a341](https://github.com/LafayetteCollegeLibraries/spot/pull/1211/commits/070a341dca34c54686737290d10dae988f2f996b)
- use URL_HOST to build an absolute url for the CAS service (#1212)
- display negative EDTF dates as BCE and strip leading zeroes (#1214, 4604539)