### PR TITLE
use URL_HOST to build cas service url

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,7 @@ module Spot
     config.lograge.enabled = ENV.fetch('SPOT_ENABLE_LOGRAGE') { false }
 
     config.rack_cas.server_url = ENV['CAS_BASE_URL']
-    config.rack_cas.service = '/users/service'
+    config.rack_cas.service = ENV['URL_HOST'].present? ? "#{url_host}/users/service" : '/users/service'
     config.rack_cas.extra_attributes_filter = %w[uid email givenName surname lnumber eduPersonEntitlement]
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,7 @@ module Spot
     config.lograge.enabled = ENV.fetch('SPOT_ENABLE_LOGRAGE') { false }
 
     config.rack_cas.server_url = ENV['CAS_BASE_URL']
-    config.rack_cas.service = ENV['URL_HOST'].present? ? "#{url_host}/users/service" : '/users/service'
+    config.rack_cas.service = ENV['URL_HOST'].present? ? "#{ENV['URL_HOST']}/users/service" : '/users/service'
     config.rack_cas.extra_attributes_filter = %w[uid email givenName surname lnumber eduPersonEntitlement]
 
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
by defining the service as the relative "/users/service", we're occasionally seeing the loadbalancer's private hostname used in the cas service url, which shouldn't be the case. this appends the path to `ENV['URL_HOST']` so that the service is an absolute url