### PR TITLE
patch WorkShowPresenter#humanize_value to handle BCE dates

### DIFF
--- a/app/presenters/concerns/spot/humanizes_date_fields.rb
+++ b/app/presenters/concerns/spot/humanizes_date_fields.rb
@@ -28,7 +28,10 @@ module Spot
     # @param [String] val
     # @return [String]
     def humanize_value(val)
-      Date.edtf(val).humanize
+      Date.edtf(val)
+          .humanize
+          .gsub(/0{0,3}(\d+)/, '\1') # remove leading zeroes
+          .gsub(/-(\d{1,4})/, '\1 BCE') # convert negative dates to BCE
     rescue
       val
     end

--- a/app/presenters/concerns/spot/humanizes_date_fields.rb
+++ b/app/presenters/concerns/spot/humanizes_date_fields.rb
@@ -31,7 +31,7 @@ module Spot
       Date.edtf(val)
           .humanize
           .gsub(/0{0,3}(\d+)/, '\1') # remove leading zeroes
-          .gsub(/-(\d{1,4})/, '\1 BCE') # convert negative dates to BCE
+          .gsub(/-(\d{1,4}[\?\~\%]?)/, '\1 BCE') # convert negative dates to BCE
     rescue
       val
     end

--- a/spec/support/shared_examples/presenters/humanizes_date_fields.rb
+++ b/spec/support/shared_examples/presenters/humanizes_date_fields.rb
@@ -32,15 +32,15 @@ RSpec.shared_examples 'it humanizes date fields' do |opts|
       end
 
       context 'circa dates' do
-        let(:original_value) { ['2000%/2010%'] }
+        let(:original_value) { ['0077%/0080'] }
 
-        it { is_expected.to eq ['circa 2000 to circa 2010'] }
+        it { is_expected.to eq ['circa 77? to 80'] }
       end
 
       context 'bce dates' do
-        let(:original_value) { ['-1000/0800%'] }
+        let(:original_value) { ['-0080/-0077%'] }
 
-        it { is_expected.to eq ['1000 BCE to circa 800'] }
+        it { is_expected.to eq ['80 BCE to circa 77? BCE'] }
       end
     end
   end

--- a/spec/support/shared_examples/presenters/humanizes_date_fields.rb
+++ b/spec/support/shared_examples/presenters/humanizes_date_fields.rb
@@ -30,6 +30,18 @@ RSpec.shared_examples 'it humanizes date fields' do |opts|
 
         it { is_expected.to eq ['1986 to 2020'] }
       end
+
+      context 'circa dates' do
+        let(:original_value) { ['2000%/2010%'] }
+
+        it { is_expected.to eq ['circa 2000 to circa 2010'] }
+      end
+
+      context 'bce dates' do
+        let(:original_value) { ['-1000/0800%'] }
+
+        it { is_expected.to eq ['1000 BCE to circa 800'] }
+      end
     end
   end
 end


### PR DESCRIPTION
cleans up the internal method used to humanize edtf date values to:
a) strip leading zeros from pre 1000 dates
b) convert negative date values to display as BCE

example:

```
value: '-0080/-0077%'
humanized: '80 BCE to circa 77? BCE'
```