### PR TITLE
More UI fixes

### DIFF
--- a/app/assets/stylesheets/spot/_homepage.scss
+++ b/app/assets/stylesheets/spot/_homepage.scss
@@ -17,7 +17,7 @@ $featured-info-text-color: $white;
   background-color: $featured-info-bg-color;
   bottom: 0;
   color: $featured-info-text-color;
-  margin: 4rem;
+  margin: 3rem;
   padding: 1rem;
   position: absolute;
   right: 0;
@@ -33,7 +33,7 @@ $featured-info-text-color: $white;
 
 .featured-collection {
   background-size: cover;
-  min-height: 26rem;
+  min-height: 18rem;
   margin: 1rem 0;
   padding-top: 7rem;
   position: relative;
@@ -43,7 +43,7 @@ $featured-info-text-color: $white;
     bottom: 0;
     color: $featured-info-text-color;
     display: block;
-    font-size: 1.75rem;
+    font-size: 1.25rem;
     left: 0;
     margin-top: 0;
     padding: 1rem;
@@ -52,7 +52,7 @@ $featured-info-text-color: $white;
   }
 
   .collection-title {
-    font-size: 3rem;
+    font-size: 2rem;
     font-weight: normal;
     margin: 0.5rem 0;
   }

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -2,11 +2,11 @@
 
 <%= render 'shared/citations' %>
 
-<div class="row work-type">
+<div class="work-type">
   <%= render 'metadata_and_viewer_panel', presenter: @presenter %>
+  <%= render 'relationships', presenter: @presenter, polymorphic_url: method(:polymorphic_url) %>
 </div>
 
-<%= render 'relationships', presenter: @presenter, polymorphic_url: method(:polymorphic_url) %>
 
 <script>
   // need to initialize the popovers in the metadata

--- a/app/views/spot/homepage/_featured_collections.html.erb
+++ b/app/views/spot/homepage/_featured_collections.html.erb
@@ -1,6 +1,6 @@
 <% if presenter.featured_collections.present? %>
 <div id="featured-collections" class="container-fluid mt-5">
-  <h2 class="display-3"><%= t(".title_#{presenter.featured_collections.size > 1 ? 'plural' : 'singular'}") %></h2>
+  <h2><%= t(".title_#{presenter.featured_collections.size > 1 ? 'plural' : 'singular'}") %></h2>
   <p class="lead"><%= t('.browse_html', url: browse_collections_path).html_safe %></p>
   <% presenter.featured_collections.each do |collection| %>
     <%= render 'featured_collection_item', collection: collection %>

--- a/app/views/spot/homepage/index.html.erb
+++ b/app/views/spot/homepage/index.html.erb
@@ -1,6 +1,7 @@
 <% provide(:page_title) { t('.page_title', name: t('hyrax.product_name')) } %>
 
 <%= render 'splash' %>
+<hr />
 
 <% if @presenter.show_senior_honors_thesis_block? %>
   <%= render 'senior_honors_thesis', presenter: @presenter %>
@@ -8,4 +9,5 @@
 <% end %>
 
 <%= render 'featured_collections', presenter: @presenter %>
+<hr />
 <%= render 'recent_items', presenter: @presenter unless @presenter.recent_items.empty? %>


### PR DESCRIPTION
for some reason, marking the work container as a "row" was causing a host of ui issues for both collections and for the entire work view page when logged out. Fixes this and makes some style adjustments to the home page